### PR TITLE
Async screener

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ heroku buildpacks:add --index 2 heroku/python -a <app-name>
 heroku config:set SERVE_WEB_UI=auto -a <app-name>
 ```
 
+By default, Heroku startup script also sets:
+- `SCREENER_RUN_MODE=async` (avoids Heroku 30s request timeout on `/api/screener/run`)
+- `WEB_CONCURRENCY=1` (single-process consistency for in-memory background jobs)
+
 **Deploy:**
 
 ```bash
@@ -125,6 +129,10 @@ If startup fails with missing modules, ensure:
 1. `.python-version` exists at repo root.
 2. `uv.lock` is committed and matches `pyproject.toml`.
 3. You redeploy after dependency changes.
+
+If screener requests fail with `H12 Request timeout`:
+1. Ensure `SCREENER_RUN_MODE=async` (default in `scripts/heroku_start.sh`).
+2. Confirm frontend requests to `/api/screener/run` eventually receive data after background polling.
 
 ---
 

--- a/api/README.md
+++ b/api/README.md
@@ -40,7 +40,8 @@ Strategy (`/api/strategy`):
 
 Screener (`/api/screener`):
 - `GET /api/screener/universes`
-- `POST /api/screener/run`
+- `POST /api/screener/run` (sync locally, async job launch on dyno by default)
+- `GET /api/screener/run/{job_id}` (poll async screener status/result)
 - `POST /api/screener/preview-order`
 
 Portfolio (`/api/portfolio`):

--- a/api/models/screener.py
+++ b/api/models/screener.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import math
-from typing import Optional
+from typing import Literal, Optional
 from pydantic import BaseModel, Field, field_validator
 from api.models.recommendation import Recommendation
 
@@ -89,6 +89,22 @@ class ScreenerResponse(BaseModel):
     data_freshness: str = "final_close"
     warnings: list[str] = Field(default_factory=list)
     social_warmup_job_id: Optional[str] = None
+
+
+class ScreenerRunLaunchResponse(BaseModel):
+    job_id: str
+    status: Literal["queued", "running", "completed", "error"]
+    created_at: str
+    updated_at: str
+
+
+class ScreenerRunStatusResponse(BaseModel):
+    job_id: str
+    status: Literal["queued", "running", "completed", "error"]
+    result: Optional[ScreenerResponse] = None
+    error: Optional[str] = None
+    created_at: str
+    updated_at: str
 
 
 class OrderPreview(BaseModel):

--- a/api/routers/screener.py
+++ b/api/routers/screener.py
@@ -2,14 +2,34 @@
 from __future__ import annotations
 
 import math
+import os
 from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import JSONResponse
 
-from api.models.screener import ScreenerRequest, ScreenerResponse, OrderPreview
+from api.models.screener import (
+    ScreenerRequest,
+    ScreenerResponse,
+    ScreenerRunLaunchResponse,
+    ScreenerRunStatusResponse,
+    OrderPreview,
+)
 from api.dependencies import get_screener_service
 from api.services.screener_service import ScreenerService
 from pydantic import BaseModel, Field, field_validator
 
 router = APIRouter()
+
+
+def _resolve_screener_run_mode() -> str:
+    """
+    Resolve screener execution mode.
+
+    Defaults to async on dyno platforms to avoid Heroku H12 request timeouts.
+    """
+    configured = str(os.getenv("SCREENER_RUN_MODE", "")).strip().lower()
+    if configured in {"sync", "async"}:
+        return configured
+    return "async" if os.getenv("DYNO") else "sync"
 
 
 class OrderPreviewRequest(BaseModel):
@@ -49,13 +69,29 @@ async def list_universes(service: ScreenerService = Depends(get_screener_service
     return service.list_universes()
 
 
-@router.post("/run", response_model=ScreenerResponse)
+@router.post(
+    "/run",
+    response_model=ScreenerResponse,
+    responses={202: {"model": ScreenerRunLaunchResponse}},
+)
 async def run_screener(
     request: ScreenerRequest,
     service: ScreenerService = Depends(get_screener_service),
 ):
-    """Run the screener on a universe of stocks."""
+    """Run screener sync or launch async job depending on environment mode."""
+    if _resolve_screener_run_mode() == "async":
+        launch = service.start_run_async(request)
+        return JSONResponse(status_code=202, content=launch.model_dump())
     return service.run_screener(request)
+
+
+@router.get("/run/{job_id}", response_model=ScreenerRunStatusResponse)
+def get_run_status(
+    job_id: str,
+    service: ScreenerService = Depends(get_screener_service),
+):
+    """Get background screener run status."""
+    return service.get_run_status(job_id)
 
 
 @router.post("/preview-order", response_model=OrderPreview)
@@ -78,4 +114,3 @@ async def preview_order(
         account_size=request.account_size,
         risk_pct=request.risk_pct,
     )
-

--- a/api/services/screener_run_manager.py
+++ b/api/services/screener_run_manager.py
@@ -1,0 +1,102 @@
+"""Background screener run jobs."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+import threading
+import uuid
+from typing import Callable, Optional
+
+from api.models.screener import ScreenerResponse
+
+
+def _now_iso() -> str:
+    return datetime.utcnow().replace(microsecond=0).isoformat()
+
+
+@dataclass
+class ScreenerRunJob:
+    job_id: str
+    status: str
+    result: Optional[ScreenerResponse]
+    error: Optional[str]
+    created_at: str
+    updated_at: str
+
+
+class ScreenerRunManager:
+    def __init__(self, *, max_jobs: int = 32) -> None:
+        self._jobs: dict[str, ScreenerRunJob] = {}
+        self._lock = threading.Lock()
+        self._max_jobs = max_jobs
+
+    def start_job(self, *, run_fn: Callable[[], ScreenerResponse]) -> str:
+        now = _now_iso()
+        job_id = uuid.uuid4().hex
+        job = ScreenerRunJob(
+            job_id=job_id,
+            status="queued",
+            result=None,
+            error=None,
+            created_at=now,
+            updated_at=now,
+        )
+        with self._lock:
+            self._jobs[job_id] = job
+            self._trim_jobs_locked()
+
+        worker = threading.Thread(
+            target=self._run_job,
+            kwargs={"job_id": job_id, "run_fn": run_fn},
+            daemon=True,
+        )
+        worker.start()
+        return job_id
+
+    def get_job(self, job_id: str) -> Optional[ScreenerRunJob]:
+        with self._lock:
+            job = self._jobs.get(job_id)
+            if job is None:
+                return None
+            return ScreenerRunJob(**job.__dict__)
+
+    def _run_job(self, *, job_id: str, run_fn: Callable[[], ScreenerResponse]) -> None:
+        self._update(job_id, status="running", result=None, error=None)
+        try:
+            result = run_fn()
+            self._update(job_id, status="completed", result=result, error=None)
+        except Exception as exc:  # pragma: no cover - defensive path
+            self._update(job_id, status="error", result=None, error=str(exc))
+
+    def _update(
+        self,
+        job_id: str,
+        *,
+        status: Optional[str] = None,
+        result: Optional[ScreenerResponse] = None,
+        error: Optional[str] = None,
+    ) -> None:
+        with self._lock:
+            job = self._jobs.get(job_id)
+            if job is None:
+                return
+            if status is not None:
+                job.status = status
+            job.result = result
+            job.error = error
+            job.updated_at = _now_iso()
+
+    def _trim_jobs_locked(self) -> None:
+        if len(self._jobs) <= self._max_jobs:
+            return
+        sorted_jobs = sorted(self._jobs.values(), key=lambda item: item.updated_at)
+        to_remove = len(self._jobs) - self._max_jobs
+        for item in sorted_jobs[:to_remove]:
+            self._jobs.pop(item.job_id, None)
+
+
+_MANAGER = ScreenerRunManager()
+
+
+def get_screener_run_manager() -> ScreenerRunManager:
+    return _MANAGER

--- a/api/services/screener_service.py
+++ b/api/services/screener_service.py
@@ -13,6 +13,8 @@ from fastapi import HTTPException
 
 from api.models.screener import (
     ScreenerRequest,
+    ScreenerRunLaunchResponse,
+    ScreenerRunStatusResponse,
     ScreenerResponse,
     ScreenerCandidate,
     OrderPreview,
@@ -41,6 +43,7 @@ from swing_screener.strategy.config import (
 )
 from swing_screener.risk.regime import compute_regime_risk_multiplier
 from api.services.social_warmup import get_social_warmup_manager
+from api.services.screener_run_manager import get_screener_run_manager
 
 logger = logging.getLogger(__name__)
 PRICE_HISTORY_MAX_BARS = 252
@@ -653,6 +656,34 @@ class ScreenerService:
         except Exception as exc:
             logger.exception("Unexpected screener error")
             raise HTTPException(status_code=500, detail="Screener failed unexpectedly")
+
+    def start_run_async(self, request: ScreenerRequest) -> ScreenerRunLaunchResponse:
+        """Start screener run in background and return job metadata."""
+        manager = get_screener_run_manager()
+        job_id = manager.start_job(run_fn=lambda: self.run_screener(request))
+        job = manager.get_job(job_id)
+        if job is None:
+            raise HTTPException(status_code=500, detail="Failed to start screener run.")
+        return ScreenerRunLaunchResponse(
+            job_id=job.job_id,
+            status=job.status,  # type: ignore[arg-type]
+            created_at=job.created_at,
+            updated_at=job.updated_at,
+        )
+
+    def get_run_status(self, job_id: str) -> ScreenerRunStatusResponse:
+        """Get status for background screener run."""
+        job = get_screener_run_manager().get_job(job_id)
+        if job is None:
+            raise HTTPException(status_code=404, detail=f"Screener run job not found: {job_id}")
+        return ScreenerRunStatusResponse(
+            job_id=job.job_id,
+            status=job.status,  # type: ignore[arg-type]
+            result=job.result,
+            error=job.error,
+            created_at=job.created_at,
+            updated_at=job.updated_at,
+        )
 
     def preview_order(
         self,

--- a/app.json
+++ b/app.json
@@ -13,6 +13,12 @@
   "env": {
     "SERVE_WEB_UI": {
       "value": "1"
+    },
+    "SCREENER_RUN_MODE": {
+      "value": "async"
+    },
+    "WEB_CONCURRENCY": {
+      "value": "1"
     }
   }
 }

--- a/scripts/heroku_start.sh
+++ b/scripts/heroku_start.sh
@@ -6,6 +6,8 @@ REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
 
 cd "${REPO_ROOT}"
 export SERVE_WEB_UI=1
+export SCREENER_RUN_MODE="${SCREENER_RUN_MODE:-async}"
+export WEB_CONCURRENCY="${WEB_CONCURRENCY:-1}"
 export PYTHONPATH="${REPO_ROOT}/src:${PYTHONPATH:-}"
 
 exec uvicorn api.main:app --host 0.0.0.0 --port "${PORT:-8000}"

--- a/tests/api/test_screener_endpoints.py
+++ b/tests/api/test_screener_endpoints.py
@@ -1,11 +1,13 @@
 import pandas as pd
 import datetime as dt
+import time
 from fastapi.testclient import TestClient
 from unittest.mock import MagicMock
 from types import SimpleNamespace
 
 from api.main import app
 import api.services.screener_service as screener_service
+from api.models.screener import ScreenerResponse
 from swing_screener.data.providers import MarketDataProvider
 
 
@@ -247,3 +249,40 @@ def test_data_freshness_is_intraday_for_today_before_close():
     now_utc = dt.datetime(2026, 2, 19, 15, 0, tzinfo=dt.timezone.utc)
     freshness = screener_service._resolve_data_freshness("2026-02-19", now_utc, ["EUR"])
     assert freshness == "intraday"
+
+
+def test_screener_async_mode_returns_job_and_status(monkeypatch):
+    monkeypatch.setenv("SCREENER_RUN_MODE", "async")
+
+    def fake_run(self, request, strategy_override=None):
+        return ScreenerResponse(
+            candidates=[],
+            asof_date="2026-02-26",
+            total_screened=0,
+            data_freshness="final_close",
+            warnings=[],
+            social_warmup_job_id=None,
+        )
+
+    monkeypatch.setattr(screener_service.ScreenerService, "run_screener", fake_run)
+
+    client = TestClient(app)
+    launch_res = client.post("/api/screener/run", json={"universe": "mega_all", "top": 20})
+    assert launch_res.status_code == 202
+    launch_payload = launch_res.json()
+    assert launch_payload["status"] in {"queued", "running", "completed"}
+    job_id = launch_payload["job_id"]
+
+    final_payload = None
+    for _ in range(20):
+        status_res = client.get(f"/api/screener/run/{job_id}")
+        assert status_res.status_code == 200
+        payload = status_res.json()
+        if payload["status"] == "completed":
+            final_payload = payload
+            break
+        time.sleep(0.05)
+
+    assert final_payload is not None
+    assert final_payload["result"]["asof_date"] == "2026-02-26"
+    assert final_payload["result"]["total_screened"] == 0

--- a/web-ui/src/features/screener/api.ts
+++ b/web-ui/src/features/screener/api.ts
@@ -1,6 +1,8 @@
 import { API_ENDPOINTS, apiUrl } from '@/lib/api';
 import {
   ScreenerRequest,
+  ScreenerRunLaunchResponseAPI,
+  ScreenerRunStatusResponseAPI,
   ScreenerResponse,
   ScreenerResponseAPI,
   UniversesResponse,
@@ -32,10 +34,41 @@ export async function runScreener(request: ScreenerRequest): Promise<ScreenerRes
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(apiRequest),
   });
+
+  if (res.status === 202) {
+    const launchPayload: ScreenerRunLaunchResponseAPI = await res.json();
+    return pollScreenerRunResult(launchPayload.job_id);
+  }
+
   if (!res.ok) {
     const error = await res.json();
     throw new Error(error.detail || 'Failed to run screener');
   }
   const apiResponse: ScreenerResponseAPI = await res.json();
   return transformScreenerResponse(apiResponse);
+}
+
+async function pollScreenerRunResult(jobId: string): Promise<ScreenerResponse> {
+  const maxAttempts = 120;
+  const delayMs = 1000;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    const res = await fetch(apiUrl(API_ENDPOINTS.screenerRunStatus(jobId)));
+    if (!res.ok) {
+      const error = await res.json();
+      throw new Error(error.detail || 'Failed to fetch screener run status');
+    }
+
+    const statusPayload: ScreenerRunStatusResponseAPI = await res.json();
+    if (statusPayload.status === 'completed' && statusPayload.result) {
+      return transformScreenerResponse(statusPayload.result);
+    }
+    if (statusPayload.status === 'error') {
+      throw new Error(statusPayload.error || 'Screener run failed');
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+  }
+
+  throw new Error('Screener run timed out. Please try again.');
 }

--- a/web-ui/src/features/screener/types.ts
+++ b/web-ui/src/features/screener/types.ts
@@ -118,6 +118,22 @@ export interface ScreenerResponseAPI {
   social_warmup_job_id?: string;
 }
 
+export interface ScreenerRunLaunchResponseAPI {
+  job_id: string;
+  status: 'queued' | 'running' | 'completed' | 'error';
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ScreenerRunStatusResponseAPI {
+  job_id: string;
+  status: 'queued' | 'running' | 'completed' | 'error';
+  result?: ScreenerResponseAPI;
+  error?: string;
+  created_at: string;
+  updated_at: string;
+}
+
 export interface OrderPreview {
   ticker: string;
   entryPrice: number;

--- a/web-ui/src/lib/api.test.ts
+++ b/web-ui/src/lib/api.test.ts
@@ -20,6 +20,7 @@ describe('API Client', () => {
 
     it('has all screener endpoints', () => {
       expect(API_ENDPOINTS.screenerRun).toBe('/api/screener/run')
+      expect(API_ENDPOINTS.screenerRunStatus('job-1')).toBe('/api/screener/run/job-1')
       expect(API_ENDPOINTS.screenerUniverses).toBe('/api/screener/universes')
       expect(API_ENDPOINTS.screenerPreview).toBe('/api/screener/preview-order')
     })

--- a/web-ui/src/lib/api.ts
+++ b/web-ui/src/lib/api.ts
@@ -11,6 +11,7 @@ export const API_ENDPOINTS = {
   
   // Screener
   screenerRun: '/api/screener/run',
+  screenerRunStatus: (jobId: string) => `/api/screener/run/${jobId}`,
   screenerUniverses: '/api/screener/universes',
   screenerPreview: '/api/screener/preview-order',
   


### PR DESCRIPTION
This pull request introduces asynchronous screener job execution to avoid Heroku request timeouts and improve reliability. The backend now supports launching screener runs as background jobs, exposing new endpoints to poll for job status and results. The web UI and API client are updated to handle this async flow transparently. Documentation and configuration are updated to reflect these changes.

**Backend: Asynchronous screener job execution**

* Added `ScreenerRunManager` in `api/services/screener_run_manager.py` to manage background screener jobs, including job creation, status tracking, and result retrieval.
* Introduced new models (`ScreenerRunLaunchResponse`, `ScreenerRunStatusResponse`) and endpoints: `POST /api/screener/run` now launches async jobs and returns job metadata; `GET /api/screener/run/{job_id}` polls job status/result. [[1]](diffhunk://#diff-6c25f5f81872b94599245f66ee5eb1d4e9ac7ad7cbec2228a09bb9520660142eR94-R109) [[2]](diffhunk://#diff-94075a525b8ecfd0cd106774770009df115c9c0ed7157c6359f2d4e993bea328L52-R96)
* Updated `ScreenerService` with `start_run_async` and `get_run_status` methods to support async job lifecycle.

**Frontend and API client: Async job polling**

* Updated `web-ui/src/features/screener/api.ts` to handle async screener launches and poll for completion, using new response types defined in `web-ui/src/features/screener/types.ts`. [[1]](diffhunk://#diff-d3c3d8a80a6777e53a1f0ff5278782785f4567237ecf9b85e29f508c1b6b022dR37-R74) [[2]](diffhunk://#diff-17cb36400307db8e297171c1ec69304d53e19bcab2a1d74cdeec39e64b018c81R121-R136)
* Added endpoint helpers and tests for new job status API in `web-ui/src/lib/api.ts` and `web-ui/src/lib/api.test.ts`. [[1]](diffhunk://#diff-03126021dfc75e03bc4f6f77ba5f38d1304a62580fe912bda9fcefee98a03ad4R14) [[2]](diffhunk://#diff-573661594a118b012136d239adb9cc524186c34d17297f5c239184fc7e48f692R23)

**Configuration and documentation**

* Updated Heroku setup instructions in `README.md`, added troubleshooting for async screener mode, and clarified buildpack/runtime order. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L76-R135) [[2]](diffhunk://#diff-c7b1c23e00a1fd0378f6ea41a7dfe1c9e043d766f738dba26860c783b82e8c6aL43-R44)
* Set default environment variables for async screener mode in `app.json` and `scripts/heroku_start.sh`. [[1]](diffhunk://#diff-96677aa35debfefd031d9d34d9c70369754ee3acb2d9a9d4090e98612efee6f5R16-R21) [[2]](diffhunk://#diff-fbe3208e13fcf3cc44255fe9a365092c27605bf268630699e02649bc22aa2f32R9-R10)

**Testing**

* Added tests for async screener job launch and polling in `tests/api/test_screener_endpoints.py`.