### PR TITLE
Fix Workspace screener create-order quick action

### DIFF
--- a/web-ui/src/components/domain/screener/ScreenerCandidatesTable.tsx
+++ b/web-ui/src/components/domain/screener/ScreenerCandidatesTable.tsx
@@ -18,6 +18,7 @@ interface ScreenerCandidatesTableProps {
   onTradeThesis: (candidate: ScreenerCandidate) => void;
   selectedTicker?: string | null;
   onRowClick?: (candidate: ScreenerCandidate) => void;
+  disableCreateOrder?: boolean;
 }
 
 /**
@@ -31,6 +32,7 @@ export default function ScreenerCandidatesTable({
   onTradeThesis,
   selectedTicker,
   onRowClick,
+  disableCreateOrder = false,
 }: ScreenerCandidatesTableProps) {
   // Track expanded rows by ticker
   const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set());
@@ -164,6 +166,7 @@ export default function ScreenerCandidatesTable({
                   <Button
                     size="sm"
                     variant="primary"
+                    disabled={disableCreateOrder}
                     onClick={(event) => {
                       event.stopPropagation();
                       onCreateOrder(candidate);
@@ -174,7 +177,7 @@ export default function ScreenerCandidatesTable({
                         : t('screener.table.createOrderTitle')
                     }
                   >
-                    {t('screener.table.createOrderAction')}
+                    {disableCreateOrder ? t('order.candidateModal.creating') : t('screener.table.createOrderAction')}
                   </Button>
                 </div>
               </td>

--- a/web-ui/src/components/domain/workspace/ScreenerInboxPanel.tsx
+++ b/web-ui/src/components/domain/workspace/ScreenerInboxPanel.tsx
@@ -10,6 +10,7 @@ import type { ScreenerCandidate } from '@/features/screener/types';
 import { useScreenerStore } from '@/stores/screenerStore';
 import { useBeginnerModeStore } from '@/stores/beginnerModeStore';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
+import { useCreateOrderMutation } from '@/features/portfolio/hooks';
 import { t } from '@/i18n/t';
 import { useLocalStorage } from '@/hooks';
 import { formatDate } from '@/utils/formatters';
@@ -82,6 +83,7 @@ export default function ScreenerInboxPanel() {
   );
 
   const universesQuery = useUniverses();
+  const quickCreateOrderMutation = useCreateOrderMutation();
   const screenerMutation = useRunScreenerMutation((data) => {
     setLastResult(data);
     if (data.candidates.length > 0) {
@@ -139,6 +141,45 @@ export default function ScreenerInboxPanel() {
     setAnalysisTab(tab);
   }, [setAnalysisTab, setSelectedTicker]);
 
+  const handleCreateOrder = useCallback(
+    (candidate: ScreenerCandidate) => {
+      handleSelectCandidate(candidate.ticker, 'order');
+
+      if (quickCreateOrderMutation.isPending || candidate.recommendation?.verdict === 'NOT_RECOMMENDED') {
+        return;
+      }
+
+      const entry = candidate.recommendation?.risk?.entry ?? candidate.entry ?? candidate.close;
+      if (typeof entry !== 'number' || !Number.isFinite(entry) || entry <= 0) {
+        return;
+      }
+
+      const atr = Number.isFinite(candidate.atr) && candidate.atr > 0 ? candidate.atr : entry * 0.03;
+      const fallbackStop = Math.max(0.01, entry - atr);
+      const stopCandidate = candidate.recommendation?.risk?.stop ?? candidate.stop ?? fallbackStop;
+      const stop =
+        Number.isFinite(stopCandidate) && stopCandidate > 0 && stopCandidate < entry
+          ? stopCandidate
+          : Math.max(0.01, entry - Math.max(atr * 0.5, entry * 0.01));
+      const shares = candidate.recommendation?.risk?.shares ?? candidate.shares ?? riskConfig.minShares ?? 1;
+      const quantity = Number.isFinite(shares) && shares > 0 ? Math.max(1, Math.round(shares)) : 1;
+
+      quickCreateOrderMutation.mutate({
+        ticker: candidate.ticker,
+        orderType: 'BUY_LIMIT',
+        quantity,
+        limitPrice: parseFloat(entry.toFixed(2)),
+        stopPrice: parseFloat(stop.toFixed(2)),
+        orderKind: 'entry',
+        notes: t('screener.defaultNotes', {
+          score: (candidate.score * 100).toFixed(1),
+          rank: candidate.rank,
+        }),
+      });
+    },
+    [handleSelectCandidate, quickCreateOrderMutation, riskConfig.minShares],
+  );
+
   const handleTradeThesisAction = useCallback((candidate: ScreenerCandidate) => {
     handleSelectCandidate(candidate.ticker, 'order');
   }, [handleSelectCandidate]);
@@ -186,6 +227,16 @@ export default function ScreenerInboxPanel() {
           </p>
         </div>
       ) : null}
+      {quickCreateOrderMutation.isError ? (
+        <div className="p-3 bg-red-50 border border-red-200 rounded-lg">
+          <p className="text-xs md:text-sm text-red-800">
+            {t('screener.error.prefix')}:{' '}
+            {quickCreateOrderMutation.error instanceof Error
+              ? quickCreateOrderMutation.error.message
+              : t('screener.error.unknown')}
+          </p>
+        </div>
+      ) : null}
 
       {!screenerMutation.isPending && !result ? (
         <div className="p-3 bg-blue-50 border border-blue-200 rounded-lg flex items-start">
@@ -226,10 +277,11 @@ export default function ScreenerInboxPanel() {
               onRowClick={(candidate) =>
                 handleSelectCandidate(candidate.ticker, analysisTab === 'sentiment' ? 'sentiment' : 'overview')
               }
-              onCreateOrder={(candidate) => handleSelectCandidate(candidate.ticker, 'order')}
+              onCreateOrder={handleCreateOrder}
               onRecommendationDetails={(candidate) => handleSelectCandidate(candidate.ticker, 'overview')}
               onSocialAnalysis={(ticker) => handleSelectCandidate(ticker, 'sentiment')}
               onTradeThesis={handleTradeThesisAction}
+              disableCreateOrder={quickCreateOrderMutation.isPending}
             />
           </div>
         </div>

--- a/web-ui/src/pages/Workspace.test.tsx
+++ b/web-ui/src/pages/Workspace.test.tsx
@@ -73,6 +73,47 @@ describe('Workspace Page', () => {
     });
   });
 
+  it('creates an order from the screener table quick action', async () => {
+    let postedOrder: Record<string, unknown> | null = null;
+    server.use(
+      http.post('*/api/portfolio/orders', async ({ request }) => {
+        postedOrder = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json(
+          {
+            order_id: 'ORD-AAPL-TEST',
+            status: 'pending',
+            ...postedOrder,
+          },
+          { status: 201 },
+        );
+      }),
+    );
+
+    const { user } = renderWithProviders(<Workspace />);
+
+    const runButtons = screen.getAllByRole('button', { name: /Run Screener/i });
+    await user.click(runButtons[0]);
+    await screen.findByRole('heading', { name: 'AAPL' });
+
+    const createButtons = await screen.findAllByRole('button', { name: 'Create Order' });
+    await user.click(createButtons[0]);
+
+    await waitFor(() => {
+      expect(postedOrder).not.toBeNull();
+    });
+    expect(postedOrder).toMatchObject({
+      ticker: 'AAPL',
+      order_type: 'BUY_LIMIT',
+      quantity: 1,
+      limit_price: 175.5,
+      stop_price: 172.25,
+      order_kind: 'entry',
+    });
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Order', selected: true })).toBeInTheDocument();
+    });
+  });
+
   it('opens fill-order modal for pending entry orders in the portfolio panel', async () => {
     server.use(
       http.get('*/api/portfolio/orders', ({ request }) => {


### PR DESCRIPTION
This pull request adds a new "quick create order" feature to the screener table, allowing users to initiate an order directly from the table. The implementation includes UI updates to disable the button during pending operations, error handling, and a new test to verify the workflow.

Quick create order feature:

* Added a `disableCreateOrder` prop to `ScreenerCandidatesTable` to control the enabled state of the "Create Order" button and updated its label to indicate when an order is being created. (`web-ui/src/components/domain/screener/ScreenerCandidatesTable.tsx`) [[1]](diffhunk://#diff-7894009f494e9a000f31ee2ae31439c5080472071d9cfb88a264deace96fdc1fR21) [[2]](diffhunk://#diff-7894009f494e9a000f31ee2ae31439c5080472071d9cfb88a264deace96fdc1fR35) [[3]](diffhunk://#diff-7894009f494e9a000f31ee2ae31439c5080472071d9cfb88a264deace96fdc1fR169) [[4]](diffhunk://#diff-7894009f494e9a000f31ee2ae31439c5080472071d9cfb88a264deace96fdc1fL177-R180)
* Implemented the `handleCreateOrder` callback in `ScreenerInboxPanel` to trigger order creation with calculated entry, stop, and quantity values, and integrated it with the screener table. (`web-ui/src/components/domain/workspace/ScreenerInboxPanel.tsx`) [[1]](diffhunk://#diff-9246c4edb32aa0d5d51f1dc74d0b90342aaa6276cc748125bbc9eee39d158356R13) [[2]](diffhunk://#diff-9246c4edb32aa0d5d51f1dc74d0b90342aaa6276cc748125bbc9eee39d158356R86) [[3]](diffhunk://#diff-9246c4edb32aa0d5d51f1dc74d0b90342aaa6276cc748125bbc9eee39d158356R144-R182) [[4]](diffhunk://#diff-9246c4edb32aa0d5d51f1dc74d0b90342aaa6276cc748125bbc9eee39d158356L229-R284)

UI and error handling improvements:

* Displayed an error message in `ScreenerInboxPanel` when the quick order creation fails. (`web-ui/src/components/domain/workspace/ScreenerInboxPanel.tsx`)

Testing:

* Added an end-to-end test to verify that an order can be created from the screener table and that the correct values are posted and displayed. (`web-ui/src/pages/Workspace.test.tsx`)