### PR TITLE
Refactor/plugins introduction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,4 @@ web-ui/.audit/
 # =========================
 test-results.xml
 coverage.xml
+docs/engineering/INTELLIGENCE_SOCIAL_CONVERGENCE_PLAN.md

--- a/api/models/__init__.py
+++ b/api/models/__init__.py
@@ -19,6 +19,11 @@ from api.models.strategy import (
     ValidationWarningModel,
     StrategyValidationResult,
 )
+from api.models.strategy_runtime import (
+    StrategyPluginDefinition,
+    StrategyPluginResolvedState,
+    StrategyResolvedConfig,
+)
 from api.models.portfolio import (
     PositionStatus,
     ActionType,
@@ -97,6 +102,9 @@ __all__ = [
     "ActiveStrategyRequest",
     "ValidationWarningModel",
     "StrategyValidationResult",
+    "StrategyPluginDefinition",
+    "StrategyPluginResolvedState",
+    "StrategyResolvedConfig",
     "PositionStatus",
     "ActionType",
     "Position",

--- a/api/models/screener.py
+++ b/api/models/screener.py
@@ -38,6 +38,10 @@ class ScreenerCandidate(BaseModel):
     overlay_sentiment_confidence: Optional[float] = None
     overlay_hype_score: Optional[float] = None
     overlay_sample_size: Optional[int] = None
+    today_volume: Optional[float] = None
+    average_volume: Optional[float] = None
+    volume_ratio: Optional[float] = None
+    volume_confirmation_passed: Optional[bool] = None
     # Plan + recommendation fields (education-first)
     signal: Optional[str] = None
     entry: Optional[float] = None

--- a/api/models/strategy_runtime.py
+++ b/api/models/strategy_runtime.py
@@ -1,0 +1,71 @@
+"""Read-only strategy runtime models for the plugin dashboard."""
+from __future__ import annotations
+
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+class StrategyPluginDocSectionModel(BaseModel):
+    title: str
+    body: str
+
+
+class StrategyPluginConfigFieldDefinitionModel(BaseModel):
+    key: str
+    label: str
+    description: Optional[str] = None
+    type: Optional[str] = None
+
+
+class StrategyPluginDefinition(BaseModel):
+    id: str
+    category: str
+    display_name: str
+    description: str = ""
+    enabled_by_default: bool = False
+    phase: str = "qualification"
+    provides: list[str] = Field(default_factory=list)
+    requires: list[str] = Field(default_factory=list)
+    modifies: list[str] = Field(default_factory=list)
+    conflicts: list[str] = Field(default_factory=list)
+    config_fields: list[StrategyPluginConfigFieldDefinitionModel] = Field(default_factory=list)
+    read_only_sections: list[StrategyPluginDocSectionModel] = Field(default_factory=list)
+
+
+class StrategyPluginResolvedValueModel(BaseModel):
+    key: str
+    label: str
+    description: Optional[str] = None
+    type: Optional[str] = None
+    default_value: object | None = None
+    effective_value: object | None = None
+    overridden: bool = False
+    source: Literal["plugin_default", "root_override"] = "plugin_default"
+
+
+class StrategyPluginResolvedState(BaseModel):
+    id: str
+    category: str
+    display_name: str
+    description: str = ""
+    enabled: bool = False
+    default_enabled: bool = False
+    phase: str = "qualification"
+    provides: list[str] = Field(default_factory=list)
+    requires: list[str] = Field(default_factory=list)
+    modifies: list[str] = Field(default_factory=list)
+    conflicts: list[str] = Field(default_factory=list)
+    depends_on: list[str] = Field(default_factory=list)
+    read_only_sections: list[StrategyPluginDocSectionModel] = Field(default_factory=list)
+    values: list[StrategyPluginResolvedValueModel] = Field(default_factory=list)
+
+
+class StrategyResolvedConfig(BaseModel):
+    name: str
+    description: Optional[str] = None
+    module: str
+    config_path: Optional[str] = None
+    execution_order: list[str] = Field(default_factory=list)
+    graph_edges: dict[str, list[str]] = Field(default_factory=dict)
+    plugins: list[StrategyPluginResolvedState] = Field(default_factory=list)

--- a/api/repositories/strategy_repo.py
+++ b/api/repositories/strategy_repo.py
@@ -139,7 +139,7 @@ class StrategyRepository:
                     "display_name": plugin.get("display_name", plugin["plugin_id"]),
                     "description": plugin.get("description", ""),
                     "enabled": plugin.get("enabled", False),
-                    "default_enabled": bool(plugin.get("defaults", {}).get("enabled", False)),
+                    "default_enabled": bool(plugin.get("default_enabled", False)),
                     "phase": plugin.get("phase", "qualification"),
                     "provides": [str(item) for item in plugin.get("provides", [])],
                     "requires": [str(item) for item in plugin.get("requires", [])],

--- a/api/repositories/strategy_repo.py
+++ b/api/repositories/strategy_repo.py
@@ -1,35 +1,198 @@
 """Strategy repository."""
 from __future__ import annotations
 
-from swing_screener.strategy.storage import (
-    DEFAULT_STRATEGY_ID,
-    load_strategies,
-    save_strategies,
-    load_active_strategy_id,
-    set_active_strategy_id,
-    get_active_strategy,
-    get_strategy_by_id,
+from swing_screener.strategy.plugin_system import (
+    resolve_strategy_config,
+    resolved_to_legacy_strategy,
+    load_plugin_definitions,
+    validate_resolved_strategy_config,
 )
+
+
+DEFAULT_STRATEGY_ID = "default"
+
+
+def _flatten_config(prefix: str, value) -> dict[str, object]:
+    if isinstance(value, dict):
+        out: dict[str, object] = {}
+        for key, child in value.items():
+            next_prefix = f"{prefix}.{key}" if prefix else str(key)
+            out.update(_flatten_config(next_prefix, child))
+        return out
+    return {prefix: value}
+
+
+def _doc_sections(docs: dict) -> list[dict]:
+    if not isinstance(docs, dict):
+        return []
+    labels = {
+        "what_it_is": "What It Is",
+        "why_it_matters": "Why It Matters",
+        "how_it_affects_trades": "How It Affects Trades",
+        "tradeoffs": "Tradeoffs",
+        "default_guidance": "Default Guidance",
+        "danger_zone": "Danger Zone",
+        "pro_tip": "Pro Tip",
+    }
+    sections: list[dict] = []
+    for key, title in labels.items():
+        value = str(docs.get(key, "")).strip()
+        if value:
+            sections.append({"title": title, "body": value})
+    return sections
+
+
+def _depends_on(plugin_id: str, graph_edges: dict[str, list[str]]) -> list[str]:
+    dependencies: list[str] = []
+    for source, targets in graph_edges.items():
+        if plugin_id in targets:
+            dependencies.append(source)
+    return sorted(dependencies)
+
+
+def _validation_payload(result: dict) -> dict:
+    warnings = []
+    for issue in result.get("issues", []):
+        level = issue.get("level", "warning")
+        mapped = "danger" if level == "error" else level
+        field = issue.get("field")
+        parameter = f"{issue['plugin_id']}.{field}" if field else issue["plugin_id"]
+        warnings.append(
+            {
+                "parameter": parameter,
+                "level": mapped,
+                "message": issue.get("message", ""),
+            }
+        )
+    danger_count = sum(1 for item in warnings if item["level"] == "danger")
+    warning_count = sum(1 for item in warnings if item["level"] == "warning")
+    info_count = sum(1 for item in warnings if item["level"] == "info")
+    safety_score = max(0, min(100, 100 - danger_count * 15 - warning_count * 8 - info_count * 3))
+    safety_level = (
+        "beginner-safe"
+        if safety_score >= 85
+        else "requires-discipline"
+        if safety_score >= 70
+        else "expert-only"
+    )
+    return {
+        "is_valid": result.get("is_valid", False),
+        "warnings": warnings,
+        "safety_score": safety_score,
+        "safety_level": safety_level,
+        "total_warnings": len(warnings),
+        "danger_count": danger_count,
+        "warning_count": warning_count,
+        "info_count": info_count,
+    }
 
 
 class StrategyRepository:
     def list_strategies(self) -> list[dict]:
-        return load_strategies()
+        return [self.get_active_strategy()]
 
     def get_strategy(self, strategy_id: str) -> dict | None:
-        return get_strategy_by_id(strategy_id)
+        strategy = self.get_active_strategy()
+        return strategy if strategy.get("id") == strategy_id else None
 
     def get_active_strategy(self) -> dict:
-        return get_active_strategy()
+        return resolved_to_legacy_strategy(resolve_strategy_config())
 
     def set_active_strategy_id(self, strategy_id: str) -> None:
-        set_active_strategy_id(strategy_id)
+        raise NotImplementedError("Strategy activation is not supported in YAML read-only mode.")
 
     def save_strategies(self, strategies: list[dict]) -> None:
-        save_strategies(strategies)
+        raise NotImplementedError("Strategy editing is not supported in YAML read-only mode.")
 
     def get_active_strategy_id(self) -> str:
-        return load_active_strategy_id()
+        return self.get_active_strategy().get("id", DEFAULT_STRATEGY_ID)
+
+    def get_resolved_config(self) -> dict:
+        resolved = resolve_strategy_config()
+        strategy = resolved.get("strategy", {})
+        graph_edges = resolved.get("graph_edges", {})
+        plugins = []
+        for plugin in resolved.get("plugins", []):
+            defaults_flat = _flatten_config("", plugin.get("defaults", {}))
+            effective_flat = _flatten_config("", plugin.get("effective_config", {}))
+            schema = plugin.get("config_schema", {})
+            keys = sorted(set(defaults_flat) | set(effective_flat) | set(schema))
+            values = []
+            for key in keys:
+                field_schema = schema.get(key, {}) if isinstance(schema, dict) else {}
+                values.append(
+                    {
+                        "key": key,
+                        "label": field_schema.get("label", key),
+                        "description": field_schema.get("description"),
+                        "type": field_schema.get("type"),
+                        "default_value": defaults_flat.get(key),
+                        "effective_value": effective_flat.get(key),
+                        "overridden": key in _flatten_config("", plugin.get("overrides", {})),
+                        "source": "root_override" if key in _flatten_config("", plugin.get("overrides", {})) else "plugin_default",
+                    }
+                )
+            plugins.append(
+                {
+                    "id": plugin["plugin_id"],
+                    "category": str(plugin.get("category", "education")).lower(),
+                    "display_name": plugin.get("display_name", plugin["plugin_id"]),
+                    "description": plugin.get("description", ""),
+                    "enabled": plugin.get("enabled", False),
+                    "default_enabled": bool(plugin.get("defaults", {}).get("enabled", False)),
+                    "phase": plugin.get("phase", "qualification"),
+                    "provides": [str(item) for item in plugin.get("provides", [])],
+                    "requires": [str(item) for item in plugin.get("requires", [])],
+                    "modifies": [str(item) for item in plugin.get("modifies", [])],
+                    "conflicts": [str(item) for item in plugin.get("conflicts", [])],
+                    "depends_on": _depends_on(plugin["plugin_id"], graph_edges),
+                    "read_only_sections": _doc_sections(plugin.get("docs", {})),
+                    "values": values,
+                }
+            )
+        return {
+            "name": strategy.get("name", "Default"),
+            "description": strategy.get("description"),
+            "module": strategy.get("module", "momentum"),
+            "config_path": "config/strategy.yaml",
+            "execution_order": resolved.get("execution_order", []),
+            "graph_edges": graph_edges,
+            "plugins": plugins,
+        }
+
+    def list_plugin_definitions(self) -> list[dict]:
+        definitions = []
+        for plugin in load_plugin_definitions():
+            config_schema = plugin.get("config_schema", {})
+            definitions.append(
+                {
+                    "id": plugin["id"],
+                    "category": str(plugin.get("category", "education")).lower(),
+                    "display_name": plugin.get("display_name", plugin["id"]),
+                    "description": plugin.get("description", ""),
+                    "enabled_by_default": bool(plugin.get("defaults", {}).get("enabled", False)),
+                    "phase": plugin.get("phase", "qualification"),
+                    "provides": [str(item) for item in plugin.get("provides", [])],
+                    "requires": [str(item) for item in plugin.get("requires", [])],
+                    "modifies": [str(item) for item in plugin.get("modifies", [])],
+                    "conflicts": [str(item) for item in plugin.get("conflicts", [])],
+                    "config_fields": [
+                        {
+                            "key": key,
+                            "label": field.get("label", key),
+                            "description": field.get("description"),
+                            "type": field.get("type"),
+                        }
+                        for key, field in config_schema.items()
+                    ],
+                    "read_only_sections": _doc_sections(plugin.get("docs", {})),
+                }
+            )
+        return definitions
+
+    def validate_config(self) -> dict:
+        raw_resolved = resolve_strategy_config()
+        return _validation_payload(validate_resolved_strategy_config(raw_resolved))
 
     @property
     def default_strategy_id(self) -> str:

--- a/api/routers/strategy.py
+++ b/api/routers/strategy.py
@@ -13,6 +13,10 @@ from api.models.strategy import (
     StrategyValidationResult,
     ValidationWarningModel,
 )
+from api.models.strategy_runtime import (
+    StrategyPluginDefinition,
+    StrategyResolvedConfig,
+)
 from api.dependencies import get_strategy_service
 from api.services.strategy_service import StrategyService
 from swing_screener.strategy.validation import validate_strategy_full
@@ -49,6 +53,24 @@ def _build_validation_result(strategy_payload: dict) -> StrategyValidationResult
 async def list_strategies(service: StrategyService = Depends(get_strategy_service)):
     """List all strategies."""
     return service.list_strategies()
+
+
+@router.get("/config", response_model=StrategyResolvedConfig)
+async def get_strategy_config(service: StrategyService = Depends(get_strategy_service)):
+    """Get resolved plugin-based strategy config from YAML."""
+    return service.get_resolved_config()
+
+
+@router.get("/plugins", response_model=list[StrategyPluginDefinition])
+async def list_strategy_plugins(service: StrategyService = Depends(get_strategy_service)):
+    """List plugin definitions discovered from YAML plugin manifests."""
+    return service.list_plugins()
+
+
+@router.get("/validation", response_model=StrategyValidationResult)
+async def get_strategy_validation(service: StrategyService = Depends(get_strategy_service)):
+    """Validate current strategy config and capability graph."""
+    return service.get_validation()
 
 
 @router.get("/active", response_model=Strategy)

--- a/api/services/screener_service.py
+++ b/api/services/screener_service.py
@@ -21,6 +21,7 @@ from api.models.screener import (
 )
 from api.models.recommendation import Recommendation
 from swing_screener.risk.engine import RiskEngineConfig, evaluate_recommendation
+from swing_screener.risk.recommendations.engine import ChecklistGate, Reason
 from api.repositories.strategy_repo import StrategyRepository
 from swing_screener.data.universe import (
     load_universe_from_package,
@@ -546,8 +547,46 @@ class ScreenerService:
                 if social_overlay_cfg.enabled and not overlay_reasons:
                     overlay_reasons = ["BACKGROUND_WARMUP"]
 
+                volume_ratio = _safe_optional_float(row.get("volume_ratio"))
+                volume_confirmation_passed = (
+                    None
+                    if _is_na_scalar(row.get("volume_confirmation_passed"))
+                    else bool(row.get("volume_confirmation_passed"))
+                )
+                today_volume = _safe_optional_float(row.get("today_volume"))
+                average_volume = _safe_optional_float(row.get("average_volume"))
+
                 rr_target = _safe_float(getattr(risk_cfg, "rr_target", 2.0), default=2.0)
                 commission_pct = _safe_float(getattr(risk_cfg, "commission_pct", 0.0), default=0.0)
+                extra_checklist: list[ChecklistGate] = []
+                extra_reasons: list[Reason] = []
+                extra_suggestions: list[str] = []
+                if volume_confirmation_passed is not None:
+                    extra_checklist.append(
+                        ChecklistGate(
+                            gate_name="volume_confirmation",
+                            passed=volume_confirmation_passed,
+                            explanation="Breakout volume confirmation passed."
+                            if volume_confirmation_passed
+                            else "Breakout volume confirmation failed.",
+                            rule="Q1",
+                        )
+                    )
+                    if not volume_confirmation_passed:
+                        extra_reasons.append(
+                            Reason(
+                                code="VOLUME_CONFIRMATION_FAILED",
+                                message="Breakout does not have enough volume confirmation.",
+                                severity="block",
+                                rule="Q1",
+                                metrics={
+                                    "volume_ratio": round(volume_ratio, 4) if volume_ratio is not None else 0.0,
+                                },
+                            )
+                        )
+                        extra_suggestions.append(
+                            "Wait for stronger participation or keep the setup on watchlist."
+                        )
 
                 rec_payload = evaluate_recommendation(
                     signal=str(signal) if not _is_na_scalar(signal) else None,
@@ -574,6 +613,9 @@ class ScreenerService:
                     momentum_12m=_safe_float(row.get("mom_12m")),
                     rel_strength=_safe_float(row.get("rs_6m")),
                     confidence=_safe_float(row.get("confidence")),
+                    extra_checklist=extra_checklist,
+                    extra_reasons=extra_reasons,
+                    extra_suggestions=extra_suggestions,
                 )
                 recommendation = Recommendation.model_validate(asdict(rec_payload))
                 rec_risk = recommendation.risk
@@ -605,6 +647,10 @@ class ScreenerService:
                         overlay_sentiment_confidence=_safe_optional_float(row.get("overlay_sentiment_confidence")),
                         overlay_hype_score=_safe_optional_float(row.get("overlay_hype_score")),
                         overlay_sample_size=_safe_optional_int(row.get("overlay_sample_size")),
+                        today_volume=today_volume,
+                        average_volume=average_volume,
+                        volume_ratio=volume_ratio,
+                        volume_confirmation_passed=volume_confirmation_passed,
                         signal=str(signal) if not _is_na_scalar(signal) else None,
                         entry=rec_risk.entry,
                         stop=rec_risk.stop if stop_val is not None else None,

--- a/api/services/strategy_service.py
+++ b/api/services/strategy_service.py
@@ -9,6 +9,11 @@ from api.models.strategy import (
     StrategyCreateRequest,
     StrategyUpdateRequest,
     ActiveStrategyRequest,
+    StrategyValidationResult,
+)
+from api.models.strategy_runtime import (
+    StrategyPluginDefinition,
+    StrategyResolvedConfig,
 )
 from api.repositories.strategy_repo import StrategyRepository
 
@@ -33,75 +38,25 @@ class StrategyService:
         return self._repo.get_active_strategy()
 
     def set_active_strategy(self, request: ActiveStrategyRequest) -> Strategy:
-        strategy = self._require_strategy(request.strategy_id)
-        self._repo.set_active_strategy_id(request.strategy_id)
-        return strategy
+        raise HTTPException(status_code=405, detail="Strategy activation is not supported in YAML read-only mode.")
 
     def get_strategy(self, strategy_id: str) -> Strategy:
         return self._require_strategy(strategy_id)
 
     def create_strategy(self, request: StrategyCreateRequest) -> Strategy:
-        if request.id == self._repo.default_strategy_id:
-            raise HTTPException(status_code=400, detail="Cannot create strategy with reserved id 'default'.")
-
-        strategies = self._repo.list_strategies()
-        if any(s.get("id") == request.id for s in strategies):
-            raise HTTPException(status_code=409, detail=f"Strategy already exists: {request.id}")
-
-        ts = self._now_iso()
-        payload = request.model_dump()
-        payload["is_default"] = False
-        payload["created_at"] = ts
-        payload["updated_at"] = ts
-
-        strategies.append(payload)
-        self._repo.save_strategies(strategies)
-        return payload
+        raise HTTPException(status_code=405, detail="Strategy editing is not supported in YAML read-only mode.")
 
     def update_strategy(self, strategy_id: str, request: StrategyUpdateRequest) -> Strategy:
-        strategies = self._repo.list_strategies()
-        ts = self._now_iso()
-
-        for idx, strategy in enumerate(strategies):
-            if strategy.get("id") != strategy_id:
-                continue
-
-            updated = request.model_dump()
-            updated["id"] = strategy_id
-            updated["is_default"] = bool(strategy.get("is_default", False))
-            updated["created_at"] = strategy.get("created_at", ts)
-            updated["updated_at"] = ts
-
-            strategies[idx] = updated
-            self._repo.save_strategies(strategies)
-            return updated
-
-        raise HTTPException(status_code=404, detail=f"Strategy not found: {strategy_id}")
+        raise HTTPException(status_code=405, detail="Strategy editing is not supported in YAML read-only mode.")
 
     def delete_strategy(self, strategy_id: str) -> dict:
-        strategies = self._repo.list_strategies()
+        raise HTTPException(status_code=405, detail="Strategy editing is not supported in YAML read-only mode.")
 
-        if strategy_id == self._repo.default_strategy_id:
-            raise HTTPException(status_code=400, detail="Default strategy cannot be deleted.")
+    def get_resolved_config(self) -> StrategyResolvedConfig:
+        return StrategyResolvedConfig.model_validate(self._repo.get_resolved_config())
 
-        active_id = self._repo.get_active_strategy_id()
+    def list_plugins(self) -> list[StrategyPluginDefinition]:
+        return [StrategyPluginDefinition.model_validate(plugin) for plugin in self._repo.list_plugin_definitions()]
 
-        kept: list[dict] = []
-        removed = False
-        for strategy in strategies:
-            if strategy.get("id") == strategy_id:
-                if strategy.get("is_default"):
-                    raise HTTPException(status_code=400, detail="Default strategy cannot be deleted.")
-                removed = True
-                continue
-            kept.append(strategy)
-
-        if not removed:
-            raise HTTPException(status_code=404, detail=f"Strategy not found: {strategy_id}")
-
-        self._repo.save_strategies(kept)
-
-        if active_id == strategy_id:
-            self._repo.set_active_strategy_id(self._repo.default_strategy_id)
-
-        return {"status": "deleted", "id": strategy_id}
+    def get_validation(self) -> StrategyValidationResult:
+        return StrategyValidationResult.model_validate(self._repo.validate_config())

--- a/config/README.md
+++ b/config/README.md
@@ -4,6 +4,24 @@ This directory contains configuration files for the Swing Screener application.
 
 ## Files
 
+### `strategy.yaml`
+
+Root strategy configuration for the plugin-based strategy runtime.
+
+**Purpose:** Enables or disables strategy plugins and overrides plugin defaults in a single YAML source of truth.
+
+**Structure:**
+- `strategy.id`, `strategy.name`, `strategy.description`, `strategy.module`
+- `strategy.plugins.<plugin_id>.enabled`
+- `strategy.plugins.<plugin_id>.config`
+
+**Notes:**
+- Plugin defaults live under `/src/swing_screener/strategy/plugins/<plugin_id>/defaults.yaml`
+- Plugin contracts and capability declarations live under `/src/swing_screener/strategy/plugins/<plugin_id>/plugin.yaml`
+- The Strategy UI is read-only and reflects the resolved result of this file plus plugin defaults
+
+**Documentation:** See `/docs/engineering/STRATEGY_PLUGIN_ARCHITECTURE.md`
+
 ### `mcp_features.yaml`
 
 Configuration file for the MCP (Model Context Protocol) server.

--- a/config/strategy.yaml
+++ b/config/strategy.yaml
@@ -1,0 +1,54 @@
+strategy:
+  id: default
+  name: Default
+  description: Plugin-based momentum strategy loaded from YAML.
+  module: momentum
+  plugins:
+    price_filter:
+      enabled: true
+    atr_filter:
+      enabled: true
+    trend_filter:
+      enabled: true
+    currency_filter:
+      enabled: true
+    rs_filter:
+      enabled: true
+      config:
+        require_rs_positive: false
+    momentum_ranking:
+      enabled: true
+    breakout_signal:
+      enabled: true
+    pullback_signal:
+      enabled: true
+    min_history_gate:
+      enabled: true
+    atr_position_sizing:
+      enabled: true
+    rr_gate:
+      enabled: true
+    fee_gate:
+      enabled: true
+    regime_risk:
+      enabled: true
+      config:
+        enabled: false
+    social_overlay:
+      enabled: true
+      config:
+        enabled: false
+    market_intelligence:
+      enabled: true
+      config:
+        enabled: false
+    breakeven_management:
+      enabled: true
+    trailing_management:
+      enabled: true
+    time_exit_management:
+      enabled: true
+    volume_confirmation:
+      enabled: true
+      config:
+        enabled: false

--- a/config/strategy.yaml
+++ b/config/strategy.yaml
@@ -26,6 +26,8 @@ strategy:
       enabled: true
     atr_position_sizing:
       enabled: true
+      config:
+        account_size: 500.0
     rr_gate:
       enabled: true
     fee_gate:

--- a/data/intelligence/discovered_feeds_cache.json
+++ b/data/intelligence/discovered_feeds_cache.json
@@ -1,1 +1,22 @@
-{}
+{
+  "exchange:*|AIR.PA|XPAR": {
+    "updated_at": "2026-03-07T11:29:32.412779",
+    "feeds": []
+  },
+  "news:all": {
+    "updated_at": "2026-03-07T11:29:32.416655",
+    "feeds": []
+  },
+  "ir:AAPL": {
+    "updated_at": "2026-03-07T11:29:32.506399",
+    "feeds": []
+  },
+  "ir:MSFT": {
+    "updated_at": "2026-03-07T11:29:42.006678",
+    "feeds": []
+  },
+  "ir:NVDA": {
+    "updated_at": "2026-03-07T11:29:45.616158",
+    "feeds": []
+  }
+}

--- a/docs/engineering/STRATEGY_PLUGIN_ARCHITECTURE.md
+++ b/docs/engineering/STRATEGY_PLUGIN_ARCHITECTURE.md
@@ -1,0 +1,211 @@
+# Strategy Plugin Architecture
+
+> Status: current.  
+> Last reviewed: 2026-03-07.
+
+This document describes the current strategy system after the YAML plugin refactor.
+
+## Summary
+
+The strategy is now:
+
+- file-driven
+- plugin-based
+- read-only in the UI
+- validated through a capability graph
+
+The source of truth is no longer an editable strategy payload stored through CRUD APIs. The source of truth is:
+
+- root strategy config: `/config/strategy.yaml`
+- plugin manifests and defaults: `/src/swing_screener/strategy/plugins/<plugin_id>/`
+
+## Directory Layout
+
+Root config:
+
+- `/config/strategy.yaml`
+
+Plugin system:
+
+- `/src/swing_screener/strategy/plugin_system.py`
+- `/src/swing_screener/strategy/plugins/<plugin_id>/plugin.yaml`
+- `/src/swing_screener/strategy/plugins/<plugin_id>/defaults.yaml`
+
+Runtime API models:
+
+- `/api/models/strategy_runtime.py`
+
+Read-only API surface:
+
+- `GET /api/strategy/config`
+- `GET /api/strategy/plugins`
+- `GET /api/strategy/validation`
+
+## Merge Model
+
+Strategy resolution works in this order:
+
+1. discover all plugin folders
+2. load each plugin `plugin.yaml`
+3. load each plugin `defaults.yaml`
+4. load `/config/strategy.yaml`
+5. apply root overrides on top of plugin defaults
+6. validate the final config and capability graph
+7. expose resolved state through the API
+
+The root YAML can:
+
+- enable or disable a plugin
+- override plugin config values
+
+The root YAML cannot:
+
+- redefine the plugin contract
+- invent unknown fields without validation errors
+
+## Plugin Contract
+
+Each plugin declares:
+
+- `id`
+- `category`
+- `phase`
+- `display_name`
+- `description`
+- `defaults_file`
+- `config_schema`
+- `docs`
+- `runtime_hooks`
+- `provides`
+- `requires`
+- `modifies`
+- `conflicts`
+
+Minimal example:
+
+```yaml
+id: volume_confirmation
+category: Qualification
+phase: qualification
+display_name: Volume Confirmation
+description: Confirm breakouts using relative volume.
+defaults_file: defaults.yaml
+
+provides:
+  - volume_breakout_confirmation
+
+requires:
+  - breakout_signal
+
+modifies:
+  - signal_validation
+
+conflicts: []
+
+runtime_hooks:
+  - qualify_candidate
+  - augment_recommendation
+```
+
+## Capability Graph
+
+The runtime builds an execution graph from:
+
+- plugin phases
+- capability requirements
+- explicit plugin dependencies
+- conflicts
+
+This prevents:
+
+- invalid plugin combinations
+- implicit ordering bugs
+- silent missing dependencies
+
+Example:
+
+- `breakout_signal` provides `breakout_signal`
+- `volume_confirmation` requires `breakout_signal`
+- runtime places `breakout_signal` before `volume_confirmation`
+
+The resolved graph is exposed by `GET /api/strategy/config` as:
+
+- `execution_order`
+- `graph_edges`
+
+The UI shows this as the read-only execution graph.
+
+## UI Model
+
+The Strategy page is now read-only.
+
+It shows:
+
+- strategy metadata
+- resolved plugin values
+- whether a value comes from plugin default or root override
+- plugin docs
+- validation warnings
+- execution graph
+- plugin capability metadata
+
+It does not:
+
+- edit strategy fields
+- save strategy mutations
+- create or delete strategies
+
+Those mutation endpoints now return `405`.
+
+## Volume Confirmation
+
+`volume_confirmation` is the first qualification plugin added on top of this architecture.
+
+Default config:
+
+```yaml
+enabled: false
+config:
+  enabled: false
+  volume_ma_window: 20
+  min_breakout_volume_ratio: 1.5
+  apply_to_breakout: true
+  apply_to_pullback: false
+```
+
+Current behavior:
+
+- applies to `breakout` and `both`
+- computes `volume_ratio = today_volume / average_volume`
+- if the configured threshold is not met, the breakout is invalidated
+- recommendation output includes a dedicated checklist gate and failure reason
+
+## How To Add A New Plugin
+
+1. create `/src/swing_screener/strategy/plugins/<plugin_id>/plugin.yaml`
+2. create `/src/swing_screener/strategy/plugins/<plugin_id>/defaults.yaml`
+3. declare schema, docs and capabilities
+4. wire runtime behavior where the declared `runtime_hooks` are consumed
+5. add root overrides in `/config/strategy.yaml` only if needed
+6. verify API payload and Strategy page rendering
+7. add tests for:
+   - discovery
+   - validation
+   - execution ordering
+   - runtime behavior
+
+## Validation Rules
+
+Validation currently checks:
+
+- schema type mismatches
+- numeric min/max violations
+- unknown root override fields
+- missing plugin dependencies
+- missing capability providers
+- declared conflicts
+
+## Notes
+
+- This system is intentionally repo-internal for now. Plugins are discovered from the repository tree, not from external packages.
+- Legacy strategy consumers still receive an adapted runtime payload where needed, but the canonical authoring model is now YAML + plugin manifests.

--- a/docs/overview/INDEX.md
+++ b/docs/overview/INDEX.md
@@ -12,6 +12,7 @@
 ## Engineering
 - `/docs/engineering/ROADMAP.md`
 - `/docs/engineering/MODULE_ARCHITECTURE.md`
+- `/docs/engineering/STRATEGY_PLUGIN_ARCHITECTURE.md`
 - `/docs/engineering/MODULE_ARCHITECTURE_MIGRATION_PLAN.md` (archived)
 - `/docs/engineering/REFACTOR_PLAN.md`
 - `/docs/engineering/REFACTOR_PLAN_UI_API.md`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
   "pandas>=2.0",
   "numpy>=1.24",
   "yfinance>=0.2",
+  "pyyaml>=6.0",
   "pyarrow>=14.0",
   "fastapi>=0.104",
   "uvicorn[standard]>=0.24",
@@ -73,3 +74,4 @@ markers = [
 
 [tool.setuptools.package-data]
 "swing_screener.data" = ["universes/*.csv", "universes/*.json"]
+"swing_screener.strategy" = ["plugins/*/*.yaml", "plugins/*/*.yml"]

--- a/src/swing_screener/risk/engine.py
+++ b/src/swing_screener/risk/engine.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 from swing_screener.risk.recommendations.engine import RecommendationPayload, build_recommendation
+from swing_screener.risk.recommendations.engine import ChecklistGate, Reason
 from swing_screener.risk.recommendations.thesis import build_trade_thesis, thesis_to_dict
 from swing_screener.risk.position_sizing import RiskConfig
 
@@ -40,6 +41,9 @@ def evaluate_recommendation(
     momentum_12m: Optional[float] = None,
     rel_strength: Optional[float] = None,
     confidence: Optional[float] = None,
+    extra_checklist: Optional[list[ChecklistGate]] = None,
+    extra_reasons: Optional[list[Reason]] = None,
+    extra_suggestions: Optional[list[str]] = None,
 ) -> RecommendationPayload:
     """
     Evaluate recommendation with optional Trade Thesis generation.
@@ -109,5 +113,8 @@ def evaluate_recommendation(
         fx_estimate_pct=costs.fx_estimate_pct,
         overlay_status=overlay_status,
         min_shares=risk_cfg.min_shares,
+        extra_checklist=extra_checklist,
+        extra_reasons=extra_reasons,
+        extra_suggestions=extra_suggestions,
         thesis=thesis_dict,
     )

--- a/src/swing_screener/risk/recommendations/engine.py
+++ b/src/swing_screener/risk/recommendations/engine.py
@@ -105,6 +105,9 @@ def build_recommendation(
     fx_estimate_pct: float = 0.0,
     overlay_status: Optional[str] = None,
     min_shares: int = 1,
+    extra_checklist: Optional[list[ChecklistGate]] = None,
+    extra_reasons: Optional[list[Reason]] = None,
+    extra_suggestions: Optional[list[str]] = None,
     thesis: Optional[dict] = None,  # Trade Thesis dictionary
 ) -> RecommendationPayload:
     if entry is None or not math.isfinite(entry) or entry <= 0:
@@ -207,6 +210,8 @@ def build_recommendation(
             rule="R5",
         ),
     ]
+    if extra_checklist:
+        checklist.extend(extra_checklist)
 
     reasons_detailed: list[Reason] = []
     suggestions: list[str] = []
@@ -301,6 +306,11 @@ def build_recommendation(
                 rule="R5",
             )
         )
+
+    if extra_reasons:
+        reasons_detailed.extend(extra_reasons)
+    if extra_suggestions:
+        suggestions.extend(extra_suggestions)
 
     verdict: Verdict = "RECOMMENDED" if all(g.passed for g in checklist) else "NOT_RECOMMENDED"
 

--- a/src/swing_screener/strategy/config.py
+++ b/src/swing_screener/strategy/config.py
@@ -94,6 +94,7 @@ def build_report_config(strategy: dict, *, top_override: Optional[int] = None) -
     risk = build_risk_config(strategy)
     social_overlay = build_social_overlay_config(strategy)
     strategy_module = strategy.get("module", "momentum") if isinstance(strategy, dict) else "momentum"
+    plugin_settings = strategy.get("plugins_runtime", {}) if isinstance(strategy, dict) else {}
 
     if top_override is not None:
         ranking = RankingConfig(
@@ -111,4 +112,5 @@ def build_report_config(strategy: dict, *, top_override: Optional[int] = None) -
         social_overlay=social_overlay,
         only_active_signals=False,
         strategy_module=strategy_module,
+        plugin_settings=plugin_settings,
     )

--- a/src/swing_screener/strategy/modules/momentum.py
+++ b/src/swing_screener/strategy/modules/momentum.py
@@ -68,6 +68,64 @@ def _compute_confidence(report: pd.DataFrame, max_atr_pct: float) -> pd.Series:
     return conf
 
 
+def _volume_confirmation_rows(
+    ohlcv: pd.DataFrame,
+    board: pd.DataFrame,
+    volume_cfg: dict,
+) -> pd.DataFrame:
+    if (
+        ohlcv is None
+        or ohlcv.empty
+        or board is None
+        or board.empty
+        or "Volume" not in ohlcv.columns.get_level_values(0)
+    ):
+        return pd.DataFrame(index=board.index if board is not None else pd.Index([], name="ticker"))
+
+    volume = ohlcv["Volume"]
+    window = max(1, int(volume_cfg.get("volume_ma_window", 20)))
+    min_ratio = float(volume_cfg.get("min_breakout_volume_ratio", 1.5))
+    apply_to_breakout = bool(volume_cfg.get("apply_to_breakout", True))
+    apply_to_pullback = bool(volume_cfg.get("apply_to_pullback", False))
+
+    rows: list[dict] = []
+    for ticker in board.index:
+        signal = str(board.loc[ticker, "signal"])
+        series = volume[ticker].dropna() if ticker in volume.columns else pd.Series(dtype=float)
+        today_volume = float(series.iloc[-1]) if not series.empty else None
+        avg_volume = None
+        if len(series) > window:
+            avg_volume = float(series.iloc[-(window + 1):-1].mean())
+        volume_ratio = (today_volume / avg_volume) if today_volume is not None and avg_volume not in (None, 0) else None
+
+        must_confirm = (
+            (signal in {"breakout", "both"} and apply_to_breakout)
+            or (signal == "pullback" and apply_to_pullback)
+        )
+        passed = True
+        adjusted_signal = signal
+        if must_confirm:
+            passed = volume_ratio is not None and volume_ratio >= min_ratio
+            if not passed:
+                if signal == "both" and not apply_to_pullback:
+                    adjusted_signal = "pullback"
+                else:
+                    adjusted_signal = "none"
+
+        rows.append(
+            {
+                "ticker": ticker,
+                "today_volume": today_volume,
+                "average_volume": avg_volume,
+                "volume_ratio": volume_ratio,
+                "volume_confirmation_passed": passed,
+                "signal": adjusted_signal,
+            }
+        )
+
+    return pd.DataFrame(rows).set_index("ticker")
+
+
 def build_momentum_report(
     ohlcv: pd.DataFrame,
     cfg: ReportConfig,
@@ -93,6 +151,16 @@ def build_momentum_report(
 
     tickers = ranked.index.tolist()
     board = build_signal_board(ohlcv, tickers, cfg.signals)
+
+    volume_plugin = cfg.plugin_settings.get("volume_confirmation", {})
+    volume_cfg = volume_plugin.get("effective_config", {}) if isinstance(volume_plugin, dict) else {}
+    volume_enabled = bool(volume_plugin.get("enabled")) and bool(volume_cfg.get("enabled", False))
+    volume_df: pd.DataFrame | None = None
+    if volume_enabled and not board.empty:
+        volume_df = _volume_confirmation_rows(ohlcv, board, volume_cfg)
+        if not volume_df.empty:
+            board["signal"] = volume_df["signal"].reindex(board.index).fillna(board["signal"])
+            volume_df = volume_df.drop(columns=["signal"], errors="ignore")
 
     atr_col = f"atr{cfg.universe.vol.atr_window}"
 
@@ -213,6 +281,9 @@ def build_momentum_report(
     # merge: ranked features + signal board (left) + plans (left)
     report = ranked.join(board, how="left", rsuffix="_sig")
 
+    if volume_df is not None and not volume_df.empty:
+        report = report.join(volume_df, how="left")
+
     if overlay_rows:
         overlay_df = pd.DataFrame(overlay_rows).set_index("ticker")
         report = report.join(overlay_df, how="left")
@@ -245,6 +316,7 @@ def build_momentum_report(
         "overlay_risk_multiplier", "overlay_max_pos_multiplier",
         "overlay_attention_z", "overlay_sentiment_score", "overlay_sentiment_confidence",
         "overlay_hype_score", "overlay_sample_size",
+        "today_volume", "average_volume", "volume_ratio", "volume_confirmation_passed",
     ]
     keep = [c for c in keep if c in report.columns]
     report = report[keep]

--- a/src/swing_screener/strategy/plugin_system.py
+++ b/src/swing_screener/strategy/plugin_system.py
@@ -1,0 +1,508 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+ROOT_DIR = Path(__file__).resolve().parents[3]
+DEFAULT_STRATEGY_CONFIG = ROOT_DIR / "config" / "strategy.yaml"
+PLUGINS_DIR = Path(__file__).resolve().parent / "plugins"
+PHASE_ORDER = {
+    "universe": 10,
+    "ranking": 20,
+    "signals": 30,
+    "qualification": 40,
+    "risk": 50,
+    "management": 60,
+    "intelligence": 70,
+    "education": 80,
+    "recommendation": 90,
+}
+KNOWN_INTERNAL_CAPABILITIES = {
+    "candidate_eligibility",
+    "signal_validation",
+    "candidate_score",
+    "risk_multiplier",
+    "risk_budget",
+    "recommendation_payload",
+}
+
+
+@dataclass(frozen=True)
+class StrategyValidationIssue:
+    plugin_id: str
+    field: str | None
+    level: str
+    message: str
+    source: str
+
+
+def _read_yaml(path: Path) -> dict[str, Any]:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    return payload if isinstance(payload, dict) else {}
+
+
+def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    out = dict(base)
+    for key, value in override.items():
+        current = out.get(key)
+        if isinstance(current, dict) and isinstance(value, dict):
+            out[key] = _deep_merge(current, value)
+        else:
+            out[key] = value
+    return out
+
+
+def _iter_plugin_dirs(base_dir: Path | None = None) -> list[Path]:
+    plugins_dir = base_dir or PLUGINS_DIR
+    if not plugins_dir.exists():
+        return []
+    return sorted(
+        [path for path in plugins_dir.iterdir() if path.is_dir() and (path / "plugin.yaml").exists()],
+        key=lambda path: path.name,
+    )
+
+
+def load_plugin_definitions(base_dir: Path | None = None) -> list[dict[str, Any]]:
+    definitions: list[dict[str, Any]] = []
+    for plugin_dir in _iter_plugin_dirs(base_dir):
+        plugin = _read_yaml(plugin_dir / "plugin.yaml")
+        plugin.setdefault("id", plugin_dir.name)
+        plugin["path"] = str(plugin_dir)
+        defaults_file = plugin_dir / plugin.get("defaults_file", "defaults.yaml")
+        plugin["defaults"] = _read_yaml(defaults_file) if defaults_file.exists() else {}
+        plugin.setdefault("config_schema", {})
+        plugin.setdefault("read_only_sections", ["Configuration"])
+        plugin.setdefault("dependencies", [])
+        plugin.setdefault("runtime_hooks", [])
+        plugin.setdefault("provides", [])
+        plugin.setdefault("requires", [])
+        plugin.setdefault("modifies", [])
+        plugin.setdefault("conflicts", [])
+        plugin.setdefault("phase", "qualification")
+        definitions.append(plugin)
+    return definitions
+
+
+def load_plugin_definition_map(base_dir: Path | None = None) -> dict[str, dict[str, Any]]:
+    return {plugin["id"]: plugin for plugin in load_plugin_definitions(base_dir)}
+
+
+def load_strategy_yaml(config_path: Path | None = None) -> dict[str, Any]:
+    path = config_path or DEFAULT_STRATEGY_CONFIG
+    payload = _read_yaml(path)
+    strategy = payload.get("strategy")
+    return strategy if isinstance(strategy, dict) else {}
+
+
+def resolve_strategy_config(
+    *,
+    config_path: Path | None = None,
+    plugins_dir: Path | None = None,
+) -> dict[str, Any]:
+    plugin_map = load_plugin_definition_map(plugins_dir)
+    strategy = load_strategy_yaml(config_path)
+
+    metadata = {
+      "id": str(strategy.get("id", "default")),
+      "name": str(strategy.get("name", "Default")),
+      "description": str(strategy.get("description", "Plugin-based strategy")),
+      "module": str(strategy.get("module", "momentum")),
+    }
+
+    plugin_overrides = strategy.get("plugins", {}) if isinstance(strategy.get("plugins"), dict) else {}
+    resolved_plugins: list[dict[str, Any]] = []
+    for plugin_id, plugin in plugin_map.items():
+        raw_override = plugin_overrides.get(plugin_id, {})
+        if not isinstance(raw_override, dict):
+            raw_override = {}
+        enabled_override = raw_override.get("enabled")
+        base_defaults = plugin.get("defaults", {})
+        base_enabled = bool(base_defaults.get("enabled", plugin.get("enabled_by_default", False)))
+        base_config = base_defaults.get("config", {}) if isinstance(base_defaults.get("config"), dict) else {}
+        override_config = raw_override.get("config", {}) if isinstance(raw_override.get("config"), dict) else {}
+        effective_config = _deep_merge(base_config, override_config)
+        enabled = bool(enabled_override) if enabled_override is not None else base_enabled
+        resolved_plugins.append(
+            {
+                "plugin_id": plugin_id,
+                "category": plugin.get("category", "Other"),
+                "display_name": plugin.get("display_name", plugin_id),
+                "description": plugin.get("description", ""),
+                "enabled": enabled,
+                "defaults": base_config,
+                "overrides": override_config,
+                "effective_config": effective_config,
+                "read_only_sections": plugin.get("read_only_sections", []),
+                "config_schema": plugin.get("config_schema", {}),
+                "docs": plugin.get("docs", {}),
+                "dependencies": plugin.get("dependencies", []),
+                "runtime_hooks": plugin.get("runtime_hooks", []),
+                "provides": plugin.get("provides", []),
+                "requires": plugin.get("requires", []),
+                "modifies": plugin.get("modifies", []),
+                "conflicts": plugin.get("conflicts", []),
+                "phase": plugin.get("phase", "qualification"),
+            }
+        )
+
+    graph = resolve_plugin_execution_graph(resolved_plugins)
+    return {
+        "strategy": metadata,
+        "plugins": resolved_plugins,
+        "execution_order": graph["execution_order"],
+        "graph_edges": graph["graph_edges"],
+    }
+
+
+def resolve_plugin_execution_graph(plugins: list[dict[str, Any]]) -> dict[str, Any]:
+    enabled_plugins = [plugin for plugin in plugins if plugin.get("enabled")]
+    provided_by_capability: dict[str, list[str]] = {}
+    for plugin in enabled_plugins:
+        for capability in plugin.get("provides", []):
+            provided_by_capability.setdefault(str(capability), []).append(plugin["plugin_id"])
+
+    graph_edges: dict[str, set[str]] = {plugin["plugin_id"]: set() for plugin in enabled_plugins}
+    indegree: dict[str, int] = {plugin["plugin_id"]: 0 for plugin in enabled_plugins}
+
+    for plugin in enabled_plugins:
+        current_id = plugin["plugin_id"]
+        current_phase_rank = PHASE_ORDER.get(str(plugin.get("phase", "qualification")), 999)
+        for requirement in plugin.get("requires", []):
+            providers = provided_by_capability.get(str(requirement), [])
+            for provider_id in providers:
+                if provider_id == current_id or current_id in graph_edges[provider_id]:
+                    continue
+                graph_edges[provider_id].add(current_id)
+                indegree[current_id] += 1
+
+        for other in enabled_plugins:
+            other_id = other["plugin_id"]
+            if other_id == current_id:
+                continue
+            other_phase_rank = PHASE_ORDER.get(str(other.get("phase", "qualification")), 999)
+            if other_phase_rank < current_phase_rank and current_id not in graph_edges[other_id]:
+                graph_edges[other_id].add(current_id)
+                indegree[current_id] += 1
+
+    ready = sorted([plugin_id for plugin_id, degree in indegree.items() if degree == 0])
+    ordered: list[str] = []
+    while ready:
+        current = ready.pop(0)
+        ordered.append(current)
+        for child in sorted(graph_edges[current]):
+            indegree[child] -= 1
+            if indegree[child] == 0:
+                ready.append(child)
+                ready.sort()
+
+    if len(ordered) != len(enabled_plugins):
+        ordered = sorted(graph_edges.keys(), key=lambda plugin_id: (
+            PHASE_ORDER.get(
+                str(next((p.get("phase") for p in enabled_plugins if p["plugin_id"] == plugin_id), "qualification")),
+                999,
+            ),
+            plugin_id,
+        ))
+
+    return {
+        "execution_order": ordered,
+        "graph_edges": {plugin_id: sorted(children) for plugin_id, children in graph_edges.items()},
+    }
+
+
+def validate_resolved_strategy_config(
+    resolved: dict[str, Any],
+    *,
+    plugins_dir: Path | None = None,
+    config_path: Path | None = None,
+) -> dict[str, Any]:
+    plugin_map = load_plugin_definition_map(plugins_dir)
+    raw_strategy = load_strategy_yaml(config_path)
+    raw_plugins = raw_strategy.get("plugins", {}) if isinstance(raw_strategy.get("plugins"), dict) else {}
+
+    issues: list[StrategyValidationIssue] = []
+    resolved_plugins = {plugin["plugin_id"]: plugin for plugin in resolved.get("plugins", [])}
+    enabled_plugins = {plugin_id: plugin for plugin_id, plugin in resolved_plugins.items() if plugin.get("enabled")}
+    provided_capabilities: dict[str, list[str]] = {}
+    for plugin_id, plugin in enabled_plugins.items():
+        for capability in plugin.get("provides", []):
+            provided_capabilities.setdefault(str(capability), []).append(plugin_id)
+
+    for plugin_id, plugin in resolved_plugins.items():
+        schema = plugin.get("config_schema", {})
+        effective = plugin.get("effective_config", {})
+        raw_override = raw_plugins.get(plugin_id, {}) if isinstance(raw_plugins.get(plugin_id), dict) else {}
+        override_config = raw_override.get("config", {}) if isinstance(raw_override.get("config"), dict) else {}
+
+        for key in override_config:
+            if key not in schema:
+                issues.append(
+                    StrategyValidationIssue(
+                        plugin_id=plugin_id,
+                        field=key,
+                        level="error",
+                        message=f"Unknown override field '{key}' for plugin '{plugin_id}'.",
+                        source="override",
+                    )
+                )
+
+        for key, field_schema in schema.items():
+            value = effective.get(key)
+            field_type = field_schema.get("type")
+            if field_type == "integer" and not isinstance(value, int):
+                issues.append(
+                    StrategyValidationIssue(plugin_id, key, "error", "Expected integer value.", "schema")
+                )
+                continue
+            if field_type == "number" and not isinstance(value, (int, float)):
+                issues.append(
+                    StrategyValidationIssue(plugin_id, key, "error", "Expected numeric value.", "schema")
+                )
+                continue
+            if field_type == "boolean" and not isinstance(value, bool):
+                issues.append(
+                    StrategyValidationIssue(plugin_id, key, "error", "Expected boolean value.", "schema")
+                )
+                continue
+            if field_type == "string" and not isinstance(value, str):
+                issues.append(
+                    StrategyValidationIssue(plugin_id, key, "error", "Expected string value.", "schema")
+                )
+                continue
+            if field_type == "array" and not isinstance(value, list):
+                issues.append(
+                    StrategyValidationIssue(plugin_id, key, "error", "Expected list value.", "schema")
+                )
+                continue
+
+            minimum = field_schema.get("min")
+            maximum = field_schema.get("max")
+            if isinstance(value, (int, float)) and minimum is not None and value < minimum:
+                issues.append(
+                    StrategyValidationIssue(plugin_id, key, "error", f"Value must be >= {minimum}.", "schema")
+                )
+            if isinstance(value, (int, float)) and maximum is not None and value > maximum:
+                issues.append(
+                    StrategyValidationIssue(plugin_id, key, "error", f"Value must be <= {maximum}.", "schema")
+                )
+
+        if plugin.get("enabled"):
+            for dependency in plugin.get("dependencies", []):
+                dep_id = str(dependency)
+                dep_plugin = resolved_plugins.get(dep_id)
+                if dep_plugin is None or not dep_plugin.get("enabled"):
+                    issues.append(
+                        StrategyValidationIssue(
+                            plugin_id=plugin_id,
+                            field=None,
+                            level="error",
+                            message=f"Plugin '{plugin_id}' requires enabled dependency '{dep_id}'.",
+                            source="dependency",
+                        )
+                    )
+            for requirement in plugin.get("requires", []):
+                providers = provided_capabilities.get(str(requirement), [])
+                if not providers:
+                    issues.append(
+                        StrategyValidationIssue(
+                            plugin_id=plugin_id,
+                            field=None,
+                            level="error",
+                            message=f"Plugin '{plugin_id}' requires capability '{requirement}' but no enabled plugin provides it.",
+                            source="capability",
+                        )
+                    )
+            for conflict in plugin.get("conflicts", []):
+                if conflict in enabled_plugins:
+                    issues.append(
+                        StrategyValidationIssue(
+                            plugin_id=plugin_id,
+                            field=None,
+                            level="error",
+                            message=f"Plugin '{plugin_id}' conflicts with enabled plugin '{conflict}'.",
+                            source="conflict",
+                        )
+                    )
+                elif conflict in provided_capabilities:
+                    issues.append(
+                        StrategyValidationIssue(
+                            plugin_id=plugin_id,
+                            field=None,
+                            level="error",
+                            message=f"Plugin '{plugin_id}' conflicts with capability '{conflict}'.",
+                            source="conflict",
+                        )
+                    )
+            for capability in plugin.get("modifies", []):
+                if capability not in provided_capabilities and capability not in KNOWN_INTERNAL_CAPABILITIES:
+                    issues.append(
+                        StrategyValidationIssue(
+                            plugin_id=plugin_id,
+                            field=None,
+                            level="warning",
+                            message=f"Plugin '{plugin_id}' modifies capability '{capability}' but no enabled plugin explicitly provides it.",
+                            source="capability",
+                        )
+                    )
+
+    return {
+        "is_valid": not any(issue.level == "error" for issue in issues),
+        "issues": [
+            {
+                "plugin_id": issue.plugin_id,
+                "field": issue.field,
+                "level": issue.level,
+                "message": issue.message,
+                "source": issue.source,
+            }
+            for issue in issues
+        ],
+        "execution_order": resolved.get("execution_order", []),
+        "graph_edges": resolved.get("graph_edges", {}),
+    }
+
+
+def resolved_plugins_by_id(resolved: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {plugin["plugin_id"]: plugin for plugin in resolved.get("plugins", [])}
+
+
+def resolved_to_legacy_strategy(resolved: dict[str, Any]) -> dict[str, Any]:
+    strategy = resolved.get("strategy", {})
+    plugins = resolved_plugins_by_id(resolved)
+
+    trend = plugins.get("trend_filter", {})
+    price_filter = plugins.get("price_filter", {})
+    atr_filter = plugins.get("atr_filter", {})
+    currency_filter = plugins.get("currency_filter", {})
+    rs_filter = plugins.get("rs_filter", {})
+    ranking = plugins.get("momentum_ranking", {})
+    breakout = plugins.get("breakout_signal", {})
+    pullback = plugins.get("pullback_signal", {})
+    min_history = plugins.get("min_history_gate", {})
+    sizing = plugins.get("atr_position_sizing", {})
+    rr_gate = plugins.get("rr_gate", {})
+    fee_gate = plugins.get("fee_gate", {})
+    regime = plugins.get("regime_risk", {})
+    social = plugins.get("social_overlay", {})
+    intelligence = plugins.get("market_intelligence", {})
+    breakeven = plugins.get("breakeven_management", {})
+    trailing = plugins.get("trailing_management", {})
+    time_exit = plugins.get("time_exit_management", {})
+
+    trend_cfg = trend.get("effective_config", {})
+    price_cfg = price_filter.get("effective_config", {})
+    atr_cfg = atr_filter.get("effective_config", {})
+    currency_cfg = currency_filter.get("effective_config", {})
+    rs_cfg = rs_filter.get("effective_config", {})
+    ranking_cfg = ranking.get("effective_config", {})
+    breakout_cfg = breakout.get("effective_config", {})
+    pullback_cfg = pullback.get("effective_config", {})
+    history_cfg = min_history.get("effective_config", {})
+    sizing_cfg = sizing.get("effective_config", {})
+    rr_cfg = rr_gate.get("effective_config", {})
+    fee_cfg = fee_gate.get("effective_config", {})
+    regime_cfg = regime.get("effective_config", {})
+    social_cfg = social.get("effective_config", {})
+    intel_cfg = intelligence.get("effective_config", {})
+    breakeven_cfg = breakeven.get("effective_config", {})
+    trailing_cfg = trailing.get("effective_config", {})
+    time_exit_cfg = time_exit.get("effective_config", {})
+
+    return {
+        "id": strategy.get("id", "default"),
+        "name": strategy.get("name", "Default"),
+        "description": strategy.get("description", ""),
+        "module": strategy.get("module", "momentum"),
+        "is_default": True,
+        "created_at": "yaml",
+        "updated_at": "yaml",
+        "universe": {
+            "trend": {
+                "sma_fast": int(trend_cfg.get("sma_fast", 20)),
+                "sma_mid": int(trend_cfg.get("sma_mid", 50)),
+                "sma_long": int(trend_cfg.get("sma_long", 200)),
+            },
+            "vol": {
+                "atr_window": int(atr_cfg.get("atr_window", 14)),
+            },
+            "mom": {
+                "lookback_6m": int(ranking_cfg.get("lookback_6m", 126)),
+                "lookback_12m": int(ranking_cfg.get("lookback_12m", 252)),
+                "benchmark": str(ranking_cfg.get("benchmark", "SPY")),
+            },
+            "filt": {
+                "min_price": float(price_cfg.get("min_price", 5.0)),
+                "max_price": float(price_cfg.get("max_price", 500.0)),
+                "max_atr_pct": float(atr_cfg.get("max_atr_pct", 15.0)),
+                "require_trend_ok": bool(trend_cfg.get("require_trend_ok", True)),
+                "require_rs_positive": bool(rs_cfg.get("require_rs_positive", False)),
+                "currencies": list(currency_cfg.get("currencies", ["USD", "EUR"])),
+            },
+        },
+        "ranking": {
+            "w_mom_6m": float(ranking_cfg.get("w_mom_6m", 0.45)),
+            "w_mom_12m": float(ranking_cfg.get("w_mom_12m", 0.35)),
+            "w_rs_6m": float(ranking_cfg.get("w_rs_6m", 0.2)),
+            "top_n": int(ranking_cfg.get("top_n", 100)),
+        },
+        "signals": {
+            "breakout_lookback": int(breakout_cfg.get("breakout_lookback", 50)),
+            "pullback_ma": int(pullback_cfg.get("pullback_ma", 20)),
+            "min_history": int(history_cfg.get("min_history", 260)),
+        },
+        "risk": {
+            "account_size": float(sizing_cfg.get("account_size", 50000.0)),
+            "risk_pct": float(sizing_cfg.get("risk_pct", 0.01)),
+            "max_position_pct": float(sizing_cfg.get("max_position_pct", 0.6)),
+            "min_shares": int(sizing_cfg.get("min_shares", 1)),
+            "k_atr": float(sizing_cfg.get("k_atr", 2.0)),
+            "min_rr": float(rr_cfg.get("min_rr", 2.0)),
+            "rr_target": float(rr_cfg.get("rr_target", 2.0)),
+            "commission_pct": float(fee_cfg.get("commission_pct", 0.0)),
+            "max_fee_risk_pct": float(fee_cfg.get("max_fee_risk_pct", 0.2)),
+            "regime_enabled": bool(regime_cfg.get("enabled", False)),
+            "regime_trend_sma": int(regime_cfg.get("regime_trend_sma", 200)),
+            "regime_trend_multiplier": float(regime_cfg.get("regime_trend_multiplier", 0.5)),
+            "regime_vol_atr_window": int(regime_cfg.get("regime_vol_atr_window", 14)),
+            "regime_vol_atr_pct_threshold": float(regime_cfg.get("regime_vol_atr_pct_threshold", 6.0)),
+            "regime_vol_multiplier": float(regime_cfg.get("regime_vol_multiplier", 0.5)),
+        },
+        "manage": {
+            "breakeven_at_r": float(breakeven_cfg.get("breakeven_at_r", 1.0)),
+            "trail_after_r": float(trailing_cfg.get("trail_after_r", 2.0)),
+            "trail_sma": int(trailing_cfg.get("trail_sma", 20)),
+            "sma_buffer_pct": float(trailing_cfg.get("sma_buffer_pct", 0.005)),
+            "max_holding_days": int(time_exit_cfg.get("max_holding_days", 20)),
+            "benchmark": str(time_exit_cfg.get("benchmark", ranking_cfg.get("benchmark", "SPY"))),
+        },
+        "social_overlay": {
+            "enabled": bool(social_cfg.get("enabled", False)),
+            "lookback_hours": int(social_cfg.get("lookback_hours", 24)),
+            "attention_z_threshold": float(social_cfg.get("attention_z_threshold", 3.0)),
+            "min_sample_size": int(social_cfg.get("min_sample_size", 20)),
+            "negative_sent_threshold": float(social_cfg.get("negative_sent_threshold", -0.4)),
+            "sentiment_conf_threshold": float(social_cfg.get("sentiment_conf_threshold", 0.7)),
+            "hype_percentile_threshold": float(social_cfg.get("hype_percentile_threshold", 95.0)),
+            "providers": list(social_cfg.get("providers", ["reddit"])),
+            "sentiment_analyzer": str(social_cfg.get("sentiment_analyzer", "keyword")),
+        },
+        "market_intelligence": dict(intel_cfg),
+        "plugins_runtime": {
+            plugin["plugin_id"]: {
+                "enabled": plugin["enabled"],
+                "effective_config": plugin["effective_config"],
+                "defaults": plugin["defaults"],
+                "overrides": plugin["overrides"],
+                "runtime_hooks": plugin["runtime_hooks"],
+                "display_name": plugin["display_name"],
+                "category": plugin["category"],
+                "description": plugin["description"],
+                "docs": plugin["docs"],
+            }
+            for plugin in resolved.get("plugins", [])
+        },
+    }

--- a/src/swing_screener/strategy/plugin_system.py
+++ b/src/swing_screener/strategy/plugin_system.py
@@ -133,6 +133,7 @@ def resolve_strategy_config(
                 "display_name": plugin.get("display_name", plugin_id),
                 "description": plugin.get("description", ""),
                 "enabled": enabled,
+                "default_enabled": base_enabled,
                 "defaults": base_config,
                 "overrides": override_config,
                 "effective_config": effective_config,

--- a/src/swing_screener/strategy/plugins/atr_filter/defaults.yaml
+++ b/src/swing_screener/strategy/plugins/atr_filter/defaults.yaml
@@ -1,0 +1,4 @@
+enabled: true
+config:
+  atr_window: 14
+  max_atr_pct: 15.0

--- a/src/swing_screener/strategy/plugins/atr_filter/plugin.yaml
+++ b/src/swing_screener/strategy/plugins/atr_filter/plugin.yaml
@@ -1,0 +1,23 @@
+id: atr_filter
+category: Filters
+phase: universe
+display_name: ATR Filter
+description: Filters high-volatility stocks and defines the ATR window used elsewhere.
+defaults_file: defaults.yaml
+read_only_sections: ["Configuration", "Docs"]
+provides: [atr_filter, atr_window]
+requires: []
+modifies: [candidate_eligibility]
+conflicts: []
+runtime_hooks: [augment_universe]
+config_schema:
+  atr_window: {type: integer, min: 1, label: "ATR Window", description: "ATR lookback window."}
+  max_atr_pct: {type: number, min: 0, label: "Max ATR %", description: "Maximum ATR percentage allowed."}
+docs:
+  what_it_is: Volatility safety filter based on ATR percent.
+  why_it_matters: Avoids names that swing too violently for the risk model.
+  how_it_affects_trades: Higher thresholds increase opportunity count and emotional pressure.
+  tradeoffs: Lower values are safer but exclude faster movers.
+  default_guidance: 14 ATR and 15% max ATR are broad default settings.
+  danger_zone: Very high ATR names can break sizing assumptions.
+  pro_tip: Volatility should inform both filtering and stop placement.

--- a/src/swing_screener/strategy/plugins/atr_position_sizing/defaults.yaml
+++ b/src/swing_screener/strategy/plugins/atr_position_sizing/defaults.yaml
@@ -1,0 +1,7 @@
+enabled: true
+config:
+  account_size: 50000.0
+  risk_pct: 0.01
+  max_position_pct: 0.6
+  min_shares: 1
+  k_atr: 2.0

--- a/src/swing_screener/strategy/plugins/atr_position_sizing/plugin.yaml
+++ b/src/swing_screener/strategy/plugins/atr_position_sizing/plugin.yaml
@@ -1,0 +1,26 @@
+id: atr_position_sizing
+category: Risk
+phase: risk
+display_name: ATR Position Sizing
+description: Build trade plans using ATR-defined stop distance and account risk constraints.
+defaults_file: defaults.yaml
+read_only_sections: ["Configuration", "Docs"]
+provides: [position_size, risk_plan]
+requires: [signal_candidates, atr_window]
+modifies: [risk_plan]
+conflicts: []
+runtime_hooks: [adjust_risk_plan]
+config_schema:
+  account_size: {type: number, min: 0, label: "Account Size", description: "Account capital used for sizing."}
+  risk_pct: {type: number, min: 0, max: 1, label: "Risk %", description: "Risk per trade as a fraction of capital."}
+  max_position_pct: {type: number, min: 0, max: 1, label: "Max Position %", description: "Maximum position allocation."}
+  min_shares: {type: integer, min: 1, label: "Min Shares", description: "Minimum tradable share count."}
+  k_atr: {type: number, min: 0, label: "ATR Multiplier", description: "Stop distance in ATR units."}
+docs:
+  what_it_is: Core risk and sizing engine.
+  why_it_matters: Converts setup quality into position size and stop levels.
+  how_it_affects_trades: Changes risk per trade, stop width and tradability.
+  tradeoffs: Tighter stops allow bigger size but are easier to shake out.
+  default_guidance: Keep risk small and repeatable.
+  danger_zone: Oversizing usually comes from changing risk rules after seeing a setup.
+  pro_tip: Position sizing is where strategy discipline becomes real.

--- a/src/swing_screener/strategy/plugins/breakeven_management/defaults.yaml
+++ b/src/swing_screener/strategy/plugins/breakeven_management/defaults.yaml
@@ -1,0 +1,3 @@
+enabled: true
+config:
+  breakeven_at_r: 1.0

--- a/src/swing_screener/strategy/plugins/breakeven_management/plugin.yaml
+++ b/src/swing_screener/strategy/plugins/breakeven_management/plugin.yaml
@@ -1,0 +1,22 @@
+id: breakeven_management
+category: Management
+phase: management
+display_name: Breakeven Management
+description: Move stops to breakeven once a trade has earned enough R.
+defaults_file: defaults.yaml
+read_only_sections: ["Configuration", "Docs"]
+provides: [breakeven_rules]
+requires: [position_size]
+modifies: [risk_plan]
+conflicts: []
+runtime_hooks: [augment_education]
+config_schema:
+  breakeven_at_r: {type: number, min: 0, label: "Breakeven At R", description: "Move stop to entry after this R multiple."}
+docs:
+  what_it_is: Stop management rule that removes downside after a trade proves itself.
+  why_it_matters: Helps protect capital on trades that start working.
+  how_it_affects_trades: Can reduce drawdown but also cut some winners early.
+  tradeoffs: Earlier breakeven means more safety and more premature exits.
+  default_guidance: 1R is a balanced beginner baseline.
+  danger_zone: Manual stop moves defeat the purpose of a systematic rule.
+  pro_tip: Breakeven rules are for consistency, not comfort.

--- a/src/swing_screener/strategy/plugins/breakout_signal/defaults.yaml
+++ b/src/swing_screener/strategy/plugins/breakout_signal/defaults.yaml
@@ -1,0 +1,3 @@
+enabled: true
+config:
+  breakout_lookback: 50

--- a/src/swing_screener/strategy/plugins/breakout_signal/plugin.yaml
+++ b/src/swing_screener/strategy/plugins/breakout_signal/plugin.yaml
@@ -1,0 +1,22 @@
+id: breakout_signal
+category: Signals
+phase: signals
+display_name: Breakout Signal
+description: Identify breakouts above the highest close of the configured lookback.
+defaults_file: defaults.yaml
+read_only_sections: ["Configuration", "Docs"]
+provides: [breakout_signal, signal_candidates]
+requires: []
+modifies: [signal_candidates]
+conflicts: []
+runtime_hooks: [augment_signal_board]
+config_schema:
+  breakout_lookback: {type: integer, min: 1, label: "Breakout Lookback", description: "Lookback window used to validate a breakout."}
+docs:
+  what_it_is: A breakout trigger based on recent highs.
+  why_it_matters: Captures names showing fresh strength.
+  how_it_affects_trades: Shorter windows create more signals, longer windows are stricter.
+  tradeoffs: Faster signals are noisier; slower signals are cleaner but fewer.
+  default_guidance: 50 is a solid swing-trading baseline.
+  danger_zone: Very low values drift toward short-term noise.
+  pro_tip: Breakouts work best when combined with trend and risk discipline.

--- a/src/swing_screener/strategy/plugins/currency_filter/defaults.yaml
+++ b/src/swing_screener/strategy/plugins/currency_filter/defaults.yaml
@@ -1,0 +1,3 @@
+enabled: true
+config:
+  currencies: [USD, EUR]

--- a/src/swing_screener/strategy/plugins/currency_filter/plugin.yaml
+++ b/src/swing_screener/strategy/plugins/currency_filter/plugin.yaml
@@ -1,0 +1,22 @@
+id: currency_filter
+category: Filters
+phase: universe
+display_name: Currency Filter
+description: Restrict the universe to the currencies you want to trade.
+defaults_file: defaults.yaml
+read_only_sections: ["Configuration", "Docs"]
+provides: [currency_filter]
+requires: []
+modifies: [candidate_eligibility]
+conflicts: []
+runtime_hooks: [augment_universe]
+config_schema:
+  currencies: {type: array, label: "Currencies", description: "Allowed trading currencies."}
+docs:
+  what_it_is: Currency gate for the tradable universe.
+  why_it_matters: Keeps screening aligned with your broker, account and FX constraints.
+  how_it_affects_trades: Excludes unsupported markets before ranking.
+  tradeoffs: More currencies mean more opportunities but more complexity.
+  default_guidance: USD and EUR cover the current app defaults.
+  danger_zone: Unsupported currencies often fail later in execution workflows.
+  pro_tip: Keep the universe close to the currencies you can actually execute in.

--- a/src/swing_screener/strategy/plugins/fee_gate/defaults.yaml
+++ b/src/swing_screener/strategy/plugins/fee_gate/defaults.yaml
@@ -1,0 +1,4 @@
+enabled: true
+config:
+  commission_pct: 0.0
+  max_fee_risk_pct: 0.2

--- a/src/swing_screener/strategy/plugins/fee_gate/plugin.yaml
+++ b/src/swing_screener/strategy/plugins/fee_gate/plugin.yaml
@@ -1,0 +1,23 @@
+id: fee_gate
+category: Risk
+phase: risk
+display_name: Fee Gate
+description: Block setups where estimated fees are too large relative to planned risk.
+defaults_file: defaults.yaml
+read_only_sections: ["Configuration", "Docs"]
+provides: [fee_validation]
+requires: [position_size]
+modifies: [signal_validation]
+conflicts: []
+runtime_hooks: [augment_recommendation]
+config_schema:
+  commission_pct: {type: number, min: 0, label: "Commission %", description: "Per-side commission estimate."}
+  max_fee_risk_pct: {type: number, min: 0, max: 1, label: "Max Fee / Risk %", description: "Maximum fee burden relative to planned risk."}
+docs:
+  what_it_is: Trade cost sanity check.
+  why_it_matters: Stops small trades from being dominated by friction.
+  how_it_affects_trades: Mostly blocks micro-setups with poor cost efficiency.
+  tradeoffs: Stricter settings avoid churn but can remove small-cap opportunities.
+  default_guidance: Keep costs small relative to risk, not just relative to notional size.
+  danger_zone: Ignoring fee drag silently erodes expectancy.
+  pro_tip: A good setup can still be a bad trade once costs are included.

--- a/src/swing_screener/strategy/plugins/market_intelligence/defaults.yaml
+++ b/src/swing_screener/strategy/plugins/market_intelligence/defaults.yaml
@@ -1,0 +1,33 @@
+enabled: true
+config:
+  enabled: false
+  providers: [yahoo_finance]
+  universe_scope: screener_universe
+  market_context_symbols: [SPY, QQQ, XLK, SMH, XBI]
+  llm:
+    enabled: false
+    provider: ollama
+    model: mistral:7b-instruct
+    base_url: http://localhost:11434
+    api_key: ""
+    enable_cache: true
+    enable_audit: true
+    cache_path: data/intelligence/llm_cache.json
+    audit_path: data/intelligence/llm_audit
+    max_concurrency: 4
+  catalyst:
+    lookback_hours: 72
+    recency_half_life_hours: 36
+    false_catalyst_return_z: 1.5
+    min_price_reaction_atr: 0.8
+    require_price_confirmation: true
+  theme:
+    enabled: true
+    min_cluster_size: 3
+    min_peer_confirmation: 2
+    curated_peer_map_path: data/intelligence/peer_map.yaml
+  opportunity:
+    technical_weight: 0.55
+    catalyst_weight: 0.45
+    max_daily_opportunities: 8
+    min_opportunity_score: 0.55

--- a/src/swing_screener/strategy/plugins/market_intelligence/plugin.yaml
+++ b/src/swing_screener/strategy/plugins/market_intelligence/plugin.yaml
@@ -1,0 +1,25 @@
+id: market_intelligence
+category: Intelligence
+phase: intelligence
+display_name: Market Intelligence
+description: Add catalyst and thematic context to the strategy stack.
+defaults_file: defaults.yaml
+read_only_sections: ["Configuration", "Docs"]
+provides: [market_intelligence]
+requires: []
+modifies: [candidate_score]
+conflicts: []
+runtime_hooks: [augment_education]
+config_schema:
+  enabled: {type: boolean, label: "Enabled", description: "Enable intelligence features."}
+  providers: {type: array, label: "Providers", description: "Enabled intelligence providers."}
+  universe_scope: {type: string, label: "Universe Scope", description: "Universe scope used by intelligence."}
+  market_context_symbols: {type: array, label: "Market Context", description: "Symbols used for market context."}
+docs:
+  what_it_is: Catalyst and thematic context layer.
+  why_it_matters: Adds narrative and event context around technically valid names.
+  how_it_affects_trades: Helps explain setups and identify event-driven opportunities.
+  tradeoffs: Richer context comes with more complexity and more data dependencies.
+  default_guidance: Keep optional and separate from the core mechanical rules.
+  danger_zone: Do not let narrative override the hard risk gates.
+  pro_tip: Use intelligence to prioritize attention, not to bypass discipline.

--- a/src/swing_screener/strategy/plugins/min_history_gate/defaults.yaml
+++ b/src/swing_screener/strategy/plugins/min_history_gate/defaults.yaml
@@ -1,0 +1,3 @@
+enabled: true
+config:
+  min_history: 260

--- a/src/swing_screener/strategy/plugins/min_history_gate/plugin.yaml
+++ b/src/swing_screener/strategy/plugins/min_history_gate/plugin.yaml
@@ -1,0 +1,22 @@
+id: min_history_gate
+category: Signals
+phase: signals
+display_name: Minimum History Gate
+description: Require a minimum amount of history before indicators and signals are trusted.
+defaults_file: defaults.yaml
+read_only_sections: ["Configuration", "Docs"]
+provides: [history_gate]
+requires: []
+modifies: [signal_candidates]
+conflicts: []
+runtime_hooks: [augment_signal_board]
+config_schema:
+  min_history: {type: integer, min: 1, label: "Min History", description: "Minimum history bars required."}
+docs:
+  what_it_is: Data sufficiency gate for signal generation.
+  why_it_matters: Avoids acting on incomplete indicator history.
+  how_it_affects_trades: Excludes newly listed symbols without enough context.
+  tradeoffs: Higher values improve stability but reduce coverage.
+  default_guidance: Around one trading year is a robust default.
+  danger_zone: Low history thresholds distort momentum and trend features.
+  pro_tip: Data quality is part of signal quality.

--- a/src/swing_screener/strategy/plugins/momentum_ranking/defaults.yaml
+++ b/src/swing_screener/strategy/plugins/momentum_ranking/defaults.yaml
@@ -1,0 +1,9 @@
+enabled: true
+config:
+  lookback_6m: 126
+  lookback_12m: 252
+  benchmark: SPY
+  w_mom_6m: 0.45
+  w_mom_12m: 0.35
+  w_rs_6m: 0.2
+  top_n: 100

--- a/src/swing_screener/strategy/plugins/momentum_ranking/plugin.yaml
+++ b/src/swing_screener/strategy/plugins/momentum_ranking/plugin.yaml
@@ -1,0 +1,28 @@
+id: momentum_ranking
+category: Ranking
+phase: ranking
+display_name: Momentum Ranking
+description: Rank candidates using 6m momentum, 12m momentum, and relative strength.
+defaults_file: defaults.yaml
+read_only_sections: ["Configuration", "Docs"]
+provides: [ranking_score]
+requires: []
+modifies: [candidate_score]
+conflicts: []
+runtime_hooks: [augment_ranking]
+config_schema:
+  lookback_6m: {type: integer, min: 1, label: "6M Lookback", description: "Momentum lookback for 6-month calculation."}
+  lookback_12m: {type: integer, min: 1, label: "12M Lookback", description: "Momentum lookback for 12-month calculation."}
+  benchmark: {type: string, label: "Benchmark", description: "Benchmark symbol used for relative strength."}
+  w_mom_6m: {type: number, min: 0, label: "Weight 6M", description: "Weight for 6-month momentum."}
+  w_mom_12m: {type: number, min: 0, label: "Weight 12M", description: "Weight for 12-month momentum."}
+  w_rs_6m: {type: number, min: 0, label: "Weight RS", description: "Weight for relative strength."}
+  top_n: {type: integer, min: 1, label: "Top N", description: "Number of ranked candidates to keep."}
+docs:
+  what_it_is: Main ranking engine for the momentum strategy.
+  why_it_matters: Defines which candidates rise to the top before signal and risk checks.
+  how_it_affects_trades: Small weight changes alter the personality of the shortlist.
+  tradeoffs: More recent momentum reacts faster; longer lookbacks are steadier.
+  default_guidance: Use balanced weights until you have enough live observations.
+  danger_zone: Over-optimizing weights on small samples creates fragile rules.
+  pro_tip: Ranking should shape candidate quality, not predict certainty.

--- a/src/swing_screener/strategy/plugins/price_filter/defaults.yaml
+++ b/src/swing_screener/strategy/plugins/price_filter/defaults.yaml
@@ -1,0 +1,4 @@
+enabled: true
+config:
+  min_price: 5.0
+  max_price: 500.0

--- a/src/swing_screener/strategy/plugins/price_filter/plugin.yaml
+++ b/src/swing_screener/strategy/plugins/price_filter/plugin.yaml
@@ -1,0 +1,23 @@
+id: price_filter
+category: Filters
+phase: universe
+display_name: Price Filter
+description: Restrict the universe to stocks within a target price range.
+defaults_file: defaults.yaml
+read_only_sections: ["Configuration", "Docs"]
+provides: [price_filter]
+requires: []
+modifies: [candidate_eligibility]
+conflicts: []
+runtime_hooks: [augment_universe]
+config_schema:
+  min_price: {type: number, min: 0, label: "Min Price", description: "Minimum allowed stock price."}
+  max_price: {type: number, min: 0, label: "Max Price", description: "Maximum allowed stock price."}
+docs:
+  what_it_is: Price range filter for the candidate universe.
+  why_it_matters: Helps avoid penny stocks or names too expensive for your sizing model.
+  how_it_affects_trades: Changes which stocks are eligible before ranking.
+  tradeoffs: Narrower ranges improve consistency but reduce opportunity count.
+  default_guidance: Keep it broad enough to avoid overfitting.
+  danger_zone: Very low prices often behave erratically.
+  pro_tip: Use price filters to match your position sizing and broker constraints.

--- a/src/swing_screener/strategy/plugins/pullback_signal/defaults.yaml
+++ b/src/swing_screener/strategy/plugins/pullback_signal/defaults.yaml
@@ -1,0 +1,3 @@
+enabled: true
+config:
+  pullback_ma: 20

--- a/src/swing_screener/strategy/plugins/pullback_signal/plugin.yaml
+++ b/src/swing_screener/strategy/plugins/pullback_signal/plugin.yaml
@@ -1,0 +1,22 @@
+id: pullback_signal
+category: Signals
+phase: signals
+display_name: Pullback Signal
+description: Identify reclaim entries after price regains the selected moving average.
+defaults_file: defaults.yaml
+read_only_sections: ["Configuration", "Docs"]
+provides: [pullback_signal, signal_candidates]
+requires: [trend_features]
+modifies: [signal_candidates]
+conflicts: []
+runtime_hooks: [augment_signal_board]
+config_schema:
+  pullback_ma: {type: integer, min: 1, label: "Pullback MA", description: "Moving average used for pullback reclaim entries."}
+docs:
+  what_it_is: Pullback reclaim trigger using a moving average.
+  why_it_matters: Helps avoid chasing extended price spikes.
+  how_it_affects_trades: Offers better entry structure in healthy trends.
+  tradeoffs: Tighter averages improve price but can miss fast trends.
+  default_guidance: 20-day MA is a standard swing baseline.
+  danger_zone: Very small windows react to noise more than structure.
+  pro_tip: Pullbacks can complement breakouts without changing the strategy philosophy.

--- a/src/swing_screener/strategy/plugins/regime_risk/defaults.yaml
+++ b/src/swing_screener/strategy/plugins/regime_risk/defaults.yaml
@@ -1,0 +1,8 @@
+enabled: true
+config:
+  enabled: false
+  regime_trend_sma: 200
+  regime_trend_multiplier: 0.5
+  regime_vol_atr_window: 14
+  regime_vol_atr_pct_threshold: 6.0
+  regime_vol_multiplier: 0.5

--- a/src/swing_screener/strategy/plugins/regime_risk/plugin.yaml
+++ b/src/swing_screener/strategy/plugins/regime_risk/plugin.yaml
@@ -1,0 +1,27 @@
+id: regime_risk
+category: Risk
+phase: risk
+display_name: Regime Risk
+description: Scale risk down when the broader market regime is unfavorable.
+defaults_file: defaults.yaml
+read_only_sections: ["Configuration", "Docs"]
+provides: [risk_multiplier]
+requires: [position_size]
+modifies: [risk_plan]
+conflicts: []
+runtime_hooks: [adjust_risk_plan]
+config_schema:
+  enabled: {type: boolean, label: "Enabled", description: "Enable regime-based risk scaling."}
+  regime_trend_sma: {type: integer, min: 1, label: "Trend SMA", description: "Market trend SMA for regime filter."}
+  regime_trend_multiplier: {type: number, min: 0, max: 1, label: "Trend Multiplier", description: "Risk multiplier when trend is weak."}
+  regime_vol_atr_window: {type: integer, min: 1, label: "ATR Window", description: "ATR window for regime volatility checks."}
+  regime_vol_atr_pct_threshold: {type: number, min: 0, label: "ATR % Threshold", description: "ATR percent threshold that triggers scaling."}
+  regime_vol_multiplier: {type: number, min: 0, max: 1, label: "Vol Multiplier", description: "Risk multiplier when volatility regime is elevated."}
+docs:
+  what_it_is: Market regime aware risk scaling.
+  why_it_matters: Bad tape often deserves smaller bets even if single-name setups look good.
+  how_it_affects_trades: Leaves candidate quality unchanged but shrinks exposure.
+  tradeoffs: Safer during weak markets, but can underexpose strong rebounds.
+  default_guidance: Keep disabled until you want market-level risk adaptation.
+  danger_zone: Regime logic should scale risk, not replace the core strategy.
+  pro_tip: Regime filters are most useful as exposure throttles, not prediction tools.

--- a/src/swing_screener/strategy/plugins/rr_gate/defaults.yaml
+++ b/src/swing_screener/strategy/plugins/rr_gate/defaults.yaml
@@ -1,0 +1,4 @@
+enabled: true
+config:
+  min_rr: 2.0
+  rr_target: 2.0

--- a/src/swing_screener/strategy/plugins/rr_gate/plugin.yaml
+++ b/src/swing_screener/strategy/plugins/rr_gate/plugin.yaml
@@ -1,0 +1,23 @@
+id: rr_gate
+category: Risk
+phase: risk
+display_name: Reward/Risk Gate
+description: Require a minimum reward-to-risk before a trade can be recommended.
+defaults_file: defaults.yaml
+read_only_sections: ["Configuration", "Docs"]
+provides: [rr_validation]
+requires: [position_size]
+modifies: [signal_validation]
+conflicts: []
+runtime_hooks: [augment_recommendation]
+config_schema:
+  min_rr: {type: number, min: 0, label: "Min R/R", description: "Minimum required reward-to-risk."}
+  rr_target: {type: number, min: 0, label: "R/R Target", description: "Target reward-to-risk used for projected target price."}
+docs:
+  what_it_is: Asymmetric payoff gate.
+  why_it_matters: Prevents taking trades with too little upside relative to downside.
+  how_it_affects_trades: Higher thresholds mean fewer but cleaner setups.
+  tradeoffs: Lower thresholds increase signal count but weaken expectancy.
+  default_guidance: 2R remains a strong default for swing trading.
+  danger_zone: Low R/R can produce activity without long-term edge.
+  pro_tip: The best trades give you room to be wrong often and still progress.

--- a/src/swing_screener/strategy/plugins/rs_filter/defaults.yaml
+++ b/src/swing_screener/strategy/plugins/rs_filter/defaults.yaml
@@ -1,0 +1,3 @@
+enabled: true
+config:
+  require_rs_positive: false

--- a/src/swing_screener/strategy/plugins/rs_filter/plugin.yaml
+++ b/src/swing_screener/strategy/plugins/rs_filter/plugin.yaml
@@ -1,0 +1,22 @@
+id: rs_filter
+category: Filters
+phase: universe
+display_name: Relative Strength Filter
+description: Optionally require positive relative strength before a stock is eligible.
+defaults_file: defaults.yaml
+read_only_sections: ["Configuration", "Docs"]
+provides: [rs_filter]
+requires: [ranking_score]
+modifies: [candidate_eligibility]
+conflicts: []
+runtime_hooks: [augment_universe]
+config_schema:
+  require_rs_positive: {type: boolean, label: "Require Positive RS", description: "Only keep stocks with positive relative strength."}
+docs:
+  what_it_is: Relative strength eligibility gate.
+  why_it_matters: Removes stocks that lag the benchmark even if other features look acceptable.
+  how_it_affects_trades: Tightens the universe around stronger names.
+  tradeoffs: Helps quality but can reduce opportunity count during mixed markets.
+  default_guidance: Keep optional unless you want a stricter momentum personality.
+  danger_zone: Forcing RS positive can over-filter smaller universes.
+  pro_tip: Use this when you want fewer but more benchmark-leading names.

--- a/src/swing_screener/strategy/plugins/social_overlay/defaults.yaml
+++ b/src/swing_screener/strategy/plugins/social_overlay/defaults.yaml
@@ -1,0 +1,11 @@
+enabled: true
+config:
+  enabled: false
+  lookback_hours: 24
+  attention_z_threshold: 3.0
+  min_sample_size: 20
+  negative_sent_threshold: -0.4
+  sentiment_conf_threshold: 0.7
+  hype_percentile_threshold: 95.0
+  providers: [reddit]
+  sentiment_analyzer: keyword

--- a/src/swing_screener/strategy/plugins/social_overlay/plugin.yaml
+++ b/src/swing_screener/strategy/plugins/social_overlay/plugin.yaml
@@ -1,0 +1,30 @@
+id: social_overlay
+category: Qualification
+phase: qualification
+display_name: Social Overlay
+description: Add social attention and sentiment context as a qualification layer.
+defaults_file: defaults.yaml
+read_only_sections: ["Configuration", "Docs"]
+provides: [social_signal_boost]
+requires: [signal_candidates]
+modifies: [candidate_score]
+conflicts: []
+runtime_hooks: [qualify_candidate, augment_recommendation]
+config_schema:
+  enabled: {type: boolean, label: "Enabled", description: "Enable social overlay."}
+  lookback_hours: {type: integer, min: 1, label: "Lookback Hours", description: "Social data lookback window."}
+  attention_z_threshold: {type: number, min: 0, label: "Attention Z", description: "High-attention threshold."}
+  min_sample_size: {type: integer, min: 0, label: "Min Sample Size", description: "Minimum social sample size."}
+  negative_sent_threshold: {type: number, label: "Negative Sentiment", description: "Threshold for negative sentiment veto."}
+  sentiment_conf_threshold: {type: number, min: 0, max: 1, label: "Sentiment Confidence", description: "Required confidence for sentiment checks."}
+  hype_percentile_threshold: {type: number, min: 0, max: 100, label: "Hype Percentile", description: "Percentile threshold for hype detection."}
+  providers: {type: array, label: "Providers", description: "Enabled social providers."}
+  sentiment_analyzer: {type: string, label: "Sentiment Analyzer", description: "Analyzer used for sentiment scoring."}
+docs:
+  what_it_is: Optional context layer using social attention and sentiment.
+  why_it_matters: Helps flag hype or unusual crowd behavior around a setup.
+  how_it_affects_trades: Can reduce risk, trigger review, or veto a setup.
+  tradeoffs: Adds context but also extra moving parts and external data risk.
+  default_guidance: Treat it as confirmation, not as the reason to trade.
+  danger_zone: If social hype is the only reason you like the trade, skip it.
+  pro_tip: Context should refine conviction, not create it from scratch.

--- a/src/swing_screener/strategy/plugins/time_exit_management/defaults.yaml
+++ b/src/swing_screener/strategy/plugins/time_exit_management/defaults.yaml
@@ -1,0 +1,4 @@
+enabled: true
+config:
+  max_holding_days: 20
+  benchmark: SPY

--- a/src/swing_screener/strategy/plugins/time_exit_management/plugin.yaml
+++ b/src/swing_screener/strategy/plugins/time_exit_management/plugin.yaml
@@ -1,0 +1,23 @@
+id: time_exit_management
+category: Management
+phase: management
+display_name: Time Exit Management
+description: Exit slow trades after the configured maximum holding period.
+defaults_file: defaults.yaml
+read_only_sections: ["Configuration", "Docs"]
+provides: [time_exit_rules]
+requires: [position_size]
+modifies: [risk_plan]
+conflicts: []
+runtime_hooks: [augment_education]
+config_schema:
+  max_holding_days: {type: integer, min: 1, label: "Max Holding Days", description: "Maximum holding period allowed."}
+  benchmark: {type: string, label: "Benchmark", description: "Benchmark context for management decisions."}
+docs:
+  what_it_is: Time-based exit discipline.
+  why_it_matters: Prevents dead capital from remaining stuck in slow setups.
+  how_it_affects_trades: Forces turnover when momentum does not materialize.
+  tradeoffs: Shorter windows rotate faster; longer windows allow slower trends.
+  default_guidance: Use time as a risk management tool, not as a prediction tool.
+  danger_zone: Holding forever because the setup once looked good is a classic trap.
+  pro_tip: Capital efficiency is part of strategy quality.

--- a/src/swing_screener/strategy/plugins/trailing_management/defaults.yaml
+++ b/src/swing_screener/strategy/plugins/trailing_management/defaults.yaml
@@ -1,0 +1,5 @@
+enabled: true
+config:
+  trail_after_r: 2.0
+  trail_sma: 20
+  sma_buffer_pct: 0.005

--- a/src/swing_screener/strategy/plugins/trailing_management/plugin.yaml
+++ b/src/swing_screener/strategy/plugins/trailing_management/plugin.yaml
@@ -1,0 +1,24 @@
+id: trailing_management
+category: Management
+phase: management
+display_name: Trailing Management
+description: Trail stops once a trade reaches the configured profit threshold.
+defaults_file: defaults.yaml
+read_only_sections: ["Configuration", "Docs"]
+provides: [trailing_rules]
+requires: [position_size]
+modifies: [risk_plan]
+conflicts: []
+runtime_hooks: [augment_education]
+config_schema:
+  trail_after_r: {type: number, min: 0, label: "Trail After R", description: "Start trailing after this R multiple."}
+  trail_sma: {type: integer, min: 1, label: "Trail SMA", description: "Moving average used for trailing."}
+  sma_buffer_pct: {type: number, min: 0, label: "SMA Buffer %", description: "Buffer applied around the trailing SMA."}
+docs:
+  what_it_is: Profit-protection rule for open winners.
+  why_it_matters: Lets the strategy keep upside while managing giveback.
+  how_it_affects_trades: Controls how quickly profits get locked in.
+  tradeoffs: Faster trailing protects gains but can end trends too early.
+  default_guidance: Keep simple and repeatable rather than overly reactive.
+  danger_zone: Overactive trailing often turns good trends into small trades.
+  pro_tip: Trailing rules should protect edge, not satisfy impatience.

--- a/src/swing_screener/strategy/plugins/trend_filter/defaults.yaml
+++ b/src/swing_screener/strategy/plugins/trend_filter/defaults.yaml
@@ -1,0 +1,6 @@
+enabled: true
+config:
+  sma_fast: 20
+  sma_mid: 50
+  sma_long: 200
+  require_trend_ok: true

--- a/src/swing_screener/strategy/plugins/trend_filter/plugin.yaml
+++ b/src/swing_screener/strategy/plugins/trend_filter/plugin.yaml
@@ -1,0 +1,25 @@
+id: trend_filter
+category: Filters
+phase: universe
+display_name: Trend Filter
+description: Require stocks to align with the configured moving-average trend structure.
+defaults_file: defaults.yaml
+read_only_sections: ["Configuration", "Docs"]
+provides: [trend_filter, trend_features]
+requires: []
+modifies: [candidate_eligibility]
+conflicts: []
+runtime_hooks: [augment_universe]
+config_schema:
+  sma_fast: {type: integer, min: 1, label: "Fast SMA", description: "Short-term trend average."}
+  sma_mid: {type: integer, min: 1, label: "Mid SMA", description: "Intermediate trend average."}
+  sma_long: {type: integer, min: 1, label: "Long SMA", description: "Long-term trend average."}
+  require_trend_ok: {type: boolean, label: "Require Trend", description: "Require stock to pass the trend stack filter."}
+docs:
+  what_it_is: Multi-SMA trend alignment filter.
+  why_it_matters: Helps keep trades aligned with the broader move.
+  how_it_affects_trades: Stricter trend requirements reduce countertrend setups.
+  tradeoffs: More trend discipline means fewer but cleaner candidates.
+  default_guidance: 20/50/200 is the standard momentum stack.
+  danger_zone: Disabling trend checks makes the strategy less robust.
+  pro_tip: Strong trends reduce the number of decisions you need to make manually.

--- a/src/swing_screener/strategy/plugins/volume_confirmation/defaults.yaml
+++ b/src/swing_screener/strategy/plugins/volume_confirmation/defaults.yaml
@@ -1,0 +1,7 @@
+enabled: true
+config:
+  enabled: false
+  volume_ma_window: 20
+  min_breakout_volume_ratio: 1.5
+  apply_to_breakout: true
+  apply_to_pullback: false

--- a/src/swing_screener/strategy/plugins/volume_confirmation/plugin.yaml
+++ b/src/swing_screener/strategy/plugins/volume_confirmation/plugin.yaml
@@ -1,0 +1,27 @@
+id: volume_confirmation
+category: Qualification
+phase: qualification
+display_name: Volume Confirmation
+description: Confirm breakouts using relative volume before they become valid setups.
+defaults_file: defaults.yaml
+read_only_sections: ["Configuration", "Docs"]
+provides: [volume_breakout_confirmation]
+requires: [breakout_signal]
+modifies: [signal_validation]
+conflicts: []
+dependencies: [breakout_signal]
+runtime_hooks: [qualify_candidate, augment_recommendation]
+config_schema:
+  enabled: {type: boolean, label: "Enabled", description: "Enable volume confirmation for breakouts."}
+  volume_ma_window: {type: integer, min: 1, label: "Volume MA Window", description: "Lookback used for average volume."}
+  min_breakout_volume_ratio: {type: number, min: 0, label: "Min Breakout Volume Ratio", description: "Required ratio between today's volume and average volume."}
+  apply_to_breakout: {type: boolean, label: "Apply To Breakout", description: "Apply confirmation to breakout and both signals."}
+  apply_to_pullback: {type: boolean, label: "Apply To Pullback", description: "Reserved for future pullback confirmation logic."}
+docs:
+  what_it_is: A hard confirmation layer for breakout participation.
+  why_it_matters: Breakouts with weak participation are more likely to fail.
+  how_it_affects_trades: Invalidates breakout setups that do not show enough volume support.
+  tradeoffs: Higher thresholds reduce false breakouts but also remove some valid names.
+  default_guidance: Start with a simple 20-day average and 1.5x threshold.
+  danger_zone: Using volume everywhere before testing it can add noise instead of edge.
+  pro_tip: Volume is most useful as a confirmation layer, not as a standalone strategy.

--- a/src/swing_screener/strategy/report_config.py
+++ b/src/swing_screener/strategy/report_config.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from swing_screener.selection.universe import UniverseConfig
 from swing_screener.selection.ranking import RankingConfig
@@ -18,4 +18,4 @@ class ReportConfig:
     social_overlay: SocialOverlayConfig = SocialOverlayConfig()
     only_active_signals: bool = False
     strategy_module: str = "momentum"
-
+    plugin_settings: dict[str, dict] = field(default_factory=dict)

--- a/tests/api/test_strategy_endpoints.py
+++ b/tests/api/test_strategy_endpoints.py
@@ -1,157 +1,45 @@
-import json
 from fastapi.testclient import TestClient
 
 from api.main import app
-import swing_screener.strategy.storage as strategy_storage
 
 
-def _patch_strategy_storage(monkeypatch, tmp_path):
-    data_dir = tmp_path / "data"
-    monkeypatch.setattr(strategy_storage, "DATA_DIR", data_dir)
-    monkeypatch.setattr(strategy_storage, "STRATEGIES_FILE", data_dir / "strategies.json")
-    monkeypatch.setattr(strategy_storage, "ACTIVE_STRATEGY_FILE", data_dir / "active_strategy.json")
-
-
-def _create_strategy_payload(base: dict, *, strategy_id: str, name: str) -> dict:
-    payload = {k: v for k, v in base.items() if k not in {"is_default", "created_at", "updated_at"}}
-    payload["id"] = strategy_id
-    payload["name"] = name
-    return payload
-
-
-def test_strategy_crud_and_active(monkeypatch, tmp_path):
-    _patch_strategy_storage(monkeypatch, tmp_path)
-
+def test_strategy_read_only_endpoints_expose_yaml_config():
     client = TestClient(app)
 
-    res = client.get("/api/strategy")
-    assert res.status_code == 200
-    strategies = res.json()
-    assert strategies
-    assert strategies[0]["id"] == "default"
+    config_res = client.get("/api/strategy/config")
+    assert config_res.status_code == 200
+    config = config_res.json()
+    assert config["name"] == "Default"
+    assert config["module"] == "momentum"
+    assert "execution_order" in config
+    assert any(plugin["id"] == "volume_confirmation" for plugin in config["plugins"])
+    volume_plugin = next(plugin for plugin in config["plugins"] if plugin["id"] == "volume_confirmation")
+    assert "breakout_signal" in volume_plugin["depends_on"]
 
-    res = client.get("/api/strategy/active")
-    assert res.status_code == 200
-    active = res.json()
-    assert active["id"] == "default"
-    assert active["universe"]["filt"]["currencies"] == ["USD", "EUR"]
+    plugins_res = client.get("/api/strategy/plugins")
+    assert plugins_res.status_code == 200
+    plugins = plugins_res.json()
+    assert any(plugin["id"] == "breakout_signal" for plugin in plugins)
+    assert any(plugin["id"] == "social_overlay" for plugin in plugins)
 
-    payload = _create_strategy_payload(active, strategy_id="test", name="Test Strategy")
-    res = client.post("/api/strategy", json=payload)
-    assert res.status_code == 200
-    created = res.json()
-    assert created["id"] == "test"
-    assert created["is_default"] is False
-
-    res = client.post("/api/strategy/active", json={"strategy_id": "test"})
-    assert res.status_code == 200
-    active = res.json()
-    assert active["id"] == "test"
-
-    payload_update = _create_strategy_payload(created, strategy_id="test", name="Updated Strategy")
-    res = client.put("/api/strategy/test", json=payload_update)
-    assert res.status_code == 200
-    updated = res.json()
-    assert updated["name"] == "Updated Strategy"
-
-    res = client.delete("/api/strategy/test")
-    assert res.status_code == 200
-
-    res = client.get("/api/strategy/active")
-    assert res.status_code == 200
-    active = res.json()
-    assert active["id"] == "default"
+    validation_res = client.get("/api/strategy/validation")
+    assert validation_res.status_code == 200
+    validation = validation_res.json()
+    assert validation["is_valid"] is True
+    assert "safety_score" in validation
 
 
-def test_strategy_delete_default_forbidden(monkeypatch, tmp_path):
-    _patch_strategy_storage(monkeypatch, tmp_path)
-
-    client = TestClient(app)
-    res = client.delete("/api/strategy/default")
-    assert res.status_code == 400
-
-
-def test_strategy_create_default_id_forbidden(monkeypatch, tmp_path):
-    _patch_strategy_storage(monkeypatch, tmp_path)
-
+def test_strategy_mutations_are_disabled_in_read_only_mode():
     client = TestClient(app)
     active = client.get("/api/strategy/active").json()
-    payload = _create_strategy_payload(active, strategy_id="default", name="Default")
-
-    res = client.post("/api/strategy", json=payload)
-    assert res.status_code == 400
-
-
-def test_strategy_rejects_invalid_currency(monkeypatch, tmp_path):
-    _patch_strategy_storage(monkeypatch, tmp_path)
-
-    client = TestClient(app)
-    active = client.get("/api/strategy/active").json()
-    payload = _create_strategy_payload(active, strategy_id="bad-currency", name="Bad Currency")
-    payload["universe"]["filt"]["currencies"] = ["JPY"]
-
-    res = client.post("/api/strategy", json=payload)
-    assert res.status_code == 422
-
-
-def test_strategy_backfills_missing_currency_field(monkeypatch, tmp_path):
-    _patch_strategy_storage(monkeypatch, tmp_path)
-    strategy_storage.DATA_DIR.mkdir(parents=True, exist_ok=True)
-
-    legacy = strategy_storage._default_strategy_payload()  # noqa: SLF001
-    legacy["universe"]["filt"].pop("currencies", None)
-    strategy_storage.STRATEGIES_FILE.write_text(json.dumps([legacy]), encoding="utf-8")
-    strategy_storage.ACTIVE_STRATEGY_FILE.write_text(json.dumps({"id": "default"}), encoding="utf-8")
-
-    client = TestClient(app)
-    active = client.get("/api/strategy/active").json()
-    assert active["universe"]["filt"]["currencies"] == ["USD", "EUR"]
-
-
-def test_strategy_migrates_legacy_backtest_fields_into_risk(monkeypatch, tmp_path):
-    _patch_strategy_storage(monkeypatch, tmp_path)
-    strategy_storage.DATA_DIR.mkdir(parents=True, exist_ok=True)
-
-    legacy = strategy_storage._default_strategy_payload()  # noqa: SLF001
-    legacy["risk"].pop("rr_target", None)
-    legacy["risk"].pop("commission_pct", None)
-    legacy["backtest"] = {
-        "take_profit_r": 2.7,
-        "commission_pct": 0.003,
+    payload = {
+        key: value
+        for key, value in active.items()
+        if key not in {"is_default", "created_at", "updated_at"}
     }
-    strategy_storage.STRATEGIES_FILE.write_text(json.dumps([legacy]), encoding="utf-8")
-    strategy_storage.ACTIVE_STRATEGY_FILE.write_text(json.dumps({"id": "default"}), encoding="utf-8")
+    payload["id"] = "new-id"
 
-    client = TestClient(app)
-    active = client.get("/api/strategy/active").json()
-
-    assert active["risk"]["rr_target"] == 2.7
-    assert active["risk"]["commission_pct"] == 0.003
-    assert "backtest" not in active
-
-    persisted = json.loads(strategy_storage.STRATEGIES_FILE.read_text(encoding="utf-8"))
-    assert persisted[0]["risk"]["rr_target"] == 2.7
-    assert persisted[0]["risk"]["commission_pct"] == 0.003
-    assert "backtest" not in persisted[0]
-
-
-def test_strategy_migration_prefers_existing_risk_fields(monkeypatch, tmp_path):
-    _patch_strategy_storage(monkeypatch, tmp_path)
-    strategy_storage.DATA_DIR.mkdir(parents=True, exist_ok=True)
-
-    legacy = strategy_storage._default_strategy_payload()  # noqa: SLF001
-    legacy["risk"]["rr_target"] = 3.1
-    legacy["risk"]["commission_pct"] = 0.001
-    legacy["backtest"] = {
-        "take_profit_r": 4.5,
-        "commission_pct": 0.02,
-    }
-    strategy_storage.STRATEGIES_FILE.write_text(json.dumps([legacy]), encoding="utf-8")
-    strategy_storage.ACTIVE_STRATEGY_FILE.write_text(json.dumps({"id": "default"}), encoding="utf-8")
-
-    client = TestClient(app)
-    active = client.get("/api/strategy/active").json()
-
-    assert active["risk"]["rr_target"] == 3.1
-    assert active["risk"]["commission_pct"] == 0.001
-    assert "backtest" not in active
+    assert client.post("/api/strategy", json=payload).status_code == 405
+    assert client.put("/api/strategy/default", json=payload).status_code == 405
+    assert client.delete("/api/strategy/default").status_code == 405
+    assert client.post("/api/strategy/active", json={"strategy_id": "default"}).status_code == 405

--- a/tests/api/test_strategy_validation_endpoint.py
+++ b/tests/api/test_strategy_validation_endpoint.py
@@ -1,94 +1,17 @@
-from __future__ import annotations
-
 from fastapi.testclient import TestClient
 
-import swing_screener.strategy.storage as strategy_storage
 from api.main import app
 
 
-def _patch_strategy_storage(monkeypatch, tmp_path):
-    data_dir = tmp_path / "data"
-    monkeypatch.setattr(strategy_storage, "DATA_DIR", data_dir)
-    monkeypatch.setattr(strategy_storage, "STRATEGIES_FILE", data_dir / "strategies.json")
-    monkeypatch.setattr(strategy_storage, "ACTIVE_STRATEGY_FILE", data_dir / "active_strategy.json")
-
-
-def _to_update_payload(strategy: dict) -> dict:
-    return {
-        key: value
-        for key, value in strategy.items()
-        if key not in {"id", "is_default", "created_at", "updated_at"}
-    }
-
-
-def test_validate_strategy_safe(monkeypatch, tmp_path):
-    _patch_strategy_storage(monkeypatch, tmp_path)
+def test_strategy_validation_endpoint_returns_read_only_summary():
     client = TestClient(app)
 
-    active = client.get("/api/strategy/active").json()
-    payload = _to_update_payload(active)
-    payload["signals"]["breakout_lookback"] = 50
-    payload["signals"]["pullback_ma"] = 20
-    payload["risk"]["min_rr"] = 2.5
-    payload["risk"]["risk_pct"] = 0.01
-    payload["universe"]["filt"]["max_atr_pct"] = 15
-    payload["manage"]["max_holding_days"] = 20
+    res = client.get("/api/strategy/validation")
 
-    res = client.post("/api/strategy/validate", json=payload)
     assert res.status_code == 200
-    data = res.json()
-    assert data["is_valid"] is True
-    assert data["warnings"] == []
-    assert data["safety_score"] == 100
-    assert data["safety_level"] == "beginner-safe"
-    assert data["total_warnings"] == 0
-    assert data["danger_count"] == 0
-
-
-def test_validate_strategy_dangerous(monkeypatch, tmp_path):
-    _patch_strategy_storage(monkeypatch, tmp_path)
-    client = TestClient(app)
-
-    active = client.get("/api/strategy/active").json()
-    payload = _to_update_payload(active)
-    payload["signals"]["breakout_lookback"] = 10
-    payload["signals"]["pullback_ma"] = 5
-    payload["risk"]["min_rr"] = 1.2
-    payload["risk"]["risk_pct"] = 0.04
-    payload["universe"]["filt"]["max_atr_pct"] = 30
-    payload["manage"]["max_holding_days"] = 3
-
-    res = client.post("/api/strategy/validate", json=payload)
-    assert res.status_code == 200
-    data = res.json()
-    assert data["is_valid"] is False
-    assert data["total_warnings"] == 6
-    assert data["danger_count"] == 4
-    assert data["warning_count"] == 2
-    assert data["info_count"] == 0
-    assert data["safety_level"] == "expert-only"
-
-
-def test_create_update_dangerous_strategy_still_allowed(monkeypatch, tmp_path):
-    _patch_strategy_storage(monkeypatch, tmp_path)
-    client = TestClient(app)
-
-    active = client.get("/api/strategy/active").json()
-    create_payload = _to_update_payload(active)
-    create_payload["id"] = "danger"
-    create_payload["name"] = "Danger Strategy"
-    create_payload["signals"]["breakout_lookback"] = 10
-    create_payload["risk"]["risk_pct"] = 0.04
-    create_payload["risk"]["min_rr"] = 1.2
-    create_payload["universe"]["filt"]["max_atr_pct"] = 30
-
-    create_res = client.post("/api/strategy", json=create_payload)
-    assert create_res.status_code == 200
-    assert create_res.json()["id"] == "danger"
-
-    update_payload = _to_update_payload(create_res.json())
-    update_payload["name"] = "Danger Strategy v2"
-    update_payload["manage"]["max_holding_days"] = 3
-    update_res = client.put("/api/strategy/danger", json=update_payload)
-    assert update_res.status_code == 200
-    assert update_res.json()["name"] == "Danger Strategy v2"
+    payload = res.json()
+    assert payload["is_valid"] is True
+    assert isinstance(payload["warnings"], list)
+    assert "safety_score" in payload
+    assert "safety_level" in payload
+    assert payload["danger_count"] == 0

--- a/tests/test_momentum.py
+++ b/tests/test_momentum.py
@@ -5,6 +5,7 @@ from swing_screener.indicators.momentum import (
     MomentumConfig,
     compute_returns,
 )
+from swing_screener.strategy.modules.momentum import _volume_confirmation_rows
 
 
 def _make_synthetic_ohlcv_for_momentum():
@@ -139,3 +140,47 @@ def test_momentum_features_handles_sparse_calendar_gaps():
     # Both AAA and SPY should have features despite gaps
     assert "AAA" in feats.index
     assert pd.notna(feats.loc["AAA", "mom_6m"])
+
+
+def test_volume_confirmation_blocks_weak_breakout_and_keeps_pullback():
+    idx = pd.bdate_range("2024-01-02", periods=25)
+    volume = pd.Series([100.0] * 24 + [120.0], index=idx)
+    ohlcv = pd.concat({"Volume": pd.DataFrame({"AAA": volume})}, axis=1)
+    board = pd.DataFrame({"signal": ["both"]}, index=pd.Index(["AAA"], name="ticker"))
+
+    result = _volume_confirmation_rows(
+        ohlcv,
+        board,
+        {
+            "volume_ma_window": 20,
+            "min_breakout_volume_ratio": 1.5,
+            "apply_to_breakout": True,
+            "apply_to_pullback": False,
+        },
+    )
+
+    assert result.loc["AAA", "volume_confirmation_passed"] == False
+    assert result.loc["AAA", "signal"] == "pullback"
+    assert float(result.loc["AAA", "volume_ratio"]) == 1.2
+
+
+def test_volume_confirmation_passes_strong_breakout():
+    idx = pd.bdate_range("2024-01-02", periods=25)
+    volume = pd.Series([100.0] * 24 + [200.0], index=idx)
+    ohlcv = pd.concat({"Volume": pd.DataFrame({"AAA": volume})}, axis=1)
+    board = pd.DataFrame({"signal": ["breakout"]}, index=pd.Index(["AAA"], name="ticker"))
+
+    result = _volume_confirmation_rows(
+        ohlcv,
+        board,
+        {
+            "volume_ma_window": 20,
+            "min_breakout_volume_ratio": 1.5,
+            "apply_to_breakout": True,
+            "apply_to_pullback": False,
+        },
+    )
+
+    assert result.loc["AAA", "volume_confirmation_passed"] == True
+    assert result.loc["AAA", "signal"] == "breakout"
+    assert float(result.loc["AAA", "volume_ratio"]) == 2.0

--- a/tests/test_recommendation_engine.py
+++ b/tests/test_recommendation_engine.py
@@ -1,4 +1,4 @@
-from swing_screener.risk.recommendations.engine import build_recommendation
+from swing_screener.risk.recommendations.engine import ChecklistGate, Reason, build_recommendation
 
 
 def test_recommendation_happy_path():
@@ -66,3 +66,39 @@ def test_recommendation_blocks_fee_drag():
 
     assert rec.verdict == "NOT_RECOMMENDED"
     assert any(r.code == "FEES_TOO_HIGH" for r in rec.reasons_detailed)
+
+
+def test_recommendation_accepts_extra_plugin_gates_and_reasons():
+    rec = build_recommendation(
+        signal="breakout",
+        entry=100.0,
+        stop=95.0,
+        shares=100,
+        account_size=100000.0,
+        risk_pct_target=0.01,
+        rr_target=2.0,
+        commission_pct=0.0,
+        slippage_bps=0.0,
+        extra_checklist=[
+            ChecklistGate(
+                gate_name="volume_confirmation",
+                passed=False,
+                explanation="Breakout volume did not clear the configured threshold.",
+                rule="PLUGIN:volume_confirmation",
+            )
+        ],
+        extra_reasons=[
+            Reason(
+                code="VOLUME_CONFIRMATION_FAILED",
+                message="Volume confirmation blocked the breakout.",
+                severity="block",
+                rule="PLUGIN:volume_confirmation",
+            )
+        ],
+        extra_suggestions=["Wait for stronger participation before acting on this breakout."],
+    )
+
+    assert rec.verdict == "NOT_RECOMMENDED"
+    assert any(g.gate_name == "volume_confirmation" and not g.passed for g in rec.checklist)
+    assert any(r.code == "VOLUME_CONFIRMATION_FAILED" for r in rec.reasons_detailed)
+    assert "Wait for stronger participation before acting on this breakout." in rec.education.what_would_make_valid

--- a/tests/test_strategy_plugin_system.py
+++ b/tests/test_strategy_plugin_system.py
@@ -1,0 +1,23 @@
+from swing_screener.strategy.plugin_system import (
+    resolve_strategy_config,
+    validate_resolved_strategy_config,
+)
+
+
+def test_plugin_system_resolves_execution_order_and_volume_dependency():
+    resolved = resolve_strategy_config()
+
+    assert "volume_confirmation" in resolved["execution_order"]
+    assert "breakout_signal" in resolved["execution_order"]
+    assert resolved["execution_order"].index("breakout_signal") < resolved["execution_order"].index(
+        "volume_confirmation"
+    )
+    assert "volume_confirmation" in resolved["graph_edges"]["breakout_signal"]
+
+
+def test_plugin_system_default_yaml_is_valid():
+    resolved = resolve_strategy_config()
+    validation = validate_resolved_strategy_config(resolved)
+
+    assert validation["is_valid"] is True
+    assert validation["issues"] == []

--- a/web-ui-assessment.md
+++ b/web-ui-assessment.md
@@ -1,0 +1,30 @@
+## Web UI Code Assessment Report
+
+### 1. Misplaced Logic
+
+*   **Finding:** UI components in `src/pages` are overly complex, containing significant business logic, data fetching, and state management. This violates the principle of separation of concerns, making components difficult to test, maintain, and reuse.
+*   **Examples:**
+    *   `DailyReview.tsx`: Contains logic for filtering candidates, handling watch/unwatch actions, and managing UI state for modals and collapsible sections. It also defines multiple large sub-components.
+    *   `Intelligence.tsx`: Manages complex state for configuration, jobs, and symbol sets. It includes logic for running intelligence analysis and CRUD operations for symbol sets.
+*   **Recommendation:**
+    *   Extract business logic into custom hooks (e.g., `useDailyReviewLogic`) or dedicated service/helper files within the `src/features` directory.
+    *   Move large sub-components (`CandidatesTable`, `UpdateStopTable`, etc.) into their own files under `src/components/domain/`.
+    *   Use a state management library (like the existing Zustand stores) more effectively to manage complex component state.
+
+### 2. Hardcoded Values
+
+*   **Finding:** The application contains hardcoded configuration and data that should be externalized. This makes the application inflexible and requires code changes for simple data modifications.
+*   **Examples:**
+    *   `Intelligence.tsx`: Hardcoded `PROVIDER_MODELS` and `PROVIDER_DEFAULTS` for LLM providers.
+    *   `Onboarding.tsx`: Hardcoded `STEPS` for the onboarding flow.
+    *   `DailyReview.tsx`: Use of `DEFAULT_CONFIG` and a hardcoded media query.
+*   **Recommendation:**
+    *   Externalize configuration like LLM providers and models to a configuration file (e.g., a JSON or YAML file) or fetch it from an API.
+    *   Move the onboarding steps data to a separate file (e.g., `src/content/onboarding.ts`) or load it from a CMS or API if it needs to be highly dynamic.
+
+### 3. Potential Dead Code
+
+*   **Finding:** The large file sizes and complexity of the components suggest that there may be unused variables, functions, or imports. There are also a number of `README.md` files in the subdirectories that may not be necessary. The `test_api.sh` file also seems out of place for a web UI.
+*   **Recommendation:**
+    *   Run a code analysis tool like `eslint` with the `no-unused-vars` rule enabled, or a specialized tool like `ts-prune` to identify and remove dead code. This will improve code clarity and reduce bundle size.
+    *   Review the necessity of the `README.md` files in the subdirectories and the `test_api.sh` file.

--- a/web-ui/eslint.config.mjs
+++ b/web-ui/eslint.config.mjs
@@ -23,7 +23,7 @@ export default [
     },
     rules: {
       'react-hooks/rules-of-hooks': 'error',
-      'react-hooks/exhaustive-deps': 'off',
+      'react-hooks/exhaustive-deps': 'error',
       'react-refresh/only-export-components': 'off',
       'no-restricted-imports': [
         'error',

--- a/web-ui/src/components/common/CollapsibleSection.tsx
+++ b/web-ui/src/components/common/CollapsibleSection.tsx
@@ -1,0 +1,56 @@
+import type { ReactNode } from 'react';
+import Card, { CardHeader, CardTitle, CardContent } from '@/components/common/Card';
+import Button from '@/components/common/Button';
+import Badge from '@/components/common/Badge';
+
+interface CollapsibleSectionProps {
+  title: string;
+  isExpanded: boolean;
+  onToggle: () => void;
+  count: number;
+  variant?: 'warning' | 'danger';
+  badgeLabel?: string;
+  expandLabel?: string;
+  collapseLabel?: string;
+  children: ReactNode;
+}
+
+export default function CollapsibleSection({
+  title,
+  isExpanded,
+  onToggle,
+  count,
+  variant,
+  badgeLabel,
+  expandLabel = '▶',
+  collapseLabel = '▼',
+  children,
+}: CollapsibleSectionProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <CardTitle>{title}</CardTitle>
+            {count > 0 && variant === 'warning' && badgeLabel ? (
+              <Badge variant="warning">{badgeLabel}</Badge>
+            ) : null}
+            {count > 0 && variant === 'danger' && badgeLabel ? (
+              <Badge variant="error">{badgeLabel}</Badge>
+            ) : null}
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onToggle}
+            title={isExpanded ? collapseLabel : expandLabel}
+            aria-label={isExpanded ? collapseLabel : expandLabel}
+          >
+            {isExpanded ? '▼' : '▶'}
+          </Button>
+        </div>
+      </CardHeader>
+      {isExpanded ? <CardContent>{children}</CardContent> : null}
+    </Card>
+  );
+}

--- a/web-ui/src/components/common/CollapsibleSection.tsx
+++ b/web-ui/src/components/common/CollapsibleSection.tsx
@@ -46,7 +46,7 @@ export default function CollapsibleSection({
             title={isExpanded ? collapseLabel : expandLabel}
             aria-label={isExpanded ? collapseLabel : expandLabel}
           >
-            {isExpanded ? '▼' : '▶'}
+            {isExpanded ? collapseLabel : expandLabel}
           </Button>
         </div>
       </CardHeader>

--- a/web-ui/src/components/domain/dailyReview/DailyReviewCandidatesTable.tsx
+++ b/web-ui/src/components/domain/dailyReview/DailyReviewCandidatesTable.tsx
@@ -1,0 +1,223 @@
+import { Info } from 'lucide-react';
+import TableShell from '@/components/common/TableShell';
+import Button from '@/components/common/Button';
+import Badge from '@/components/common/Badge';
+import MetricHelpLabel from '@/components/domain/education/MetricHelpLabel';
+import CachedSymbolPriceChart from '@/components/domain/market/CachedSymbolPriceChart';
+import DailyReviewWatchInlineBlock, {
+  type DailyReviewWatchProps,
+} from '@/components/domain/dailyReview/DailyReviewWatchInlineBlock';
+import type { DailyReviewCandidate } from '@/features/dailyReview/types';
+import { formatCurrency, formatNumber } from '@/utils/formatters';
+import { t } from '@/i18n/t';
+
+interface DailyReviewCandidatesTableProps extends DailyReviewWatchProps {
+  candidates: DailyReviewCandidate[];
+  onShowRecommendation: (candidate: DailyReviewCandidate) => void;
+  onCreateOrder: (candidate: DailyReviewCandidate) => void;
+  isCompactMobileLayout: boolean;
+}
+
+export default function DailyReviewCandidatesTable({
+  candidates,
+  onShowRecommendation,
+  onCreateOrder,
+  isCompactMobileLayout,
+  watchItemsByTicker,
+  watchPending,
+  onWatch,
+  onUnwatch,
+}: DailyReviewCandidatesTableProps) {
+  if (isCompactMobileLayout) {
+    return (
+      <div className="space-y-3">
+        {candidates.map((candidate) => (
+          <div
+            key={candidate.ticker}
+            className="rounded-xl border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <a
+                  href={`https://finance.yahoo.com/quote/${candidate.ticker}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="font-mono text-base font-bold text-blue-700 hover:underline"
+                  title={t('dailyReview.table.candidates.yahooFinanceTooltip', { ticker: candidate.ticker })}
+                >
+                  {candidate.ticker}
+                </a>
+                <p className="mt-0.5 text-xs text-gray-500">
+                  {candidate.sector || t('common.placeholders.dash')}
+                </p>
+                <DailyReviewWatchInlineBlock
+                  ticker={candidate.ticker}
+                  currentPrice={candidate.close}
+                  source="daily_review_candidates"
+                  watchItemsByTicker={watchItemsByTicker}
+                  watchPending={watchPending}
+                  onWatch={onWatch}
+                  onUnwatch={onUnwatch}
+                />
+              </div>
+              <Badge variant="primary">{candidate.signal}</Badge>
+            </div>
+
+            <CachedSymbolPriceChart ticker={candidate.ticker} className="mt-2" />
+
+            <div className="mt-3 grid grid-cols-2 gap-2 text-xs">
+              <div className="rounded-md bg-gray-50 px-2 py-1 dark:bg-gray-700/70">
+                <p className="text-gray-500">{t('dailyReview.table.candidates.headers.entry')}</p>
+                <p className="font-semibold">{formatCurrency(candidate.entry)}</p>
+              </div>
+              <div className="rounded-md bg-gray-50 px-2 py-1 dark:bg-gray-700/70">
+                <p className="text-gray-500">{t('dailyReview.table.candidates.headers.stop')}</p>
+                <p className="font-semibold">{formatCurrency(candidate.stop)}</p>
+              </div>
+              <div className="rounded-md bg-gray-50 px-2 py-1 dark:bg-gray-700/70">
+                <p className="text-gray-500">{t('dailyReview.table.candidates.headers.shares')}</p>
+                <p className="font-semibold">{candidate.shares}</p>
+              </div>
+              <div className="rounded-md bg-gray-50 px-2 py-1 dark:bg-gray-700/70">
+                <p className="text-gray-500">{t('dailyReview.table.candidates.headers.riskReward')}</p>
+                <p className="font-semibold">
+                  {t('common.units.rValue', { value: formatNumber(candidate.rReward, 1) })}
+                </p>
+              </div>
+              <div className="col-span-2 rounded-md bg-gray-50 px-2 py-1 dark:bg-gray-700/70">
+                <p className="text-gray-500">{t('dailyReview.table.candidates.headers.confidence')}</p>
+                <p className="font-semibold text-purple-700 dark:text-purple-300">
+                  {candidate.confidence != null ? formatNumber(candidate.confidence, 1) : '-'}
+                </p>
+              </div>
+            </div>
+
+            <div className="mt-3 flex items-center gap-2">
+              {candidate.recommendation ? (
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  className="shrink-0"
+                  onClick={() => onShowRecommendation(candidate)}
+                  title={t('dailyReview.table.candidates.recommendationTitle')}
+                  aria-label={t('dailyReview.table.candidates.recommendationAria', { ticker: candidate.ticker })}
+                >
+                  <Info className="h-4 w-4" />
+                </Button>
+              ) : null}
+              <Button
+                variant="primary"
+                size="sm"
+                className="flex-1"
+                onClick={() => onCreateOrder(candidate)}
+                title={
+                  candidate.recommendation?.verdict === 'NOT_RECOMMENDED'
+                    ? t('dailyReview.table.candidates.createOrderNotRecommendedTitle')
+                    : t('dailyReview.table.candidates.createOrderTitle')
+                }
+              >
+                {t('dailyReview.table.candidates.createOrder')}
+              </Button>
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <TableShell
+      empty={candidates.length === 0}
+      emptyMessage={t('dailyReview.table.candidates.empty')}
+      tableClassName="text-sm"
+      headers={(
+        <tr>
+          <th className="text-left p-2">{t('dailyReview.table.candidates.headers.ticker')}</th>
+          <th className="text-right p-2">
+            <MetricHelpLabel metricKey="CONFIDENCE" className="justify-end w-full" />
+          </th>
+          <th className="text-left p-2">{t('dailyReview.table.candidates.headers.signal')}</th>
+          <th className="text-right p-2">{t('dailyReview.table.candidates.headers.entry')}</th>
+          <th className="text-right p-2">{t('dailyReview.table.candidates.headers.stop')}</th>
+          <th className="text-right p-2">{t('dailyReview.table.candidates.headers.shares')}</th>
+          <th className="text-right p-2">
+            <MetricHelpLabel metricKey="RR" labelOverride="R:R" className="justify-end w-full" />
+          </th>
+          <th className="text-left p-2">{t('dailyReview.table.candidates.headers.sector')}</th>
+          <th className="text-center p-2">{t('dailyReview.table.candidates.headers.info')}</th>
+          <th className="text-right p-2">{t('dailyReview.table.candidates.headers.action')}</th>
+        </tr>
+      )}
+    >
+      {candidates.map((candidate) => (
+        <tr key={candidate.ticker} className="border-b dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800">
+          <td className="p-2 font-mono font-bold">
+            <a
+              href={`https://finance.yahoo.com/quote/${candidate.ticker}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-600 hover:text-blue-800 hover:underline"
+              title={t('dailyReview.table.candidates.yahooFinanceTooltip', { ticker: candidate.ticker })}
+            >
+              {candidate.ticker}
+            </a>
+            <DailyReviewWatchInlineBlock
+              ticker={candidate.ticker}
+              currentPrice={candidate.close}
+              source="daily_review_candidates"
+              watchItemsByTicker={watchItemsByTicker}
+              watchPending={watchPending}
+              onWatch={onWatch}
+              onUnwatch={onUnwatch}
+            />
+            <CachedSymbolPriceChart ticker={candidate.ticker} className="mt-1" />
+          </td>
+          <td className="p-2 text-right">
+            <span className="font-semibold text-purple-600">
+              {candidate.confidence != null ? formatNumber(candidate.confidence, 1) : '-'}
+            </span>
+          </td>
+          <td className="p-2">
+            <Badge variant="primary">{candidate.signal}</Badge>
+          </td>
+          <td className="p-2 text-right">{formatCurrency(candidate.entry)}</td>
+          <td className="p-2 text-right">{formatCurrency(candidate.stop)}</td>
+          <td className="p-2 text-right">{candidate.shares}</td>
+          <td className="p-2 text-right font-bold">
+            {t('common.units.rValue', { value: formatNumber(candidate.rReward, 1) })}
+          </td>
+          <td className="p-2 text-sm text-gray-600 dark:text-gray-400">
+            {candidate.sector || t('common.placeholders.dash')}
+          </td>
+          <td className="p-2 text-center">
+            {candidate.recommendation ? (
+              <button
+                onClick={() => onShowRecommendation(candidate)}
+                className="min-h-11 min-w-11 p-1 hover:bg-gray-200 dark:hover:bg-gray-700 rounded"
+                title={t('dailyReview.table.candidates.recommendationTitle')}
+                aria-label={t('dailyReview.table.candidates.recommendationAria', { ticker: candidate.ticker })}
+              >
+                <Info className="w-4 h-4" />
+              </button>
+            ) : null}
+          </td>
+          <td className="p-2 text-right">
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={() => onCreateOrder(candidate)}
+              title={
+                candidate.recommendation?.verdict === 'NOT_RECOMMENDED'
+                  ? t('dailyReview.table.candidates.createOrderNotRecommendedTitle')
+                  : t('dailyReview.table.candidates.createOrderTitle')
+              }
+            >
+              {t('dailyReview.table.candidates.createOrder')}
+            </Button>
+          </td>
+        </tr>
+      ))}
+    </TableShell>
+  );
+}

--- a/web-ui/src/components/domain/dailyReview/DailyReviewCloseTable.tsx
+++ b/web-ui/src/components/domain/dailyReview/DailyReviewCloseTable.tsx
@@ -1,0 +1,162 @@
+import TableShell from '@/components/common/TableShell';
+import Button from '@/components/common/Button';
+import Badge from '@/components/common/Badge';
+import MetricHelpLabel from '@/components/domain/education/MetricHelpLabel';
+import CachedSymbolPriceChart from '@/components/domain/market/CachedSymbolPriceChart';
+import DailyReviewWatchInlineBlock, {
+  type DailyReviewWatchProps,
+} from '@/components/domain/dailyReview/DailyReviewWatchInlineBlock';
+import { formatDailyReviewReason } from '@/utils/dailyReviewFormatters';
+import type { DailyReviewPositionClose } from '@/features/dailyReview/types';
+import { formatCurrency, formatNumber } from '@/utils/formatters';
+import { t } from '@/i18n/t';
+
+interface DailyReviewCloseTableProps extends DailyReviewWatchProps {
+  positions: DailyReviewPositionClose[];
+  onAction: (position: DailyReviewPositionClose) => void;
+  isCompactMobileLayout: boolean;
+}
+
+export default function DailyReviewCloseTable({
+  positions,
+  onAction,
+  isCompactMobileLayout,
+  watchItemsByTicker,
+  watchPending,
+  onWatch,
+  onUnwatch,
+}: DailyReviewCloseTableProps) {
+  if (isCompactMobileLayout) {
+    return (
+      <div className="space-y-3">
+        {positions.map((pos) => (
+          <div
+            key={pos.positionId}
+            className="rounded-xl border border-red-200 bg-red-50/60 p-3 dark:border-red-900 dark:bg-red-950/20"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <a
+                href={`https://finance.yahoo.com/quote/${pos.ticker}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-mono text-base font-bold text-blue-700 hover:underline"
+                title={t('dailyReview.table.close.yahooFinanceTooltip', { ticker: pos.ticker })}
+              >
+                {pos.ticker}
+              </a>
+              <DailyReviewWatchInlineBlock
+                ticker={pos.ticker}
+                currentPrice={pos.currentPrice}
+                source="daily_review_close"
+                watchItemsByTicker={watchItemsByTicker}
+                watchPending={watchPending}
+                onWatch={onWatch}
+                onUnwatch={onUnwatch}
+              />
+              <Badge variant="error">{t('dailyReview.table.close.actionLabel')}</Badge>
+            </div>
+
+            <CachedSymbolPriceChart ticker={pos.ticker} className="mt-2" />
+
+            <div className="mt-3 grid grid-cols-3 gap-2 text-xs">
+              <div className="rounded-md bg-white px-2 py-1 dark:bg-gray-800/70">
+                <p className="text-gray-500">{t('dailyReview.table.close.headers.entry')}</p>
+                <p className="font-semibold">{formatCurrency(pos.entryPrice)}</p>
+              </div>
+              <div className="rounded-md bg-white px-2 py-1 dark:bg-gray-800/70">
+                <p className="text-gray-500">{t('dailyReview.table.close.headers.current')}</p>
+                <p className="font-semibold">{formatCurrency(pos.currentPrice)}</p>
+              </div>
+              <div className="rounded-md bg-white px-2 py-1 dark:bg-gray-800/70">
+                <p className="text-gray-500">{t('dailyReview.table.close.headers.stop')}</p>
+                <p>{formatCurrency(pos.stopPrice)}</p>
+              </div>
+            </div>
+
+            <p className="mt-3 text-xs text-gray-600 dark:text-gray-300">{formatDailyReviewReason(pos.reason)}</p>
+
+            <div className="mt-3 flex items-center justify-between gap-3">
+              <span className="text-sm font-semibold text-red-700 dark:text-red-300">
+                {t('common.units.rValue', { value: formatNumber(pos.rNow, 2) })}
+              </span>
+              <Button
+                variant="danger"
+                size="sm"
+                onClick={() => onAction(pos)}
+                title={t('dailyReview.table.close.actionTitle')}
+              >
+                {t('dailyReview.table.close.actionLabel')}
+              </Button>
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <TableShell
+      empty={positions.length === 0}
+      emptyMessage={t('dailyReview.table.close.empty')}
+      tableClassName="text-sm"
+      headers={(
+        <tr>
+          <th className="text-left p-2">{t('dailyReview.table.close.headers.ticker')}</th>
+          <th className="text-right p-2">{t('dailyReview.table.close.headers.entry')}</th>
+          <th className="text-right p-2">{t('dailyReview.table.close.headers.current')}</th>
+          <th className="text-right p-2">{t('dailyReview.table.close.headers.stop')}</th>
+          <th className="text-right p-2">
+            <MetricHelpLabel metricKey="R_NOW" className="justify-end w-full" />
+          </th>
+          <th className="text-left p-2">{t('dailyReview.table.close.headers.reason')}</th>
+          <th className="text-right p-2">{t('dailyReview.table.close.headers.action')}</th>
+        </tr>
+      )}
+    >
+      {positions.map((pos) => (
+        <tr key={pos.positionId} className="border-b dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800">
+          <td className="p-2 font-mono font-bold">
+            <a
+              href={`https://finance.yahoo.com/quote/${pos.ticker}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-600 hover:text-blue-800 hover:underline"
+              title={t('dailyReview.table.close.yahooFinanceTooltip', { ticker: pos.ticker })}
+            >
+              {pos.ticker}
+            </a>
+            <DailyReviewWatchInlineBlock
+              ticker={pos.ticker}
+              currentPrice={pos.currentPrice}
+              source="daily_review_close"
+              watchItemsByTicker={watchItemsByTicker}
+              watchPending={watchPending}
+              onWatch={onWatch}
+              onUnwatch={onUnwatch}
+            />
+            <CachedSymbolPriceChart ticker={pos.ticker} className="mt-1" />
+          </td>
+          <td className="p-2 text-right">{formatCurrency(pos.entryPrice)}</td>
+          <td className="p-2 text-right">{formatCurrency(pos.currentPrice)}</td>
+          <td className="p-2 text-right">{formatCurrency(pos.stopPrice)}</td>
+          <td className="p-2 text-right">
+            <span className="text-red-700 dark:text-red-300 font-bold">
+              {t('common.units.rValue', { value: formatNumber(pos.rNow, 2) })}
+            </span>
+          </td>
+          <td className="p-2 text-sm">{formatDailyReviewReason(pos.reason)}</td>
+          <td className="p-2 text-right">
+            <Button
+              variant="danger"
+              size="sm"
+              onClick={() => onAction(pos)}
+              title={t('dailyReview.table.close.actionTitle')}
+            >
+              {t('dailyReview.table.close.actionLabel')}
+            </Button>
+          </td>
+        </tr>
+      ))}
+    </TableShell>
+  );
+}

--- a/web-ui/src/components/domain/dailyReview/DailyReviewHoldTable.tsx
+++ b/web-ui/src/components/domain/dailyReview/DailyReviewHoldTable.tsx
@@ -1,0 +1,145 @@
+import TableShell from '@/components/common/TableShell';
+import Badge from '@/components/common/Badge';
+import MetricHelpLabel from '@/components/domain/education/MetricHelpLabel';
+import CachedSymbolPriceChart from '@/components/domain/market/CachedSymbolPriceChart';
+import DailyReviewWatchInlineBlock, {
+  type DailyReviewWatchProps,
+} from '@/components/domain/dailyReview/DailyReviewWatchInlineBlock';
+import { formatDailyReviewReason } from '@/utils/dailyReviewFormatters';
+import type { DailyReviewPositionHold } from '@/features/dailyReview/types';
+import { formatCurrency, formatNumber } from '@/utils/formatters';
+import { t } from '@/i18n/t';
+
+interface DailyReviewHoldTableProps extends DailyReviewWatchProps {
+  positions: DailyReviewPositionHold[];
+  isCompactMobileLayout: boolean;
+}
+
+export default function DailyReviewHoldTable({
+  positions,
+  isCompactMobileLayout,
+  watchItemsByTicker,
+  watchPending,
+  onWatch,
+  onUnwatch,
+}: DailyReviewHoldTableProps) {
+  if (isCompactMobileLayout) {
+    return (
+      <div className="space-y-3">
+        {positions.map((pos) => (
+          <div
+            key={pos.positionId}
+            className="rounded-xl border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <a
+                href={`https://finance.yahoo.com/quote/${pos.ticker}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-mono text-base font-bold text-blue-700 hover:underline"
+                title={t('dailyReview.table.hold.yahooFinanceTooltip', { ticker: pos.ticker })}
+              >
+                {pos.ticker}
+              </a>
+              <DailyReviewWatchInlineBlock
+                ticker={pos.ticker}
+                currentPrice={pos.currentPrice}
+                source="daily_review_hold"
+                watchItemsByTicker={watchItemsByTicker}
+                watchPending={watchPending}
+                onWatch={onWatch}
+                onUnwatch={onUnwatch}
+              />
+              <Badge variant="success">{t('dailyReview.table.hold.holdBadge')}</Badge>
+            </div>
+
+            <CachedSymbolPriceChart ticker={pos.ticker} className="mt-2" />
+
+            <div className="mt-3 grid grid-cols-3 gap-2 text-xs">
+              <div className="rounded-md bg-gray-50 px-2 py-1 dark:bg-gray-700/70">
+                <p className="text-gray-500">{t('dailyReview.table.hold.headers.entry')}</p>
+                <p className="font-semibold">{formatCurrency(pos.entryPrice)}</p>
+              </div>
+              <div className="rounded-md bg-gray-50 px-2 py-1 dark:bg-gray-700/70">
+                <p className="text-gray-500">{t('dailyReview.table.hold.headers.current')}</p>
+                <p className="font-semibold">{formatCurrency(pos.currentPrice)}</p>
+              </div>
+              <div className="rounded-md bg-gray-50 px-2 py-1 dark:bg-gray-700/70">
+                <p className="text-gray-500">{t('dailyReview.table.hold.headers.stop')}</p>
+                <p>{formatCurrency(pos.stopPrice)}</p>
+              </div>
+            </div>
+
+            <div className="mt-3 flex items-center justify-between gap-3">
+              <p className="text-xs text-gray-600 dark:text-gray-300">{formatDailyReviewReason(pos.reason)}</p>
+              <span
+                className={
+                  pos.rNow >= 0
+                    ? 'text-sm font-semibold text-green-700 dark:text-green-300'
+                    : 'text-sm font-semibold text-red-700 dark:text-red-300'
+                }
+              >
+                {t('common.units.rValue', { value: formatNumber(pos.rNow, 2) })}
+              </span>
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <TableShell
+      empty={positions.length === 0}
+      emptyMessage={t('dailyReview.table.hold.empty')}
+      tableClassName="text-sm"
+      headers={(
+        <tr>
+          <th className="text-left p-2">{t('dailyReview.table.hold.headers.ticker')}</th>
+          <th className="text-right p-2">{t('dailyReview.table.hold.headers.entry')}</th>
+          <th className="text-right p-2">{t('dailyReview.table.hold.headers.current')}</th>
+          <th className="text-right p-2">{t('dailyReview.table.hold.headers.stop')}</th>
+          <th className="text-right p-2">
+            <MetricHelpLabel metricKey="R_NOW" className="justify-end w-full" />
+          </th>
+          <th className="text-left p-2">{t('dailyReview.table.hold.headers.reason')}</th>
+        </tr>
+      )}
+    >
+      {positions.map((pos) => (
+        <tr key={pos.positionId} className="border-b dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800">
+          <td className="p-2 font-mono font-bold">
+            <a
+              href={`https://finance.yahoo.com/quote/${pos.ticker}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-600 hover:text-blue-800 hover:underline"
+              title={t('dailyReview.table.hold.yahooFinanceTooltip', { ticker: pos.ticker })}
+            >
+              {pos.ticker}
+            </a>
+            <DailyReviewWatchInlineBlock
+              ticker={pos.ticker}
+              currentPrice={pos.currentPrice}
+              source="daily_review_hold"
+              watchItemsByTicker={watchItemsByTicker}
+              watchPending={watchPending}
+              onWatch={onWatch}
+              onUnwatch={onUnwatch}
+            />
+            <CachedSymbolPriceChart ticker={pos.ticker} className="mt-1" />
+          </td>
+          <td className="p-2 text-right">{formatCurrency(pos.entryPrice)}</td>
+          <td className="p-2 text-right">{formatCurrency(pos.currentPrice)}</td>
+          <td className="p-2 text-right">{formatCurrency(pos.stopPrice)}</td>
+          <td className="p-2 text-right">
+            <span className={pos.rNow >= 0 ? 'text-green-700 dark:text-green-300' : 'text-red-700 dark:text-red-300'}>
+              {t('common.units.rValue', { value: formatNumber(pos.rNow, 2) })}
+            </span>
+          </td>
+          <td className="p-2 text-sm text-gray-600 dark:text-gray-400">{formatDailyReviewReason(pos.reason)}</td>
+        </tr>
+      ))}
+    </TableShell>
+  );
+}

--- a/web-ui/src/components/domain/dailyReview/DailyReviewSummaryCard.tsx
+++ b/web-ui/src/components/domain/dailyReview/DailyReviewSummaryCard.tsx
@@ -1,0 +1,32 @@
+import Card, { CardContent } from '@/components/common/Card';
+
+interface SummaryCardProps {
+  title: string;
+  value: number;
+  variant: 'blue' | 'yellow' | 'red' | 'green' | 'gray';
+  icon: string;
+}
+
+const VARIANT_CLASSES: Record<SummaryCardProps['variant'], string> = {
+  blue: 'bg-blue-50 dark:bg-blue-900/20 border-blue-200 dark:border-blue-800',
+  yellow: 'bg-yellow-50 dark:bg-yellow-900/20 border-yellow-200 dark:border-yellow-800',
+  red: 'bg-red-50 dark:bg-red-900/20 border-red-200 dark:border-red-800',
+  green: 'bg-green-50 dark:bg-green-900/20 border-green-200 dark:border-green-800',
+  gray: 'bg-gray-50 dark:bg-gray-900/20 border-gray-200 dark:border-gray-800',
+};
+
+export default function DailyReviewSummaryCard({ title, value, variant, icon }: SummaryCardProps) {
+  return (
+    <Card className={VARIANT_CLASSES[variant]}>
+      <CardContent>
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm text-gray-600 dark:text-gray-400">{title}</p>
+            <p className="text-3xl font-bold mt-1">{value}</p>
+          </div>
+          <span className="text-4xl">{icon}</span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/web-ui/src/components/domain/dailyReview/DailyReviewUpdateStopTable.tsx
+++ b/web-ui/src/components/domain/dailyReview/DailyReviewUpdateStopTable.tsx
@@ -1,0 +1,178 @@
+import TableShell from '@/components/common/TableShell';
+import Button from '@/components/common/Button';
+import Badge from '@/components/common/Badge';
+import MetricHelpLabel from '@/components/domain/education/MetricHelpLabel';
+import CachedSymbolPriceChart from '@/components/domain/market/CachedSymbolPriceChart';
+import DailyReviewWatchInlineBlock, {
+  type DailyReviewWatchProps,
+} from '@/components/domain/dailyReview/DailyReviewWatchInlineBlock';
+import { formatDailyReviewReason } from '@/utils/dailyReviewFormatters';
+import type { DailyReviewPositionUpdate } from '@/features/dailyReview/types';
+import { formatCurrency, formatNumber } from '@/utils/formatters';
+import { t } from '@/i18n/t';
+
+interface DailyReviewUpdateStopTableProps extends DailyReviewWatchProps {
+  positions: DailyReviewPositionUpdate[];
+  onAction: (position: DailyReviewPositionUpdate) => void;
+  isCompactMobileLayout: boolean;
+}
+
+export default function DailyReviewUpdateStopTable({
+  positions,
+  onAction,
+  isCompactMobileLayout,
+  watchItemsByTicker,
+  watchPending,
+  onWatch,
+  onUnwatch,
+}: DailyReviewUpdateStopTableProps) {
+  if (isCompactMobileLayout) {
+    return (
+      <div className="space-y-3">
+        {positions.map((pos) => (
+          <div
+            key={pos.positionId}
+            className="rounded-xl border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <a
+                href={`https://finance.yahoo.com/quote/${pos.ticker}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-mono text-base font-bold text-blue-700 hover:underline"
+                title={t('dailyReview.table.update.yahooFinanceTooltip', { ticker: pos.ticker })}
+              >
+                {pos.ticker}
+              </a>
+              <DailyReviewWatchInlineBlock
+                ticker={pos.ticker}
+                currentPrice={pos.currentPrice}
+                source="daily_review_update_stop"
+                watchItemsByTicker={watchItemsByTicker}
+                watchPending={watchPending}
+                onWatch={onWatch}
+                onUnwatch={onUnwatch}
+              />
+              <Badge variant="warning">{t('dailyReview.table.update.actionLabel')}</Badge>
+            </div>
+
+            <CachedSymbolPriceChart ticker={pos.ticker} className="mt-2" />
+
+            <div className="mt-3 grid grid-cols-2 gap-2 text-xs">
+              <div className="rounded-md bg-gray-50 px-2 py-1 dark:bg-gray-700/70">
+                <p className="text-gray-500">{t('dailyReview.table.update.headers.entry')}</p>
+                <p className="font-semibold">{formatCurrency(pos.entryPrice)}</p>
+              </div>
+              <div className="rounded-md bg-gray-50 px-2 py-1 dark:bg-gray-700/70">
+                <p className="text-gray-500">{t('dailyReview.table.update.headers.current')}</p>
+                <p className="font-semibold">{formatCurrency(pos.currentPrice)}</p>
+              </div>
+              <div className="rounded-md bg-gray-50 px-2 py-1 dark:bg-gray-700/70">
+                <p className="text-gray-500">{t('dailyReview.table.update.headers.stopOld')}</p>
+                <p>{formatCurrency(pos.stopCurrent)}</p>
+              </div>
+              <div className="rounded-md bg-gray-50 px-2 py-1 dark:bg-gray-700/70">
+                <p className="text-gray-500">{t('dailyReview.table.update.headers.stopNew')}</p>
+                <p className="font-semibold text-green-700 dark:text-green-300">
+                  {formatCurrency(pos.stopSuggested)}
+                </p>
+              </div>
+            </div>
+
+            <p className="mt-3 text-xs text-gray-600 dark:text-gray-300">{formatDailyReviewReason(pos.reason)}</p>
+
+            <div className="mt-3 flex items-center justify-between gap-3">
+              <span
+                className={
+                  pos.rNow >= 0
+                    ? 'text-sm font-semibold text-green-700 dark:text-green-300'
+                    : 'text-sm font-semibold text-red-700 dark:text-red-300'
+                }
+              >
+                {t('common.units.rValue', { value: formatNumber(pos.rNow, 2) })}
+              </span>
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => onAction(pos)}
+                title={t('dailyReview.table.update.actionTitle')}
+              >
+                {t('dailyReview.table.update.actionLabel')}
+              </Button>
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <TableShell
+      empty={positions.length === 0}
+      emptyMessage={t('dailyReview.table.update.empty')}
+      tableClassName="text-sm"
+      headers={(
+        <tr>
+          <th className="text-left p-2">{t('dailyReview.table.update.headers.ticker')}</th>
+          <th className="text-right p-2">{t('dailyReview.table.update.headers.entry')}</th>
+          <th className="text-right p-2">{t('dailyReview.table.update.headers.current')}</th>
+          <th className="text-right p-2">{t('dailyReview.table.update.headers.stopOld')}</th>
+          <th className="text-right p-2">{t('dailyReview.table.update.headers.stopNew')}</th>
+          <th className="text-right p-2">
+            <MetricHelpLabel metricKey="R_NOW" className="justify-end w-full" />
+          </th>
+          <th className="text-left p-2">{t('dailyReview.table.update.headers.reason')}</th>
+          <th className="text-right p-2">{t('dailyReview.table.update.headers.action')}</th>
+        </tr>
+      )}
+    >
+      {positions.map((pos) => (
+        <tr key={pos.positionId} className="border-b dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800">
+          <td className="p-2 font-mono font-bold">
+            <a
+              href={`https://finance.yahoo.com/quote/${pos.ticker}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-600 hover:text-blue-800 hover:underline"
+              title={t('dailyReview.table.update.yahooFinanceTooltip', { ticker: pos.ticker })}
+            >
+              {pos.ticker}
+            </a>
+            <DailyReviewWatchInlineBlock
+              ticker={pos.ticker}
+              currentPrice={pos.currentPrice}
+              source="daily_review_update_stop"
+              watchItemsByTicker={watchItemsByTicker}
+              watchPending={watchPending}
+              onWatch={onWatch}
+              onUnwatch={onUnwatch}
+            />
+            <CachedSymbolPriceChart ticker={pos.ticker} className="mt-1" />
+          </td>
+          <td className="p-2 text-right">{formatCurrency(pos.entryPrice)}</td>
+          <td className="p-2 text-right">{formatCurrency(pos.currentPrice)}</td>
+          <td className="p-2 text-right text-gray-600 dark:text-gray-400">{formatCurrency(pos.stopCurrent)}</td>
+          <td className="p-2 text-right font-bold text-green-700 dark:text-green-300">
+            {formatCurrency(pos.stopSuggested)}
+          </td>
+          <td className="p-2 text-right">
+            <span className={pos.rNow >= 0 ? 'text-green-700 dark:text-green-300' : 'text-red-700 dark:text-red-300'}>
+              {t('common.units.rValue', { value: formatNumber(pos.rNow, 2) })}
+            </span>
+          </td>
+          <td className="p-2 text-sm">{formatDailyReviewReason(pos.reason)}</td>
+          <td className="p-2 text-right">
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => onAction(pos)}
+              title={t('dailyReview.table.update.actionTitle')}
+            >
+              {t('dailyReview.table.update.actionLabel')}
+            </Button>
+          </td>
+        </tr>
+      ))}
+    </TableShell>
+  );
+}

--- a/web-ui/src/components/domain/dailyReview/DailyReviewWatchInlineBlock.tsx
+++ b/web-ui/src/components/domain/dailyReview/DailyReviewWatchInlineBlock.tsx
@@ -1,0 +1,47 @@
+import WatchMetaInline from '@/components/domain/watchlist/WatchMetaInline';
+import WatchToggleButton from '@/components/domain/watchlist/WatchToggleButton';
+import type { WatchItem } from '@/features/watchlist/types';
+
+export interface DailyReviewWatchProps {
+  watchItemsByTicker: Map<string, WatchItem>;
+  watchPending: boolean;
+  onWatch: (ticker: string, currentPrice: number | null | undefined, source: string) => void;
+  onUnwatch: (ticker: string) => void;
+}
+
+interface WatchInlineBlockProps extends DailyReviewWatchProps {
+  ticker: string;
+  currentPrice: number | null | undefined;
+  source: string;
+}
+
+export default function DailyReviewWatchInlineBlock({
+  ticker,
+  currentPrice,
+  source,
+  watchItemsByTicker,
+  watchPending,
+  onWatch,
+  onUnwatch,
+}: WatchInlineBlockProps) {
+  const watchItem = watchItemsByTicker.get(ticker.trim().toUpperCase());
+  return (
+    <div className="mt-1 flex flex-col gap-1">
+      <WatchToggleButton
+        ticker={ticker}
+        isWatched={Boolean(watchItem)}
+        isPending={watchPending}
+        onWatch={(nextTicker) => onWatch(nextTicker, currentPrice, source)}
+        onUnwatch={onUnwatch}
+      />
+      {watchItem ? (
+        <WatchMetaInline
+          watchedAt={watchItem.watchedAt}
+          watchPrice={watchItem.watchPrice}
+          currentPrice={currentPrice}
+          currency={null}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/web-ui/src/components/domain/intelligence/IntelligenceConfigPanel.tsx
+++ b/web-ui/src/components/domain/intelligence/IntelligenceConfigPanel.tsx
@@ -1,0 +1,314 @@
+import Card, { CardContent, CardHeader, CardTitle } from '@/components/common/Card';
+import Button from '@/components/common/Button';
+import { PROVIDER_DEFAULTS, PROVIDER_MODELS } from '@/content/intelligenceProviders';
+import type { IntelligenceConfig, IntelligenceLlmProvider, IntelligenceProviderInfo, IntelligenceProviderTestResponse } from '@/features/intelligence/types';
+import { t } from '@/i18n/t';
+
+interface IntelligenceConfigPanelProps {
+  draftConfig: IntelligenceConfig;
+  llmModelOptions: string[];
+  isSaving: boolean;
+  isTestingProvider?: boolean;
+  testProviderResult: IntelligenceProviderTestResponse | null | undefined;
+  providersStatus: IntelligenceProviderInfo[] | null | undefined;
+  onConfigChange: (config: IntelligenceConfig) => void;
+  onSave: () => void;
+  onTestProvider: () => void;
+}
+
+export default function IntelligenceConfigPanel({
+  draftConfig,
+  llmModelOptions,
+  isSaving,
+  providersStatus,
+  testProviderResult,
+  onConfigChange,
+  onSave,
+  onTestProvider,
+}: IntelligenceConfigPanelProps) {
+  return (
+    <Card variant="bordered">
+      <CardHeader>
+        <CardTitle>{t('intelligencePage.config.title')}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <label className="text-sm">
+            <span className="mb-1 block text-xs text-gray-500">{t('intelligencePage.config.enabled')}</span>
+            <input
+              type="checkbox"
+              checked={draftConfig.enabled}
+              onChange={(event) => onConfigChange({ ...draftConfig, enabled: event.target.checked })}
+              aria-label={t('intelligencePage.config.enabled')}
+              className="h-5 w-5 rounded border border-gray-300"
+            />
+          </label>
+
+          <label className="text-sm">
+            <span className="mb-1 block text-xs text-gray-500">{t('intelligencePage.config.providers')}</span>
+            <input
+              value={draftConfig.providers.join(', ')}
+              onChange={(event) =>
+                onConfigChange({
+                  ...draftConfig,
+                  providers: event.target.value
+                    .split(',')
+                    .map((value) => value.trim().toLowerCase())
+                    .filter((value, index, list) => value && list.indexOf(value) === index),
+                })
+              }
+              className="w-full rounded border border-gray-300 px-3 py-2"
+            />
+          </label>
+
+          <label className="text-sm">
+            <span className="mb-1 block text-xs text-gray-500">{t('intelligencePage.config.llmProvider')}</span>
+            <select
+              value={draftConfig.llm.provider}
+              onChange={(event) => {
+                const nextProvider = event.target.value as IntelligenceLlmProvider;
+                const defaults = PROVIDER_DEFAULTS[nextProvider];
+                const nextModel = PROVIDER_MODELS[nextProvider].includes(draftConfig.llm.model)
+                  ? draftConfig.llm.model
+                  : defaults.model;
+                onConfigChange({
+                  ...draftConfig,
+                  llm: {
+                    ...draftConfig.llm,
+                    provider: nextProvider,
+                    model: nextModel,
+                    baseUrl: defaults.baseUrl,
+                  },
+                });
+              }}
+              aria-label={t('intelligencePage.config.llmProvider')}
+              className="w-full rounded border border-gray-300 px-3 py-2"
+            >
+              <option value="ollama">ollama</option>
+              <option value="openai">openai</option>
+              <option value="mock">mock</option>
+            </select>
+          </label>
+
+          <label className="text-sm">
+            <span className="mb-1 block text-xs text-gray-500">{t('intelligencePage.config.llmModel')}</span>
+            <select
+              value={draftConfig.llm.model}
+              onChange={(event) =>
+                onConfigChange({ ...draftConfig, llm: { ...draftConfig.llm, model: event.target.value } })
+              }
+              aria-label={t('intelligencePage.config.llmModel')}
+              className="w-full rounded border border-gray-300 px-3 py-2"
+            >
+              {llmModelOptions.map((modelName) => (
+                <option key={modelName} value={modelName}>
+                  {modelName}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="text-sm">
+            <span className="mb-1 block text-xs text-gray-500">{t('intelligencePage.config.llmBaseUrl')}</span>
+            <input
+              value={draftConfig.llm.baseUrl}
+              onChange={(event) =>
+                onConfigChange({ ...draftConfig, llm: { ...draftConfig.llm, baseUrl: event.target.value } })
+              }
+              className="w-full rounded border border-gray-300 px-3 py-2"
+            />
+          </label>
+
+          <label className="text-sm">
+            <span className="mb-1 block text-xs text-gray-500">{t('intelligencePage.config.llmApiKey')}</span>
+            <input
+              type="password"
+              autoComplete="off"
+              value={draftConfig.llm.apiKey}
+              onChange={(event) =>
+                onConfigChange({ ...draftConfig, llm: { ...draftConfig.llm, apiKey: event.target.value } })
+              }
+              className="w-full rounded border border-gray-300 px-3 py-2"
+            />
+          </label>
+
+          <label className="text-sm md:col-span-2">
+            <span className="mb-1 block text-xs text-gray-500">{t('intelligencePage.config.llmSystemPrompt')}</span>
+            <textarea
+              value={draftConfig.llm.systemPrompt}
+              onChange={(event) =>
+                onConfigChange({ ...draftConfig, llm: { ...draftConfig.llm, systemPrompt: event.target.value } })
+              }
+              rows={4}
+              placeholder={t('intelligencePage.config.llmSystemPromptPlaceholder')}
+              className="w-full rounded border border-gray-300 px-3 py-2 font-mono text-xs"
+            />
+          </label>
+
+          <label className="text-sm md:col-span-2">
+            <span className="mb-1 block text-xs text-gray-500">
+              {t('intelligencePage.config.llmUserPromptTemplate')}
+            </span>
+            <textarea
+              value={draftConfig.llm.userPromptTemplate}
+              onChange={(event) =>
+                onConfigChange({
+                  ...draftConfig,
+                  llm: { ...draftConfig.llm, userPromptTemplate: event.target.value },
+                })
+              }
+              rows={8}
+              placeholder={t('intelligencePage.config.llmUserPromptTemplatePlaceholder')}
+              className="w-full rounded border border-gray-300 px-3 py-2 font-mono text-xs"
+            />
+            <p className="mt-1 text-xs text-gray-500">{t('intelligencePage.config.llmPromptTemplateHint')}</p>
+          </label>
+
+          <label className="text-sm">
+            <span className="mb-1 block text-xs text-gray-500">{t('intelligencePage.config.maxConcurrency')}</span>
+            <input
+              type="number"
+              min={1}
+              max={16}
+              value={draftConfig.llm.maxConcurrency}
+              onChange={(event) =>
+                onConfigChange({
+                  ...draftConfig,
+                  llm: {
+                    ...draftConfig.llm,
+                    maxConcurrency: Math.max(1, Math.min(16, Number(event.target.value) || 1)),
+                  },
+                })
+              }
+              className="w-full rounded border border-gray-300 px-3 py-2"
+            />
+          </label>
+
+          <label className="text-sm">
+            <span className="mb-1 block text-xs text-gray-500">{t('intelligencePage.config.lookbackHours')}</span>
+            <input
+              type="number"
+              min={1}
+              value={draftConfig.catalyst.lookbackHours}
+              onChange={(event) =>
+                onConfigChange({
+                  ...draftConfig,
+                  catalyst: {
+                    ...draftConfig.catalyst,
+                    lookbackHours: Math.max(1, Number(event.target.value) || 1),
+                  },
+                })
+              }
+              className="w-full rounded border border-gray-300 px-3 py-2"
+            />
+          </label>
+
+          <label className="text-sm">
+            <span className="mb-1 block text-xs text-gray-500">{t('intelligencePage.config.minScore')}</span>
+            <input
+              type="number"
+              step={0.01}
+              min={0}
+              max={1}
+              value={draftConfig.opportunity.minOpportunityScore}
+              onChange={(event) =>
+                onConfigChange({
+                  ...draftConfig,
+                  opportunity: {
+                    ...draftConfig.opportunity,
+                    minOpportunityScore: Math.max(0, Math.min(1, Number(event.target.value) || 0)),
+                  },
+                })
+              }
+              className="w-full rounded border border-gray-300 px-3 py-2"
+            />
+          </label>
+
+          <label className="text-sm">
+            <span className="mb-1 block text-xs text-gray-500">Enable fallback scraping</span>
+            <input
+              type="checkbox"
+              checked={draftConfig.sources.scrapingEnabled}
+              onChange={(event) =>
+                onConfigChange({
+                  ...draftConfig,
+                  sources: { ...draftConfig.sources, scrapingEnabled: event.target.checked },
+                })
+              }
+              className="h-5 w-5 rounded border border-gray-300"
+            />
+          </label>
+
+          <label className="text-sm">
+            <span className="mb-1 block text-xs text-gray-500">Allowed domains (comma-separated)</span>
+            <input
+              value={draftConfig.sources.allowedDomains.join(', ')}
+              onChange={(event) =>
+                onConfigChange({
+                  ...draftConfig,
+                  sources: {
+                    ...draftConfig.sources,
+                    allowedDomains: event.target.value
+                      .split(',')
+                      .map((value) => value.trim().toLowerCase())
+                      .filter((value, index, list) => value && list.indexOf(value) === index),
+                  },
+                })
+              }
+              className="w-full rounded border border-gray-300 px-3 py-2"
+            />
+          </label>
+
+          <label className="text-sm">
+            <span className="mb-1 block text-xs text-gray-500">Binary event window (days)</span>
+            <input
+              type="number"
+              min={1}
+              max={30}
+              value={draftConfig.calendar.binaryEventWindowDays}
+              onChange={(event) =>
+                onConfigChange({
+                  ...draftConfig,
+                  calendar: {
+                    ...draftConfig.calendar,
+                    binaryEventWindowDays: Math.max(1, Math.min(30, Number(event.target.value) || 1)),
+                  },
+                })
+              }
+              className="w-full rounded border border-gray-300 px-3 py-2"
+            />
+          </label>
+        </div>
+
+        <div className="mt-4 flex flex-wrap gap-2">
+          <Button onClick={onSave} disabled={isSaving}>
+            {isSaving ? t('intelligencePage.config.saving') : t('intelligencePage.config.save')}
+          </Button>
+          <Button variant="secondary" onClick={onTestProvider}>
+            {t('intelligencePage.config.testProvider')}
+          </Button>
+        </div>
+
+        {testProviderResult && (
+          <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+            {t('intelligencePage.config.providerResult', {
+              provider: testProviderResult.provider,
+              status: testProviderResult.available ? 'OK' : 'UNAVAILABLE',
+            })}
+          </p>
+        )}
+
+        {providersStatus && (
+          <div className="mt-3 space-y-1 text-xs text-gray-500">
+            {providersStatus.map((provider) => (
+              <p key={provider.provider}>
+                {provider.provider}: {provider.available ? 'OK' : 'UNAVAILABLE'}
+                {provider.detail ? ` (${provider.detail})` : ''}
+              </p>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/web-ui/src/components/domain/strategy/StrategyPluginCard.tsx
+++ b/web-ui/src/components/domain/strategy/StrategyPluginCard.tsx
@@ -1,0 +1,118 @@
+import Card, { CardContent, CardHeader, CardTitle } from '@/components/common/Card';
+import Badge from '@/components/common/Badge';
+import type { StrategyPluginDefinition, StrategyPluginResolvedState } from '@/features/strategy/types';
+
+interface StrategyPluginCardProps {
+  plugin: StrategyPluginResolvedState;
+  definition?: StrategyPluginDefinition;
+}
+
+function formatValue(value: unknown): string {
+  if (value == null) return '—';
+  if (Array.isArray(value)) return value.join(', ');
+  if (typeof value === 'boolean') return value ? 'Yes' : 'No';
+  return String(value);
+}
+
+function renderCapabilityGroup(title: string, values: string[]) {
+  if (!values.length) return null;
+  return (
+    <div>
+      <p className="text-xs font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-300">{title}</p>
+      <div className="mt-2 flex flex-wrap gap-2">
+        {values.map((value) => (
+          <Badge key={`${title}-${value}`} variant="default">
+            {value}
+          </Badge>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default function StrategyPluginCard({ plugin, definition }: StrategyPluginCardProps) {
+  const sections = plugin.readOnlySections.length ? plugin.readOnlySections : definition?.readOnlySections ?? [];
+
+  return (
+    <Card variant="bordered" className="h-full">
+      <CardHeader className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div>
+          <CardTitle>{plugin.displayName}</CardTitle>
+          <p className="mt-1 text-sm text-gray-600 dark:text-gray-300">
+            {plugin.description || definition?.description || 'No description available.'}
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Badge variant={plugin.enabled ? 'success' : 'default'}>
+            {plugin.enabled ? 'Enabled' : 'Disabled'}
+          </Badge>
+          <Badge variant="default">{plugin.phase}</Badge>
+          {plugin.enabled !== plugin.defaultEnabled ? (
+            <Badge variant="warning">Override</Badge>
+          ) : null}
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid gap-3 md:grid-cols-2">
+          {renderCapabilityGroup('Provides', plugin.provides)}
+          {renderCapabilityGroup('Requires', plugin.requires)}
+          {renderCapabilityGroup('Modifies', plugin.modifies)}
+          {renderCapabilityGroup('Conflicts', plugin.conflicts)}
+          {renderCapabilityGroup('Depends On', plugin.dependsOn)}
+        </div>
+
+        {plugin.values.length ? (
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-gray-200 text-sm dark:divide-gray-700">
+              <thead>
+                <tr className="text-left text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                  <th className="py-2 pr-4">Field</th>
+                  <th className="py-2 pr-4">Default</th>
+                  <th className="py-2 pr-4">Effective</th>
+                  <th className="py-2">Source</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 dark:divide-gray-800">
+                {plugin.values.map((value) => (
+                  <tr key={`${plugin.id}-${value.key}`} className="align-top">
+                    <td className="py-3 pr-4">
+                      <div className="font-medium text-gray-900 dark:text-gray-100">{value.label}</div>
+                      {value.description ? (
+                        <div className="mt-1 text-xs text-gray-500 dark:text-gray-400">{value.description}</div>
+                      ) : null}
+                    </td>
+                    <td className="py-3 pr-4 text-gray-700 dark:text-gray-300">{formatValue(value.defaultValue)}</td>
+                    <td className="py-3 pr-4 text-gray-900 dark:text-gray-100">{formatValue(value.effectiveValue)}</td>
+                    <td className="py-3">
+                      <Badge variant={value.source === 'root_override' ? 'warning' : 'default'}>
+                        {value.source === 'root_override' ? 'Root override' : 'Plugin default'}
+                      </Badge>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <p className="text-sm text-gray-500 dark:text-gray-400">No configuration fields exposed.</p>
+        )}
+
+        {sections.length ? (
+          <div className="grid gap-3 md:grid-cols-2">
+            {sections.map((section) => (
+              <div
+                key={`${plugin.id}-${section.title}`}
+                className="rounded-lg border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-900/40"
+              >
+                <p className="text-xs font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-300">
+                  {section.title}
+                </p>
+                <p className="mt-2 text-sm text-gray-700 dark:text-gray-300">{section.body}</p>
+              </div>
+            ))}
+          </div>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}

--- a/web-ui/src/components/domain/strategy/StrategyPluginCard.tsx
+++ b/web-ui/src/components/domain/strategy/StrategyPluginCard.tsx
@@ -5,6 +5,8 @@ import type { StrategyPluginDefinition, StrategyPluginResolvedState } from '@/fe
 interface StrategyPluginCardProps {
   plugin: StrategyPluginResolvedState;
   definition?: StrategyPluginDefinition;
+  isOpen: boolean;
+  onToggle: () => void;
 }
 
 function formatValue(value: unknown): string {
@@ -30,89 +32,108 @@ function renderCapabilityGroup(title: string, values: string[]) {
   );
 }
 
-export default function StrategyPluginCard({ plugin, definition }: StrategyPluginCardProps) {
+export default function StrategyPluginCard({
+  plugin,
+  definition,
+  isOpen,
+  onToggle,
+}: StrategyPluginCardProps) {
   const sections = plugin.readOnlySections.length ? plugin.readOnlySections : definition?.readOnlySections ?? [];
 
   return (
     <Card variant="bordered" className="h-full">
-      <CardHeader className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
-        <div>
-          <CardTitle>{plugin.displayName}</CardTitle>
-          <p className="mt-1 text-sm text-gray-600 dark:text-gray-300">
-            {plugin.description || definition?.description || 'No description available.'}
-          </p>
-        </div>
-        <div className="flex flex-wrap gap-2">
-          <Badge variant={plugin.enabled ? 'success' : 'default'}>
-            {plugin.enabled ? 'Enabled' : 'Disabled'}
-          </Badge>
-          <Badge variant="default">{plugin.phase}</Badge>
-          {plugin.enabled !== plugin.defaultEnabled ? (
-            <Badge variant="warning">Override</Badge>
-          ) : null}
-        </div>
+      <CardHeader>
+        <button
+          type="button"
+          onClick={onToggle}
+          aria-expanded={isOpen}
+          className="flex w-full flex-col gap-3 text-left md:flex-row md:items-start md:justify-between"
+        >
+          <div>
+            <div className="flex items-center gap-3">
+              <CardTitle>{plugin.displayName}</CardTitle>
+              <span className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                {isOpen ? 'Collapse' : 'Expand'}
+              </span>
+            </div>
+            <p className="mt-1 text-sm text-gray-600 dark:text-gray-300">
+              {plugin.description || definition?.description || 'No description available.'}
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Badge variant={plugin.enabled ? 'success' : 'default'}>
+              {plugin.enabled ? 'Enabled' : 'Disabled'}
+            </Badge>
+            <Badge variant="default">{plugin.phase}</Badge>
+            {plugin.enabled !== plugin.defaultEnabled ? (
+              <Badge variant="warning">Override</Badge>
+            ) : null}
+          </div>
+        </button>
       </CardHeader>
-      <CardContent className="space-y-4">
-        <div className="grid gap-3 md:grid-cols-2">
-          {renderCapabilityGroup('Provides', plugin.provides)}
-          {renderCapabilityGroup('Requires', plugin.requires)}
-          {renderCapabilityGroup('Modifies', plugin.modifies)}
-          {renderCapabilityGroup('Conflicts', plugin.conflicts)}
-          {renderCapabilityGroup('Depends On', plugin.dependsOn)}
-        </div>
-
-        {plugin.values.length ? (
-          <div className="overflow-x-auto">
-            <table className="min-w-full divide-y divide-gray-200 text-sm dark:divide-gray-700">
-              <thead>
-                <tr className="text-left text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
-                  <th className="py-2 pr-4">Field</th>
-                  <th className="py-2 pr-4">Default</th>
-                  <th className="py-2 pr-4">Effective</th>
-                  <th className="py-2">Source</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-gray-100 dark:divide-gray-800">
-                {plugin.values.map((value) => (
-                  <tr key={`${plugin.id}-${value.key}`} className="align-top">
-                    <td className="py-3 pr-4">
-                      <div className="font-medium text-gray-900 dark:text-gray-100">{value.label}</div>
-                      {value.description ? (
-                        <div className="mt-1 text-xs text-gray-500 dark:text-gray-400">{value.description}</div>
-                      ) : null}
-                    </td>
-                    <td className="py-3 pr-4 text-gray-700 dark:text-gray-300">{formatValue(value.defaultValue)}</td>
-                    <td className="py-3 pr-4 text-gray-900 dark:text-gray-100">{formatValue(value.effectiveValue)}</td>
-                    <td className="py-3">
-                      <Badge variant={value.source === 'root_override' ? 'warning' : 'default'}>
-                        {value.source === 'root_override' ? 'Root override' : 'Plugin default'}
-                      </Badge>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        ) : (
-          <p className="text-sm text-gray-500 dark:text-gray-400">No configuration fields exposed.</p>
-        )}
-
-        {sections.length ? (
+      {isOpen ? (
+        <CardContent className="space-y-4">
           <div className="grid gap-3 md:grid-cols-2">
-            {sections.map((section) => (
-              <div
-                key={`${plugin.id}-${section.title}`}
-                className="rounded-lg border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-900/40"
-              >
-                <p className="text-xs font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-300">
-                  {section.title}
-                </p>
-                <p className="mt-2 text-sm text-gray-700 dark:text-gray-300">{section.body}</p>
-              </div>
-            ))}
+            {renderCapabilityGroup('Provides', plugin.provides)}
+            {renderCapabilityGroup('Requires', plugin.requires)}
+            {renderCapabilityGroup('Modifies', plugin.modifies)}
+            {renderCapabilityGroup('Conflicts', plugin.conflicts)}
+            {renderCapabilityGroup('Depends On', plugin.dependsOn)}
           </div>
-        ) : null}
-      </CardContent>
+
+          {plugin.values.length ? (
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y divide-gray-200 text-sm dark:divide-gray-700">
+                <thead>
+                  <tr className="text-left text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                    <th className="py-2 pr-4">Field</th>
+                    <th className="py-2 pr-4">Default</th>
+                    <th className="py-2 pr-4">Effective</th>
+                    <th className="py-2">Source</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-100 dark:divide-gray-800">
+                  {plugin.values.map((value) => (
+                    <tr key={`${plugin.id}-${value.key}`} className="align-top">
+                      <td className="py-3 pr-4">
+                        <div className="font-medium text-gray-900 dark:text-gray-100">{value.label}</div>
+                        {value.description ? (
+                          <div className="mt-1 text-xs text-gray-500 dark:text-gray-400">{value.description}</div>
+                        ) : null}
+                      </td>
+                      <td className="py-3 pr-4 text-gray-700 dark:text-gray-300">{formatValue(value.defaultValue)}</td>
+                      <td className="py-3 pr-4 text-gray-900 dark:text-gray-100">{formatValue(value.effectiveValue)}</td>
+                      <td className="py-3">
+                        <Badge variant={value.source === 'root_override' ? 'warning' : 'default'}>
+                          {value.source === 'root_override' ? 'Root override' : 'Plugin default'}
+                        </Badge>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <p className="text-sm text-gray-500 dark:text-gray-400">No configuration fields exposed.</p>
+          )}
+
+          {sections.length ? (
+            <div className="grid gap-3 md:grid-cols-2">
+              {sections.map((section) => (
+                <div
+                  key={`${plugin.id}-${section.title}`}
+                  className="rounded-lg border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-900/40"
+                >
+                  <p className="text-xs font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-300">
+                    {section.title}
+                  </p>
+                  <p className="mt-2 text-sm text-gray-700 dark:text-gray-300">{section.body}</p>
+                </div>
+              ))}
+            </div>
+          ) : null}
+        </CardContent>
+      ) : null}
     </Card>
   );
 }

--- a/web-ui/src/components/domain/strategy/StrategyPresets.tsx
+++ b/web-ui/src/components/domain/strategy/StrategyPresets.tsx
@@ -2,9 +2,23 @@
  * Strategy Presets Component
  * Provides beginner-friendly preset configurations
  */
-import { Strategy } from '@/features/strategy/types';
+import {
+  Strategy,
+  StrategyFilt,
+  StrategyManage,
+  StrategyRisk,
+  StrategySignals,
+} from '@/features/strategy/types';
 import Card, { CardHeader, CardTitle, CardContent } from '@/components/common/Card';
 import Button from '@/components/common/Button';
+
+/** Partial overrides a preset can apply. Only top-level sections and their partial fields are covered. */
+export interface StrategyPresetValues {
+  risk?: Partial<StrategyRisk>;
+  signals?: Partial<StrategySignals>;
+  universe?: { filt?: Partial<StrategyFilt> };
+  manage?: Partial<StrategyManage>;
+}
 
 export interface StrategyPreset {
   id: string;
@@ -12,7 +26,7 @@ export interface StrategyPreset {
   description: string;
   icon: string;
   level: 'conservative' | 'balanced' | 'aggressive';
-  values: Partial<Strategy>;
+  values: StrategyPresetValues;
 }
 
 export const momentumPresets: StrategyPreset[] = [
@@ -29,7 +43,7 @@ export const momentumPresets: StrategyPreset[] = [
         kAtr: 2.5,
         minRr: 2.5,
         maxFeeRiskPct: 0.15,
-      } as any,
+      },
       signals: {
         breakoutLookback: 60,
         pullbackMa: 20,
@@ -40,13 +54,13 @@ export const momentumPresets: StrategyPreset[] = [
           maxAtrPct: 12.0, // 12%
           requireTrendOk: true,
           requireRsPositive: true,
-        } as any,
-      } as any,
+        },
+      },
       manage: {
         breakevenAtR: 1,
         trailAfterR: 2,
         maxHoldingDays: 20,
-      } as any,
+      },
     },
   },
   {
@@ -62,7 +76,7 @@ export const momentumPresets: StrategyPreset[] = [
         kAtr: 2.0,
         minRr: 2.0,
         maxFeeRiskPct: 0.20,
-      } as any,
+      },
       signals: {
         breakoutLookback: 50,
         pullbackMa: 20,
@@ -73,13 +87,13 @@ export const momentumPresets: StrategyPreset[] = [
           maxAtrPct: 15.0, // 15%
           requireTrendOk: true,
           requireRsPositive: false,
-        } as any,
-      } as any,
+        },
+      },
       manage: {
         breakevenAtR: 1,
         trailAfterR: 2,
         maxHoldingDays: 20,
-      } as any,
+      },
     },
   },
   {
@@ -95,7 +109,7 @@ export const momentumPresets: StrategyPreset[] = [
         kAtr: 1.5,
         minRr: 1.5,
         maxFeeRiskPct: 0.25,
-      } as any,
+      },
       signals: {
         breakoutLookback: 40,
         pullbackMa: 20,
@@ -106,13 +120,13 @@ export const momentumPresets: StrategyPreset[] = [
           maxAtrPct: 18.0, // 18%
           requireTrendOk: false,
           requireRsPositive: false,
-        } as any,
-      } as any,
+        },
+      },
       manage: {
         breakevenAtR: 1,
         trailAfterR: 2.5,
         maxHoldingDays: 25,
-      } as any,
+      },
     },
   },
 ];

--- a/web-ui/src/components/domain/workspace/PortfolioTable.tsx
+++ b/web-ui/src/components/domain/workspace/PortfolioTable.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo } from 'react';
+import { useModal } from '@/hooks/useModal';
 import { useLocation } from 'react-router-dom';
 import DataTable, { type DataTableColumn } from '@/components/common/DataTable';
 import Button from '@/components/common/Button';
@@ -58,26 +59,20 @@ export default function PortfolioTable() {
 
   const positionsQuery = usePositions('open');
   const ordersQuery = useOrders('pending');
-  const positions = positionsQuery.data ?? [];
-  const orders = ordersQuery.data ?? [];
   const isLoading = positionsQuery.isLoading || ordersQuery.isLoading;
   const isReady = positionsQuery.isFetched && ordersQuery.isFetched;
   const isError = positionsQuery.isError || ordersQuery.isError;
 
-  const [selectedPosition, setSelectedPosition] = useState<PositionWithMetrics | null>(null);
-  const [selectedPendingOrder, setSelectedPendingOrder] = useState<Order | null>(null);
-  const [showUpdateStopModal, setShowUpdateStopModal] = useState(false);
-  const [showCloseModal, setShowCloseModal] = useState(false);
-  const [showFillOrderModal, setShowFillOrderModal] = useState(false);
+  const updateStopModal = useModal<PositionWithMetrics>();
+  const closeModal = useModal<PositionWithMetrics>();
+  const fillOrderModal = useModal<Order>();
 
-  const updateStopMutation = useUpdateStopMutation(() => {
-    setShowUpdateStopModal(false);
-    setSelectedPosition(null);
-  });
-  const closePositionMutation = useClosePositionMutation(() => {
-    setShowCloseModal(false);
-    setSelectedPosition(null);
-  });
+  const { open: openUpdateStop, close: closeUpdateStop } = updateStopModal;
+  const { open: openClosePosition, close: closeClosePosition } = closeModal;
+  const { open: openFillOrder, close: closeFillOrder } = fillOrderModal;
+
+  const updateStopMutation = useUpdateStopMutation(() => updateStopModal.close());
+  const closePositionMutation = useClosePositionMutation(() => closeModal.close());
   const watchlistQuery = useWatchlist();
   const watchSymbolMutation = useWatchSymbolMutation();
   const unwatchSymbolMutation = useUnwatchSymbolMutation();
@@ -111,13 +106,12 @@ export default function PortfolioTable() {
     unwatchSymbolMutation.mutate(normalizedTicker);
   };
 
-  const fillOrderMutation = useFillOrderMutation(() => {
-    setShowFillOrderModal(false);
-    setSelectedPendingOrder(null);
-  });
+  const fillOrderMutation = useFillOrderMutation(() => fillOrderModal.close());
   const cancelOrderMutation = useCancelOrderMutation();
 
   const rows = useMemo<PortfolioRow[]>(() => {
+    const positions = positionsQuery.data ?? [];
+    const orders = ordersQuery.data ?? [];
     const byPositionId = new Map<string, { stopOrder?: Order; targetOrder?: Order }>();
     const standaloneOrders: Order[] = [];
 
@@ -178,7 +172,7 @@ export default function PortfolioTable() {
     }));
 
     return [...positionRows, ...standaloneRows];
-  }, [orders, positions]);
+  }, [positionsQuery.data, ordersQuery.data]);
 
   useEffect(() => {
     const searchParams = new URLSearchParams(location.search);
@@ -217,15 +211,13 @@ export default function PortfolioTable() {
         return;
       }
 
-      setSelectedPosition(matchedPosition);
-      setSelectedPendingOrder(null);
-      setShowFillOrderModal(false);
+      closeFillOrder();
       if (action === 'update-stop') {
-        setShowCloseModal(false);
-        setShowUpdateStopModal(true);
+        closeClosePosition();
+        openUpdateStop(matchedPosition);
       } else {
-        setShowUpdateStopModal(false);
-        setShowCloseModal(true);
+        closeUpdateStop();
+        openClosePosition(matchedPosition);
       }
       clearPortfolioIntent();
       return;
@@ -243,17 +235,15 @@ export default function PortfolioTable() {
         return;
       }
 
-      setSelectedPendingOrder(matchedOrder);
-      setSelectedPosition(null);
-      setShowUpdateStopModal(false);
-      setShowCloseModal(false);
-      setShowFillOrderModal(true);
+      closeUpdateStop();
+      closeClosePosition();
+      openFillOrder(matchedOrder);
       clearPortfolioIntent();
       return;
     }
 
     clearPortfolioIntent();
-  }, [isReady, location, rows, setSelectedTicker]);
+  }, [isReady, location, rows, setSelectedTicker, openUpdateStop, closeUpdateStop, openClosePosition, closeClosePosition, openFillOrder, closeFillOrder]);
 
   const columns: DataTableColumn<PortfolioRow>[] = [
     {
@@ -349,8 +339,7 @@ export default function PortfolioTable() {
               size="sm"
               variant="primary"
               onClick={() => {
-                setSelectedPosition(row.position);
-                setShowUpdateStopModal(true);
+                updateStopModal.open(row.position ?? undefined);
               }}
             >
               {t('positionsPage.updateStop')}
@@ -359,8 +348,7 @@ export default function PortfolioTable() {
               size="sm"
               variant="secondary"
               onClick={() => {
-                setSelectedPosition(row.position);
-                setShowCloseModal(true);
+                closeModal.open(row.position ?? undefined);
               }}
             >
               {t('positionsPage.closePosition')}
@@ -374,8 +362,7 @@ export default function PortfolioTable() {
               disabled={!row.order || cancelOrderMutation.isPending || fillOrderMutation.isPending}
               onClick={() => {
                 if (!row.order) return;
-                setSelectedPendingOrder(row.order);
-                setShowFillOrderModal(true);
+                fillOrderModal.open(row.order);
               }}
             >
               {t('common.actions.fillOrder')}
@@ -423,16 +410,13 @@ export default function PortfolioTable() {
         onRowClick={(row) => setSelectedTicker(row.ticker)}
       />
 
-      {showUpdateStopModal && selectedPosition ? (
+      {updateStopModal.isOpen && updateStopModal.data ? (
         <UpdateStopModalForm
-          position={selectedPosition}
-          onClose={() => {
-            setShowUpdateStopModal(false);
-            setSelectedPosition(null);
-          }}
+          position={updateStopModal.data}
+          onClose={updateStopModal.close}
           onSubmit={(request) =>
             updateStopMutation.mutate({
-              positionId: selectedPosition.positionId!,
+              positionId: updateStopModal.data!.positionId!,
               request,
             })
           }
@@ -441,16 +425,13 @@ export default function PortfolioTable() {
         />
       ) : null}
 
-      {showCloseModal && selectedPosition ? (
+      {closeModal.isOpen && closeModal.data ? (
         <ClosePositionModalForm
-          position={selectedPosition}
-          onClose={() => {
-            setShowCloseModal(false);
-            setSelectedPosition(null);
-          }}
+          position={closeModal.data}
+          onClose={closeModal.close}
           onSubmit={(request) =>
             closePositionMutation.mutate({
-              positionId: selectedPosition.positionId!,
+              positionId: closeModal.data!.positionId!,
               request,
             })
           }
@@ -459,16 +440,13 @@ export default function PortfolioTable() {
         />
       ) : null}
 
-      {showFillOrderModal && selectedPendingOrder ? (
+      {fillOrderModal.isOpen && fillOrderModal.data ? (
         <FillOrderModalForm
-          order={selectedPendingOrder}
-          onClose={() => {
-            setShowFillOrderModal(false);
-            setSelectedPendingOrder(null);
-          }}
+          order={fillOrderModal.data}
+          onClose={fillOrderModal.close}
           onSubmit={(request) =>
             fillOrderMutation.mutate({
-              orderId: selectedPendingOrder.orderId,
+              orderId: fillOrderModal.data!.orderId,
               request,
             })
           }

--- a/web-ui/src/components/domain/workspace/ScreenerInboxPanel.tsx
+++ b/web-ui/src/components/domain/workspace/ScreenerInboxPanel.tsx
@@ -113,7 +113,7 @@ export default function ScreenerInboxPanel({
       minHistory: strategySignals?.minHistory ?? DEFAULT_CONFIG.indicators.minHistory,
     });
   }, [
-    screenerMutation.mutate,
+    screenerMutation,
     selectedUniverse,
     topN,
     minPrice,

--- a/web-ui/src/content/intelligenceProviders.ts
+++ b/web-ui/src/content/intelligenceProviders.ts
@@ -1,0 +1,16 @@
+import type { IntelligenceLlmProvider } from '@/features/intelligence/types';
+
+export const PROVIDER_MODELS: Record<IntelligenceLlmProvider, string[]> = {
+  ollama: ['mistral:7b-instruct', 'llama3.1:8b-instruct', 'qwen2.5:7b-instruct'],
+  openai: ['gpt-4o-mini', 'gpt-4.1-mini', 'gpt-4.1', 'o4-mini'],
+  mock: ['mock-classifier'],
+};
+
+export const PROVIDER_DEFAULTS: Record<
+  IntelligenceLlmProvider,
+  { model: string; baseUrl: string }
+> = {
+  ollama: { model: 'mistral:7b-instruct', baseUrl: 'http://localhost:11434' },
+  openai: { model: 'gpt-4o-mini', baseUrl: 'https://api.openai.com/v1' },
+  mock: { model: 'mock-classifier', baseUrl: '' },
+};

--- a/web-ui/src/content/onboardingSteps.tsx
+++ b/web-ui/src/content/onboardingSteps.tsx
@@ -1,0 +1,81 @@
+import type { ReactNode } from 'react';
+import { CheckCircle, Calendar, Search, ShoppingCart } from 'lucide-react';
+import OnboardingStrategySetupStep from '@/components/domain/onboarding/OnboardingStrategySetupStep';
+import { t } from '@/i18n/t';
+
+export type OnboardingStep = {
+  title: string;
+  description: string;
+  icon: typeof CheckCircle;
+  content: ReactNode;
+};
+
+export const ONBOARDING_STEPS: OnboardingStep[] = [
+  {
+    title: t('onboardingPage.steps.welcome.title'),
+    description: t('onboardingPage.steps.welcome.description'),
+    icon: CheckCircle,
+    content: (
+      <div className="space-y-4 text-sm text-gray-700">
+        <p>{t('onboardingPage.steps.welcome.body')}</p>
+        <ol className="list-decimal space-y-2 pl-5">
+          <li>{t('onboardingPage.steps.welcome.items.configure')}</li>
+          <li>{t('onboardingPage.steps.welcome.items.review')}</li>
+          <li>{t('onboardingPage.steps.welcome.items.act')}</li>
+          <li>{t('onboardingPage.steps.welcome.items.verify')}</li>
+        </ol>
+      </div>
+    ),
+  },
+  {
+    title: t('onboardingPage.steps.strategy.title'),
+    description: t('onboardingPage.steps.strategy.description'),
+    icon: CheckCircle,
+    content: <OnboardingStrategySetupStep />,
+  },
+  {
+    title: t('onboardingPage.steps.dailyReview.title'),
+    description: t('onboardingPage.steps.dailyReview.description'),
+    icon: Calendar,
+    content: (
+      <div className="space-y-3 text-sm text-gray-700">
+        <p>{t('onboardingPage.steps.dailyReview.body')}</p>
+        <ul className="list-disc space-y-1 pl-5">
+          <li>{t('onboardingPage.steps.dailyReview.items.candidates')}</li>
+          <li>{t('onboardingPage.steps.dailyReview.items.updateStop')}</li>
+          <li>{t('onboardingPage.steps.dailyReview.items.close')}</li>
+          <li>{t('onboardingPage.steps.dailyReview.items.hold')}</li>
+        </ul>
+      </div>
+    ),
+  },
+  {
+    title: t('onboardingPage.steps.action.title'),
+    description: t('onboardingPage.steps.action.description'),
+    icon: ShoppingCart,
+    content: (
+      <div className="space-y-3 text-sm text-gray-700">
+        <p>{t('onboardingPage.steps.action.body')}</p>
+        <ul className="list-disc space-y-1 pl-5">
+          <li>{t('onboardingPage.steps.action.items.createOrder')}</li>
+          <li>{t('onboardingPage.steps.action.items.updatePosition')}</li>
+          <li>{t('onboardingPage.steps.action.items.noAction')}</li>
+        </ul>
+      </div>
+    ),
+  },
+  {
+    title: t('onboardingPage.steps.verify.title'),
+    description: t('onboardingPage.steps.verify.description'),
+    icon: Search,
+    content: (
+      <div className="space-y-3 text-sm text-gray-700">
+        <p>{t('onboardingPage.steps.verify.body')}</p>
+        <ul className="list-disc space-y-1 pl-5">
+          <li>{t('onboardingPage.steps.verify.items.orders')}</li>
+          <li>{t('onboardingPage.steps.verify.items.positions')}</li>
+        </ul>
+      </div>
+    ),
+  },
+];

--- a/web-ui/src/features/dailyReview/useDailyReviewPageState.ts
+++ b/web-ui/src/features/dailyReview/useDailyReviewPageState.ts
@@ -1,0 +1,149 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useUnwatchSymbolMutation, useWatchSymbolMutation, useWatchlist } from '@/features/watchlist/hooks';
+import type { WatchItem } from '@/features/watchlist/types';
+import type { DailyReviewCandidate } from '@/features/dailyReview/types';
+import { useLocalStorage } from '@/hooks/useLocalStorage';
+
+const MOBILE_LAYOUT_MEDIA_QUERY = '(max-width: 767px)';
+
+function getMobileLayoutMatch() {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return false;
+  }
+  return window.matchMedia(MOBILE_LAYOUT_MEDIA_QUERY).matches;
+}
+
+export interface DailyReviewPageState {
+  expandedSections: { candidates: boolean; hold: boolean; update: boolean; close: boolean };
+  toggleSection: (section: 'candidates' | 'hold' | 'update' | 'close') => void;
+  insightCandidate: DailyReviewCandidate | null;
+  setInsightCandidate: (candidate: DailyReviewCandidate | null) => void;
+  showCreateOrderModal: boolean;
+  setShowCreateOrderModal: (show: boolean) => void;
+  selectedCandidate: DailyReviewCandidate | null;
+  setSelectedCandidate: (candidate: DailyReviewCandidate | null) => void;
+  dismissedReadinessBlocker: boolean;
+  setDismissedReadinessBlocker: (dismissed: boolean) => void;
+  isCompactMobileLayout: boolean;
+  watchItemsByTicker: Map<string, WatchItem>;
+  watchPending: boolean;
+  handleWatch: (ticker: string, currentPrice: number | null | undefined, source: string) => void;
+  handleUnwatch: (ticker: string) => void;
+  openWorkspacePortfolioAction: (params: {
+    action: 'update-stop' | 'close-position';
+    ticker: string;
+    positionId: string;
+  }) => void;
+}
+
+export function useDailyReviewPageState(): DailyReviewPageState {
+  const [expandedSections, setExpandedSections] = useState({
+    candidates: true,
+    hold: false,
+    update: true,
+    close: true,
+  });
+  const [insightCandidate, setInsightCandidate] = useState<DailyReviewCandidate | null>(null);
+  const [showCreateOrderModal, setShowCreateOrderModal] = useState(false);
+  const [selectedCandidate, setSelectedCandidate] = useState<DailyReviewCandidate | null>(null);
+  const [dismissedReadinessBlocker, setDismissedReadinessBlocker] = useLocalStorage(
+    'dailyReview.dismissedReadinessBlocker',
+    false,
+    // Handle both legacy raw-string ("true") and new JSON (true) formats
+    (val) => val === true || val === 'true',
+  );
+  const [isCompactMobileLayout, setIsCompactMobileLayout] = useState(getMobileLayoutMatch);
+
+  const navigate = useNavigate();
+  const watchlistQuery = useWatchlist();
+  const watchSymbolMutation = useWatchSymbolMutation();
+  const unwatchSymbolMutation = useUnwatchSymbolMutation();
+
+  const watchItemsByTicker = useMemo(() => {
+    const map = new Map<string, WatchItem>();
+    for (const item of watchlistQuery.data ?? []) {
+      map.set(item.ticker.toUpperCase(), item);
+    }
+    return map;
+  }, [watchlistQuery.data]);
+
+  const handleWatch = useCallback(
+    (ticker: string, currentPrice: number | null | undefined, source: string) => {
+      const normalizedTicker = ticker.trim().toUpperCase();
+      if (!normalizedTicker || watchItemsByTicker.has(normalizedTicker)) {
+        return;
+      }
+      watchSymbolMutation.mutate({
+        ticker: normalizedTicker,
+        watchPrice: currentPrice ?? null,
+        currency: null,
+        source,
+      });
+    },
+    [watchItemsByTicker, watchSymbolMutation],
+  );
+
+  const handleUnwatch = useCallback(
+    (ticker: string) => {
+      const normalizedTicker = ticker.trim().toUpperCase();
+      if (!normalizedTicker || !watchItemsByTicker.has(normalizedTicker)) {
+        return;
+      }
+      unwatchSymbolMutation.mutate(normalizedTicker);
+    },
+    [watchItemsByTicker, unwatchSymbolMutation],
+  );
+
+  const watchPending = watchSymbolMutation.isPending || unwatchSymbolMutation.isPending;
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return;
+    }
+    const mediaQueryList = window.matchMedia(MOBILE_LAYOUT_MEDIA_QUERY);
+    const handleChange = (event: MediaQueryListEvent) => {
+      setIsCompactMobileLayout(event.matches);
+    };
+    setIsCompactMobileLayout(mediaQueryList.matches);
+    mediaQueryList.addEventListener('change', handleChange);
+    return () => mediaQueryList.removeEventListener('change', handleChange);
+  }, []);
+
+  const toggleSection = useCallback(
+    (section: 'candidates' | 'hold' | 'update' | 'close') => {
+      setExpandedSections((prev) => ({ ...prev, [section]: !prev[section] }));
+    },
+    [],
+  );
+
+  const openWorkspacePortfolioAction = useCallback(
+    (params: { action: 'update-stop' | 'close-position'; ticker: string; positionId: string }) => {
+      const searchParams = new URLSearchParams();
+      searchParams.set('portfolioAction', params.action);
+      searchParams.set('ticker', params.ticker);
+      searchParams.set('positionId', params.positionId);
+      navigate(`/workspace?${searchParams.toString()}`);
+    },
+    [navigate],
+  );
+
+  return {
+    expandedSections,
+    toggleSection,
+    insightCandidate,
+    setInsightCandidate,
+    showCreateOrderModal,
+    setShowCreateOrderModal,
+    selectedCandidate,
+    setSelectedCandidate,
+    dismissedReadinessBlocker,
+    setDismissedReadinessBlocker,
+    isCompactMobileLayout,
+    watchItemsByTicker,
+    watchPending,
+    handleWatch,
+    handleUnwatch,
+    openWorkspacePortfolioAction,
+  };
+}

--- a/web-ui/src/features/intelligence/useIntelligenceSymbolSetEditor.ts
+++ b/web-ui/src/features/intelligence/useIntelligenceSymbolSetEditor.ts
@@ -1,0 +1,113 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  useCreateIntelligenceSymbolSetMutation,
+  useDeleteIntelligenceSymbolSetMutation,
+  useIntelligenceSymbolSetsQuery,
+  useUpdateIntelligenceSymbolSetMutation,
+} from '@/features/intelligence/hooks';
+import type { IntelligenceSymbolSet } from '@/features/intelligence/types';
+
+function normalizeSymbols(input: string): string[] {
+  const seen = new Set<string>();
+  return input
+    .split(',')
+    .map((value) => value.trim().toUpperCase())
+    .filter((value) => {
+      if (!value || seen.has(value)) return false;
+      seen.add(value);
+      return true;
+    });
+}
+
+export interface IntelligenceSymbolSetEditorState {
+  symbolSets: IntelligenceSymbolSet[];
+  selectedSymbolSetId: string;
+  setSelectedSymbolSetId: (id: string) => void;
+  selectedSymbolSet: IntelligenceSymbolSet | undefined;
+  symbolSetName: string;
+  setSymbolSetName: (name: string) => void;
+  symbolSetSymbolsInput: string;
+  setSymbolSetSymbolsInput: (input: string) => void;
+  createSymbolSet: () => void;
+  updateSymbolSet: () => void;
+  deleteSymbolSet: (id: string) => void;
+  isCreating: boolean;
+  isUpdating: boolean;
+  isDeleting: boolean;
+}
+
+export function useIntelligenceSymbolSetEditor(): IntelligenceSymbolSetEditorState {
+  const symbolSetsQuery = useIntelligenceSymbolSetsQuery();
+  const createSymbolSetMutation = useCreateIntelligenceSymbolSetMutation();
+  const updateSymbolSetMutation = useUpdateIntelligenceSymbolSetMutation();
+  const deleteSymbolSetMutation = useDeleteIntelligenceSymbolSetMutation();
+
+  const [selectedSymbolSetId, setSelectedSymbolSetId] = useState('');
+  const [symbolSetName, setSymbolSetName] = useState('');
+  const [symbolSetSymbolsInput, setSymbolSetSymbolsInput] = useState('');
+
+  const symbolSets = symbolSetsQuery.data?.items ?? [];
+  const selectedSymbolSet = symbolSets.find((item) => item.id === selectedSymbolSetId);
+
+  useEffect(() => {
+    if (selectedSymbolSet) {
+      setSymbolSetName(selectedSymbolSet.name);
+      setSymbolSetSymbolsInput(selectedSymbolSet.symbols.join(', '));
+    }
+  }, [selectedSymbolSet]);
+
+  const createSymbolSet = useCallback(() => {
+    const symbols = normalizeSymbols(symbolSetSymbolsInput);
+    if (!symbolSetName.trim() || symbols.length === 0) return;
+    createSymbolSetMutation.mutate(
+      { name: symbolSetName.trim(), symbols },
+      {
+        onSuccess: (created) => {
+          setSelectedSymbolSetId(created.id);
+        },
+      },
+    );
+  }, [symbolSetName, symbolSetSymbolsInput, createSymbolSetMutation]);
+
+  const updateSymbolSet = useCallback(() => {
+    if (!selectedSymbolSetId) return;
+    const symbols = normalizeSymbols(symbolSetSymbolsInput);
+    if (!symbolSetName.trim() || symbols.length === 0) return;
+    updateSymbolSetMutation.mutate({
+      id: selectedSymbolSetId,
+      payload: { name: symbolSetName.trim(), symbols },
+    });
+  }, [selectedSymbolSetId, symbolSetName, symbolSetSymbolsInput, updateSymbolSetMutation]);
+
+  const deleteSymbolSet = useCallback(
+    (id: string) => {
+      deleteSymbolSetMutation.mutate(id, {
+        onSuccess: () => {
+          if (selectedSymbolSetId === id) {
+            setSelectedSymbolSetId('');
+            setSymbolSetName('');
+            setSymbolSetSymbolsInput('');
+          }
+        },
+      });
+    },
+    [selectedSymbolSetId, deleteSymbolSetMutation],
+  );
+
+  return {
+    symbolSets,
+    selectedSymbolSetId,
+    setSelectedSymbolSetId,
+    selectedSymbolSet,
+    symbolSetName,
+    setSymbolSetName,
+    symbolSetSymbolsInput,
+    setSymbolSetSymbolsInput,
+    createSymbolSet,
+    updateSymbolSet,
+    deleteSymbolSet,
+    isCreating: createSymbolSetMutation.isPending,
+    isUpdating: updateSymbolSetMutation.isPending,
+    isDeleting: deleteSymbolSetMutation.isPending,
+  };
+}

--- a/web-ui/src/features/strategy/api.ts
+++ b/web-ui/src/features/strategy/api.ts
@@ -12,9 +12,15 @@ import {
 import {
   Strategy,
   StrategyAPI,
+  StrategyPluginDefinition,
+  StrategyPluginDefinitionAPI,
+  StrategyResolvedConfig,
+  StrategyResolvedConfigAPI,
   ActiveStrategyRequestAPI,
   StrategyUpdateRequestAPI,
   transformStrategy,
+  transformStrategyPluginDefinition,
+  transformStrategyResolvedConfig,
   toStrategyCreateRequest,
   toStrategyUpdateRequest,
 } from '@/features/strategy/types';
@@ -63,6 +69,20 @@ export async function fetchStrategies(): Promise<Strategy[]> {
   return data.map(transformStrategy);
 }
 
+export async function fetchStrategyConfig(): Promise<StrategyResolvedConfig> {
+  const res = await fetch(apiUrl(API_ENDPOINTS.strategyConfig));
+  if (!res.ok) throw new Error('Failed to load strategy config');
+  const data: StrategyResolvedConfigAPI = await res.json();
+  return transformStrategyResolvedConfig(data);
+}
+
+export async function fetchStrategyPlugins(): Promise<StrategyPluginDefinition[]> {
+  const res = await fetch(apiUrl(API_ENDPOINTS.strategyPlugins));
+  if (!res.ok) throw new Error('Failed to load strategy plugins');
+  const data: StrategyPluginDefinitionAPI[] = await res.json();
+  return data.map(transformStrategyPluginDefinition);
+}
+
 export async function fetchActiveStrategy(): Promise<Strategy> {
   if (isLocalPersistenceMode()) {
     return getActiveStrategyLocal();
@@ -71,6 +91,16 @@ export async function fetchActiveStrategy(): Promise<Strategy> {
   if (!res.ok) throw new Error('Failed to load active strategy');
   const data: StrategyAPI = await res.json();
   return transformStrategy(data);
+}
+
+export async function fetchResolvedStrategyValidation(): Promise<StrategyValidationResult> {
+  const res = await fetch(apiUrl(API_ENDPOINTS.strategyValidationReadOnly));
+  if (!res.ok) {
+    const error = await res.json().catch(() => ({}));
+    throw new Error(error.detail || 'Failed to load strategy validation');
+  }
+  const data: StrategyValidationResultApi = await res.json();
+  return transformValidationResult(data);
 }
 
 export async function setActiveStrategy(strategyId: string): Promise<Strategy> {

--- a/web-ui/src/features/strategy/hooks.ts
+++ b/web-ui/src/features/strategy/hooks.ts
@@ -3,12 +3,20 @@ import {
   createStrategy,
   deleteStrategy,
   fetchActiveStrategy,
+  fetchResolvedStrategyValidation,
+  fetchStrategyConfig,
+  fetchStrategyPlugins,
   fetchStrategies,
   setActiveStrategy,
   updateStrategy,
   validateStrategy,
 } from '@/features/strategy/api';
-import type { Strategy, StrategyUpdateRequestAPI } from '@/features/strategy/types';
+import type {
+  Strategy,
+  StrategyPluginDefinition,
+  StrategyResolvedConfig,
+  StrategyUpdateRequestAPI,
+} from '@/features/strategy/types';
 import { queryKeys } from '@/lib/queryKeys';
 import { invalidateStrategyQueries } from '@/lib/queryInvalidation';
 
@@ -19,10 +27,31 @@ export function useStrategiesQuery() {
   });
 }
 
+export function useStrategyConfigQuery() {
+  return useQuery<StrategyResolvedConfig>({
+    queryKey: queryKeys.strategyConfig(),
+    queryFn: fetchStrategyConfig,
+  });
+}
+
+export function useStrategyPluginsQuery() {
+  return useQuery<StrategyPluginDefinition[]>({
+    queryKey: queryKeys.strategyPlugins(),
+    queryFn: fetchStrategyPlugins,
+  });
+}
+
 export function useActiveStrategyQuery() {
   return useQuery({
     queryKey: queryKeys.strategyActive(),
     queryFn: fetchActiveStrategy,
+  });
+}
+
+export function useResolvedStrategyValidationQuery() {
+  return useQuery({
+    queryKey: queryKeys.strategyValidationReadOnly(),
+    queryFn: fetchResolvedStrategyValidation,
   });
 }
 

--- a/web-ui/src/features/strategy/types.ts
+++ b/web-ui/src/features/strategy/types.ts
@@ -585,3 +585,254 @@ export function toStrategyCreateRequest(
     ...toStrategyUpdateRequest(base),
   };
 }
+
+export type StrategyPluginCategory =
+  | 'filters'
+  | 'ranking'
+  | 'signals'
+  | 'risk'
+  | 'qualification'
+  | 'management'
+  | 'intelligence'
+  | 'education'
+  | string;
+
+export interface StrategyPluginDocSection {
+  title: string;
+  body: string;
+}
+
+export interface StrategyPluginConfigFieldDefinition {
+  key: string;
+  label: string;
+  description?: string;
+  type?: string;
+}
+
+export interface StrategyPluginDefinition {
+  id: string;
+  category: StrategyPluginCategory;
+  displayName: string;
+  description: string;
+  enabledByDefault: boolean;
+  phase: string;
+  provides: string[];
+  requires: string[];
+  modifies: string[];
+  conflicts: string[];
+  configFields: StrategyPluginConfigFieldDefinition[];
+  readOnlySections: StrategyPluginDocSection[];
+}
+
+export type StrategyConfigValue = string | number | boolean | null | Array<string | number>;
+
+export interface StrategyPluginResolvedValue {
+  key: string;
+  label: string;
+  description?: string;
+  type?: string;
+  defaultValue: StrategyConfigValue;
+  effectiveValue: StrategyConfigValue;
+  overridden: boolean;
+  source: 'plugin_default' | 'root_override';
+}
+
+export interface StrategyPluginResolvedState {
+  id: string;
+  category: StrategyPluginCategory;
+  displayName: string;
+  description: string;
+  enabled: boolean;
+  defaultEnabled: boolean;
+  phase: string;
+  provides: string[];
+  requires: string[];
+  modifies: string[];
+  conflicts: string[];
+  dependsOn: string[];
+  readOnlySections: StrategyPluginDocSection[];
+  values: StrategyPluginResolvedValue[];
+}
+
+export interface StrategyResolvedConfig {
+  name: string;
+  description?: string;
+  module: string;
+  configPath?: string;
+  executionOrder: string[];
+  graphEdges: Record<string, string[]>;
+  plugins: StrategyPluginResolvedState[];
+}
+
+export interface StrategyPluginConfigFieldDefinitionAPI {
+  key: string;
+  label?: string;
+  description?: string;
+  type?: string;
+}
+
+export interface StrategyPluginDocSectionAPI {
+  title?: string;
+  body?: string;
+}
+
+export interface StrategyPluginDefinitionAPI {
+  id: string;
+  category?: string;
+  display_name?: string;
+  displayName?: string;
+  description?: string;
+  enabled_by_default?: boolean;
+  enabledByDefault?: boolean;
+  phase?: string;
+  provides?: string[];
+  requires?: string[];
+  modifies?: string[];
+  conflicts?: string[];
+  config_fields?: StrategyPluginConfigFieldDefinitionAPI[];
+  configFields?: StrategyPluginConfigFieldDefinitionAPI[];
+  read_only_sections?: StrategyPluginDocSectionAPI[];
+  readOnlySections?: StrategyPluginDocSectionAPI[];
+}
+
+export interface StrategyPluginResolvedValueAPI {
+  key: string;
+  label?: string;
+  description?: string;
+  type?: string;
+  default_value?: unknown;
+  defaultValue?: unknown;
+  effective_value?: unknown;
+  effectiveValue?: unknown;
+  overridden?: boolean;
+  source?: 'plugin_default' | 'root_override' | string;
+}
+
+export interface StrategyPluginResolvedStateAPI {
+  id: string;
+  category?: string;
+  display_name?: string;
+  displayName?: string;
+  description?: string;
+  enabled?: boolean;
+  default_enabled?: boolean;
+  defaultEnabled?: boolean;
+  phase?: string;
+  provides?: string[];
+  requires?: string[];
+  modifies?: string[];
+  conflicts?: string[];
+  depends_on?: string[];
+  dependsOn?: string[];
+  read_only_sections?: StrategyPluginDocSectionAPI[];
+  readOnlySections?: StrategyPluginDocSectionAPI[];
+  values?: StrategyPluginResolvedValueAPI[];
+}
+
+export interface StrategyResolvedConfigAPI {
+  name?: string;
+  description?: string | null;
+  module?: string;
+  config_path?: string;
+  configPath?: string;
+  execution_order?: string[];
+  executionOrder?: string[];
+  graph_edges?: Record<string, string[]>;
+  graphEdges?: Record<string, string[]>;
+  plugins?: StrategyPluginResolvedStateAPI[] | Record<string, StrategyPluginResolvedStateAPI>;
+}
+
+function toConfigValue(value: unknown): StrategyConfigValue {
+  if (value == null) return null;
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    const normalized = value.filter(
+      (item): item is string | number => typeof item === 'string' || typeof item === 'number'
+    );
+    return normalized;
+  }
+  return JSON.stringify(value);
+}
+
+function normalizeDocSections(
+  sections?: StrategyPluginDocSectionAPI[] | null,
+): StrategyPluginDocSection[] {
+  return (sections ?? [])
+    .map((section) => ({
+      title: section.title ?? 'Notes',
+      body: section.body ?? '',
+    }))
+    .filter((section) => section.body.trim().length > 0);
+}
+
+export function transformStrategyPluginDefinition(
+  api: StrategyPluginDefinitionAPI,
+): StrategyPluginDefinition {
+  return {
+    id: api.id,
+    category: api.category ?? 'education',
+    displayName: api.display_name ?? api.displayName ?? api.id,
+    description: api.description ?? '',
+    enabledByDefault: api.enabled_by_default ?? api.enabledByDefault ?? false,
+    phase: api.phase ?? 'qualification',
+    provides: api.provides ?? [],
+    requires: api.requires ?? [],
+    modifies: api.modifies ?? [],
+    conflicts: api.conflicts ?? [],
+    configFields: (api.config_fields ?? api.configFields ?? []).map((field) => ({
+      key: field.key,
+      label: field.label ?? field.key,
+      description: field.description,
+      type: field.type,
+    })),
+    readOnlySections: normalizeDocSections(api.read_only_sections ?? api.readOnlySections),
+  };
+}
+
+export function transformStrategyPluginResolvedState(
+  api: StrategyPluginResolvedStateAPI,
+): StrategyPluginResolvedState {
+  return {
+    id: api.id,
+    category: api.category ?? 'education',
+    displayName: api.display_name ?? api.displayName ?? api.id,
+    description: api.description ?? '',
+    enabled: api.enabled ?? false,
+    defaultEnabled: api.default_enabled ?? api.defaultEnabled ?? false,
+    phase: api.phase ?? 'qualification',
+    provides: api.provides ?? [],
+    requires: api.requires ?? [],
+    modifies: api.modifies ?? [],
+    conflicts: api.conflicts ?? [],
+    dependsOn: api.depends_on ?? api.dependsOn ?? [],
+    readOnlySections: normalizeDocSections(api.read_only_sections ?? api.readOnlySections),
+    values: (api.values ?? []).map((value) => ({
+      key: value.key,
+      label: value.label ?? value.key,
+      description: value.description,
+      type: value.type,
+      defaultValue: toConfigValue(value.default_value ?? value.defaultValue),
+      effectiveValue: toConfigValue(value.effective_value ?? value.effectiveValue),
+      overridden: value.overridden ?? false,
+      source: value.source === 'root_override' ? 'root_override' : 'plugin_default',
+    })),
+  };
+}
+
+export function transformStrategyResolvedConfig(api: StrategyResolvedConfigAPI): StrategyResolvedConfig {
+  const pluginsArray = Array.isArray(api.plugins)
+    ? api.plugins
+    : Object.values(api.plugins ?? {});
+
+  return {
+    name: api.name ?? 'Strategy Config',
+    description: api.description ?? undefined,
+    module: api.module ?? 'momentum',
+    configPath: api.config_path ?? api.configPath,
+    executionOrder: api.execution_order ?? api.executionOrder ?? [],
+    graphEdges: api.graph_edges ?? api.graphEdges ?? {},
+    plugins: pluginsArray.map(transformStrategyPluginResolvedState),
+  };
+}

--- a/web-ui/src/features/strategy/useStrategyEditor.ts
+++ b/web-ui/src/features/strategy/useStrategyEditor.ts
@@ -41,7 +41,7 @@ export function useStrategyEditor() {
     clearStatusLater(setStatusMessage, import.meta.env.MODE, 2000);
   });
 
-  const strategies = strategiesQuery.data ?? [];
+  const strategies = useMemo(() => strategiesQuery.data ?? [], [strategiesQuery.data]);
   const activeStrategy = activeStrategyQuery.data;
 
   const createMutation = useCreateStrategyMutation(

--- a/web-ui/src/i18n/messages.en.ts
+++ b/web-ui/src/i18n/messages.en.ts
@@ -1751,6 +1751,26 @@ export const messagesEn = {
       intelligence: 'Intelligence',
       education: 'Education',
     },
+    pluginDashboard: {
+      loading: 'Loading strategy configuration…',
+      loadFailed: 'Failed to load strategy configuration.',
+      subtitle: 'Read-only strategy dashboard backed by YAML plugin configuration.',
+      pluginsCount: '{{count}} plugins',
+      resolvedValuesNote: 'Values shown here are resolved from plugin defaults plus root YAML overrides.',
+      validation: {
+        title: 'Validation',
+        valid: 'Valid',
+        needsAttention: 'Needs attention',
+        safetyScore: 'Safety score {{score}}',
+        noWarnings: 'No validation warnings.',
+      },
+      executionGraph: {
+        title: 'Execution Graph',
+        description: 'Execution order is resolved from plugin phases plus declared capabilities and dependencies.',
+        dependsOn: 'Depends on: {{items}}',
+        noPlugins: 'No enabled plugins found.',
+      },
+    },
   },
   tableState: {
     loadingFallback: 'Loading data...',

--- a/web-ui/src/i18n/messages.en.ts
+++ b/web-ui/src/i18n/messages.en.ts
@@ -1741,6 +1741,16 @@ export const messagesEn = {
         highFee: 'Max fee/risk above 30% increases fee drag risk.',
       },
     },
+    categories: {
+      filters: 'Filters',
+      ranking: 'Ranking',
+      signals: 'Signals',
+      risk: 'Risk',
+      qualification: 'Qualification',
+      management: 'Management',
+      intelligence: 'Intelligence',
+      education: 'Education',
+    },
   },
   tableState: {
     loadingFallback: 'Loading data...',

--- a/web-ui/src/lib/api.ts
+++ b/web-ui/src/lib/api.ts
@@ -7,6 +7,9 @@ export const API_ENDPOINTS = {
   strategy: '/api/strategy',
   strategyActive: '/api/strategy/active',
   strategyValidate: '/api/strategy/validate',
+  strategyConfig: '/api/strategy/config',
+  strategyPlugins: '/api/strategy/plugins',
+  strategyValidationReadOnly: '/api/strategy/validation',
   strategyById: (id: string) => `/api/strategy/${id}`,
   
   // Screener

--- a/web-ui/src/lib/queryInvalidation.ts
+++ b/web-ui/src/lib/queryInvalidation.ts
@@ -5,7 +5,10 @@ export async function invalidateStrategyQueries(queryClient: QueryClient): Promi
   await Promise.all([
     queryClient.invalidateQueries({ queryKey: queryKeys.strategies() }),
     queryClient.invalidateQueries({ queryKey: queryKeys.strategyActive() }),
+    queryClient.invalidateQueries({ queryKey: queryKeys.strategyConfig() }),
+    queryClient.invalidateQueries({ queryKey: queryKeys.strategyPlugins() }),
     queryClient.invalidateQueries({ queryKey: queryKeys.strategyValidation() }),
+    queryClient.invalidateQueries({ queryKey: queryKeys.strategyValidationReadOnly() }),
   ]);
 }
 

--- a/web-ui/src/lib/queryKeys.ts
+++ b/web-ui/src/lib/queryKeys.ts
@@ -3,8 +3,11 @@ import type { OrderFilterStatus, PositionFilterStatus } from '@/features/portfol
 export const queryKeys = {
   strategies: () => ['strategies'] as const,
   strategyActive: () => ['strategy-active'] as const,
+  strategyConfig: () => ['strategy-config'] as const,
+  strategyPlugins: () => ['strategy-plugins'] as const,
   strategyValidation: (payloadHash?: string | null) =>
     payloadHash == null ? (['strategy-validation'] as const) : (['strategy-validation', payloadHash] as const),
+  strategyValidationReadOnly: () => ['strategy-validation-readonly'] as const,
   universes: () => ['universes'] as const,
   dailyReview: (topN: number, universe?: string | null) => ['dailyReview', topN, universe ?? null] as const,
   orders: (status?: OrderFilterStatus) =>

--- a/web-ui/src/pages/DailyReview.tsx
+++ b/web-ui/src/pages/DailyReview.tsx
@@ -1,65 +1,52 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Info, RefreshCw } from 'lucide-react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import { useDailyReview } from '@/features/dailyReview/api';
-import Card, { CardHeader, CardTitle, CardContent } from '@/components/common/Card';
+import Card, { CardContent } from '@/components/common/Card';
 import Button from '@/components/common/Button';
-import Badge from '@/components/common/Badge';
-import TableShell from '@/components/common/TableShell';
+import CollapsibleSection from '@/components/common/CollapsibleSection';
 import { formatCurrency, formatNumber } from '@/utils/formatters';
 import { useActiveStrategyQuery } from '@/features/strategy/hooks';
 import { DEFAULT_CONFIG, type RiskConfig } from '@/types/config';
 import GlossaryLegend from '@/components/domain/education/GlossaryLegend';
-import MetricHelpLabel from '@/components/domain/education/MetricHelpLabel';
 import { DAILY_REVIEW_GLOSSARY_KEYS } from '@/content/educationGlossary';
 import TradeInsightModal from '@/components/domain/recommendation/TradeInsightModal';
 import CandidateOrderModal from '@/components/domain/orders/CandidateOrderModal';
-import CachedSymbolPriceChart from '@/components/domain/market/CachedSymbolPriceChart';
-import WatchMetaInline from '@/components/domain/watchlist/WatchMetaInline';
-import WatchToggleButton from '@/components/domain/watchlist/WatchToggleButton';
+import { RefreshCw } from 'lucide-react';
 import { queryKeys } from '@/lib/queryKeys';
 import { t } from '@/i18n/t';
-import { useUnwatchSymbolMutation, useWatchSymbolMutation, useWatchlist } from '@/features/watchlist/hooks';
-import type { WatchItem } from '@/features/watchlist/types';
 import {
   parseUniverseFromStorage,
   SCREENER_UNIVERSE_STORAGE_KEY,
 } from '@/features/screener/universeStorage';
-import type {
-  DailyReviewCandidate,
-  DailyReviewPositionHold,
-  DailyReviewPositionUpdate,
-  DailyReviewPositionClose,
-} from '@/features/dailyReview/types';
 import { useBeginnerModeStore } from '@/stores/beginnerModeStore';
 import { useStrategyReadiness } from '@/features/strategy/useStrategyReadiness';
 import StrategyReadinessBlocker from '@/components/domain/onboarding/StrategyReadinessBlocker';
-
-const MOBILE_LAYOUT_MEDIA_QUERY = '(max-width: 767px)';
-
-function getMobileLayoutMatch() {
-  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
-    return false;
-  }
-  return window.matchMedia(MOBILE_LAYOUT_MEDIA_QUERY).matches;
-}
+import DailyReviewSummaryCard from '@/components/domain/dailyReview/DailyReviewSummaryCard';
+import DailyReviewCandidatesTable from '@/components/domain/dailyReview/DailyReviewCandidatesTable';
+import DailyReviewUpdateStopTable from '@/components/domain/dailyReview/DailyReviewUpdateStopTable';
+import DailyReviewCloseTable from '@/components/domain/dailyReview/DailyReviewCloseTable';
+import DailyReviewHoldTable from '@/components/domain/dailyReview/DailyReviewHoldTable';
+import { useDailyReviewPageState } from '@/features/dailyReview/useDailyReviewPageState';
 
 export default function DailyReview() {
-  const [expandedSections, setExpandedSections] = useState({
-    candidates: true,
-    hold: false,
-    update: true,
-    close: true,
-  });
-  const [insightCandidate, setInsightCandidate] = useState<DailyReviewCandidate | null>(null);
-  const [showCreateOrderModal, setShowCreateOrderModal] = useState(false);
-  const [selectedCandidate, setSelectedCandidate] = useState<DailyReviewCandidate | null>(null);
-  const [dismissedReadinessBlocker, setDismissedReadinessBlocker] = useState(() => {
-    // Persist dismissal state in localStorage
-    return localStorage.getItem('dailyReview.dismissedReadinessBlocker') === 'true';
-  });
-  const [isCompactMobileLayout, setIsCompactMobileLayout] = useState(getMobileLayoutMatch);
+  const {
+    expandedSections,
+    toggleSection,
+    insightCandidate,
+    setInsightCandidate,
+    showCreateOrderModal,
+    setShowCreateOrderModal,
+    selectedCandidate,
+    setSelectedCandidate,
+    dismissedReadinessBlocker,
+    setDismissedReadinessBlocker,
+    isCompactMobileLayout,
+    watchItemsByTicker,
+    watchPending,
+    handleWatch,
+    handleUnwatch,
+    openWorkspacePortfolioAction,
+  } = useDailyReviewPageState();
 
   const queryClient = useQueryClient();
   const navigate = useNavigate();
@@ -68,79 +55,7 @@ export default function DailyReview() {
   const activeStrategyQuery = useActiveStrategyQuery();
   const { isBeginnerMode } = useBeginnerModeStore();
   const { isReady: strategyReady } = useStrategyReadiness();
-  const watchlistQuery = useWatchlist();
-  const watchSymbolMutation = useWatchSymbolMutation();
-  const unwatchSymbolMutation = useUnwatchSymbolMutation();
-
-  const watchItemsByTicker = useMemo(() => {
-    const map = new Map<string, WatchItem>();
-    for (const item of watchlistQuery.data ?? []) {
-      map.set(item.ticker.toUpperCase(), item);
-    }
-    return map;
-  }, [watchlistQuery.data]);
-
-  const handleWatch = useCallback(
-    (ticker: string, currentPrice: number | null | undefined, source: string) => {
-      const normalizedTicker = ticker.trim().toUpperCase();
-      if (!normalizedTicker || watchItemsByTicker.has(normalizedTicker)) {
-        return;
-      }
-      watchSymbolMutation.mutate({
-        ticker: normalizedTicker,
-        watchPrice: currentPrice ?? null,
-        currency: null,
-        source,
-      });
-    },
-    [watchItemsByTicker, watchSymbolMutation],
-  );
-
-  const handleUnwatch = useCallback(
-    (ticker: string) => {
-      const normalizedTicker = ticker.trim().toUpperCase();
-      if (!normalizedTicker || !watchItemsByTicker.has(normalizedTicker)) {
-        return;
-      }
-      unwatchSymbolMutation.mutate(normalizedTicker);
-    },
-    [watchItemsByTicker, unwatchSymbolMutation],
-  );
-  const watchPending = watchSymbolMutation.isPending || unwatchSymbolMutation.isPending;
-  
-  // Persist dismissal to localStorage
-  useEffect(() => {
-    localStorage.setItem('dailyReview.dismissedReadinessBlocker', String(dismissedReadinessBlocker));
-  }, [dismissedReadinessBlocker]);
-
-  useEffect(() => {
-    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
-      return;
-    }
-
-    const mediaQueryList = window.matchMedia(MOBILE_LAYOUT_MEDIA_QUERY);
-    const handleChange = (event: MediaQueryListEvent) => {
-      setIsCompactMobileLayout(event.matches);
-    };
-
-    setIsCompactMobileLayout(mediaQueryList.matches);
-    mediaQueryList.addEventListener('change', handleChange);
-    return () => mediaQueryList.removeEventListener('change', handleChange);
-  }, []);
   const riskConfig: RiskConfig = activeStrategyQuery.data?.risk ?? DEFAULT_CONFIG.risk;
-  const openWorkspacePortfolioAction = useCallback(
-    (params: { action: 'update-stop' | 'close-position'; ticker: string; positionId: string }) => {
-      const searchParams = new URLSearchParams();
-      searchParams.set('portfolioAction', params.action);
-      searchParams.set('ticker', params.ticker);
-      searchParams.set('positionId', params.positionId);
-      navigate(`/workspace?${searchParams.toString()}`);
-    },
-    [navigate],
-  );
-  const toggleSection = (section: keyof typeof expandedSections) => {
-    setExpandedSections((prev) => ({ ...prev, [section]: !prev[section] }));
-  };
 
   if (isLoading) {
     return (
@@ -190,6 +105,11 @@ export default function DailyReview() {
   const hiddenCandidates = review.newCandidates.length - recommendedCandidates.length;
   const quickActionCandidate = recommendedCandidates[0] ?? null;
 
+  const sectionExpandLabel = t('dailyReview.sections.expand');
+  const sectionCollapseLabel = t('dailyReview.sections.collapse');
+  const actionsBadgeLabel = (count: number) =>
+    t('dailyReview.sections.actionsBadge', { count, suffix: count !== 1 ? 's' : '' });
+
   return (
     <div className="space-y-6">
       <div className="flex justify-between items-start">
@@ -224,20 +144,20 @@ export default function DailyReview() {
       )}
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-        <SummaryCard title={t('dailyReview.summary.newCandidates')} value={summary.newCandidates} variant="blue" icon="📈" />
-        <SummaryCard
+        <DailyReviewSummaryCard title={t('dailyReview.summary.newCandidates')} value={summary.newCandidates} variant="blue" icon="📈" />
+        <DailyReviewSummaryCard
           title={t('dailyReview.summary.updateStop')}
           value={summary.updateStop}
           variant={summary.updateStop > 0 ? 'yellow' : 'gray'}
           icon="🔄"
         />
-        <SummaryCard
+        <DailyReviewSummaryCard
           title={t('dailyReview.summary.closePositions')}
           value={summary.closePositions}
           variant={summary.closePositions > 0 ? 'red' : 'gray'}
           icon="❌"
         />
-        <SummaryCard title={t('dailyReview.summary.holdPositions')} value={summary.noAction} variant="green" icon="✅" />
+        <DailyReviewSummaryCard title={t('dailyReview.summary.holdPositions')} value={summary.noAction} variant="green" icon="✅" />
       </div>
 
       {quickActionCandidate ? (
@@ -271,6 +191,8 @@ export default function DailyReview() {
         isExpanded={expandedSections.candidates}
         onToggle={() => toggleSection('candidates')}
         count={recommendedCandidates.length}
+        expandLabel={sectionExpandLabel}
+        collapseLabel={sectionCollapseLabel}
       >
         {recommendedCandidates.length === 0 ? (
           <div className="space-y-3">
@@ -308,7 +230,7 @@ export default function DailyReview() {
                 })}
               </p>
             ) : null}
-            <CandidatesTable
+            <DailyReviewCandidatesTable
               candidates={recommendedCandidates}
               onShowRecommendation={setInsightCandidate}
               onCreateOrder={(candidate) => {
@@ -331,13 +253,16 @@ export default function DailyReview() {
         onToggle={() => toggleSection('update')}
         count={review.positionsUpdateStop.length}
         variant="warning"
+        badgeLabel={actionsBadgeLabel(review.positionsUpdateStop.length)}
+        expandLabel={sectionExpandLabel}
+        collapseLabel={sectionCollapseLabel}
       >
         {review.positionsUpdateStop.length === 0 ? (
           <p className="text-gray-600 dark:text-gray-400">{t('dailyReview.sections.noStopUpdates')}</p>
         ) : (
           <div className="space-y-3">
             <GlossaryLegend metricKeys={DAILY_REVIEW_GLOSSARY_KEYS} title={t('dailyReview.sections.stopGlossary')} />
-            <UpdateStopTable
+            <DailyReviewUpdateStopTable
               positions={review.positionsUpdateStop}
               onAction={(position) =>
                 openWorkspacePortfolioAction({
@@ -362,11 +287,14 @@ export default function DailyReview() {
         onToggle={() => toggleSection('close')}
         count={review.positionsClose.length}
         variant="danger"
+        badgeLabel={actionsBadgeLabel(review.positionsClose.length)}
+        expandLabel={sectionExpandLabel}
+        collapseLabel={sectionCollapseLabel}
       >
         {review.positionsClose.length === 0 ? (
           <p className="text-gray-600 dark:text-gray-400">{t('dailyReview.sections.noClose')}</p>
         ) : (
-          <CloseTable
+          <DailyReviewCloseTable
             positions={review.positionsClose}
             onAction={(position) =>
               openWorkspacePortfolioAction({
@@ -389,11 +317,13 @@ export default function DailyReview() {
         isExpanded={expandedSections.hold}
         onToggle={() => toggleSection('hold')}
         count={review.positionsHold.length}
+        expandLabel={sectionExpandLabel}
+        collapseLabel={sectionCollapseLabel}
       >
         {review.positionsHold.length === 0 ? (
           <p className="text-gray-600 dark:text-gray-400">{t('dailyReview.sections.noHold')}</p>
         ) : (
-          <HoldTable
+          <DailyReviewHoldTable
             positions={review.positionsHold}
             isCompactMobileLayout={isCompactMobileLayout}
             watchItemsByTicker={watchItemsByTicker}
@@ -450,776 +380,3 @@ export default function DailyReview() {
   );
 }
 
-function SummaryCard({
-  title,
-  value,
-  variant,
-  icon,
-}: {
-  title: string;
-  value: number;
-  variant: 'blue' | 'yellow' | 'red' | 'green' | 'gray';
-  icon: string;
-}) {
-  const variantClasses = {
-    blue: 'bg-blue-50 dark:bg-blue-900/20 border-blue-200 dark:border-blue-800',
-    yellow: 'bg-yellow-50 dark:bg-yellow-900/20 border-yellow-200 dark:border-yellow-800',
-    red: 'bg-red-50 dark:bg-red-900/20 border-red-200 dark:border-red-800',
-    green: 'bg-green-50 dark:bg-green-900/20 border-green-200 dark:border-green-800',
-    gray: 'bg-gray-50 dark:bg-gray-900/20 border-gray-200 dark:border-gray-800',
-  };
-
-  return (
-    <Card className={variantClasses[variant]}>
-      <CardContent>
-        <div className="flex items-center justify-between">
-          <div>
-            <p className="text-sm text-gray-600 dark:text-gray-400">{title}</p>
-            <p className="text-3xl font-bold mt-1">{value}</p>
-          </div>
-          <span className="text-4xl">{icon}</span>
-        </div>
-      </CardContent>
-    </Card>
-  );
-}
-
-function CollapsibleSection({
-  title,
-  isExpanded,
-  onToggle,
-  count,
-  variant,
-  children,
-}: {
-  title: string;
-  isExpanded: boolean;
-  onToggle: () => void;
-  count: number;
-  variant?: 'warning' | 'danger';
-  children: React.ReactNode;
-}) {
-  return (
-    <Card>
-      <CardHeader>
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <CardTitle>{title}</CardTitle>
-            {count > 0 && variant === 'warning' ? (
-              <Badge variant="warning">
-                {t('dailyReview.sections.actionsBadge', { count, suffix: count !== 1 ? 's' : '' })}
-              </Badge>
-            ) : null}
-            {count > 0 && variant === 'danger' ? (
-              <Badge variant="error">
-                {t('dailyReview.sections.actionsBadge', { count, suffix: count !== 1 ? 's' : '' })}
-              </Badge>
-            ) : null}
-          </div>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={onToggle}
-            title={isExpanded ? t('dailyReview.sections.collapse') : t('dailyReview.sections.expand')}
-            aria-label={isExpanded ? t('dailyReview.sections.collapse') : t('dailyReview.sections.expand')}
-          >
-            {isExpanded ? '▼' : '▶'}
-          </Button>
-        </div>
-      </CardHeader>
-      {isExpanded ? <CardContent>{children}</CardContent> : null}
-    </Card>
-  );
-}
-
-interface DailyReviewWatchProps {
-  watchItemsByTicker: Map<string, WatchItem>;
-  watchPending: boolean;
-  onWatch: (ticker: string, currentPrice: number | null | undefined, source: string) => void;
-  onUnwatch: (ticker: string) => void;
-}
-
-function WatchInlineBlock({
-  ticker,
-  currentPrice,
-  source,
-  watchItemsByTicker,
-  watchPending,
-  onWatch,
-  onUnwatch,
-}: {
-  ticker: string;
-  currentPrice: number | null | undefined;
-  source: string;
-} & DailyReviewWatchProps) {
-  const watchItem = watchItemsByTicker.get(ticker.trim().toUpperCase());
-  return (
-    <div className="mt-1 flex flex-col gap-1">
-      <WatchToggleButton
-        ticker={ticker}
-        isWatched={Boolean(watchItem)}
-        isPending={watchPending}
-        onWatch={(nextTicker) => onWatch(nextTicker, currentPrice, source)}
-        onUnwatch={onUnwatch}
-      />
-      {watchItem ? (
-        <WatchMetaInline
-          watchedAt={watchItem.watchedAt}
-          watchPrice={watchItem.watchPrice}
-          currentPrice={currentPrice}
-          currency={null}
-        />
-      ) : null}
-    </div>
-  );
-}
-
-function CandidatesTable({
-  candidates,
-  onShowRecommendation,
-  onCreateOrder,
-  isCompactMobileLayout,
-  watchItemsByTicker,
-  watchPending,
-  onWatch,
-  onUnwatch,
-}: {
-  candidates: DailyReviewCandidate[];
-  onShowRecommendation: (candidate: DailyReviewCandidate) => void;
-  onCreateOrder: (candidate: DailyReviewCandidate) => void;
-  isCompactMobileLayout: boolean;
-} & DailyReviewWatchProps) {
-  if (isCompactMobileLayout) {
-    return (
-      <div className="space-y-3">
-        {candidates.map((candidate) => (
-          <div
-            key={candidate.ticker}
-            className="rounded-xl border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800"
-          >
-            <div className="flex items-start justify-between gap-3">
-              <div>
-                <a
-                  href={`https://finance.yahoo.com/quote/${candidate.ticker}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="font-mono text-base font-bold text-blue-700 hover:underline"
-                  title={t('dailyReview.table.candidates.yahooFinanceTooltip', { ticker: candidate.ticker })}
-                >
-                  {candidate.ticker}
-                </a>
-                <p className="mt-0.5 text-xs text-gray-500">
-                  {candidate.sector || t('common.placeholders.dash')}
-                </p>
-                <WatchInlineBlock
-                  ticker={candidate.ticker}
-                  currentPrice={candidate.close}
-                  source="daily_review_candidates"
-                  watchItemsByTicker={watchItemsByTicker}
-                  watchPending={watchPending}
-                  onWatch={onWatch}
-                  onUnwatch={onUnwatch}
-                />
-              </div>
-              <Badge variant="primary">{candidate.signal}</Badge>
-            </div>
-
-            <CachedSymbolPriceChart ticker={candidate.ticker} className="mt-2" />
-
-            <div className="mt-3 grid grid-cols-2 gap-2 text-xs">
-              <div className="rounded-md bg-gray-50 px-2 py-1 dark:bg-gray-700/70">
-                <p className="text-gray-500">{t('dailyReview.table.candidates.headers.entry')}</p>
-                <p className="font-semibold">{formatCurrency(candidate.entry)}</p>
-              </div>
-              <div className="rounded-md bg-gray-50 px-2 py-1 dark:bg-gray-700/70">
-                <p className="text-gray-500">{t('dailyReview.table.candidates.headers.stop')}</p>
-                <p className="font-semibold">{formatCurrency(candidate.stop)}</p>
-              </div>
-              <div className="rounded-md bg-gray-50 px-2 py-1 dark:bg-gray-700/70">
-                <p className="text-gray-500">{t('dailyReview.table.candidates.headers.shares')}</p>
-                <p className="font-semibold">{candidate.shares}</p>
-              </div>
-              <div className="rounded-md bg-gray-50 px-2 py-1 dark:bg-gray-700/70">
-                <p className="text-gray-500">{t('dailyReview.table.candidates.headers.riskReward')}</p>
-                <p className="font-semibold">
-                  {t('common.units.rValue', { value: formatNumber(candidate.rReward, 1) })}
-                </p>
-              </div>
-              <div className="col-span-2 rounded-md bg-gray-50 px-2 py-1 dark:bg-gray-700/70">
-                <p className="text-gray-500">{t('dailyReview.table.candidates.headers.confidence')}</p>
-                <p className="font-semibold text-purple-700 dark:text-purple-300">
-                  {candidate.confidence != null ? formatNumber(candidate.confidence, 1) : '-'}
-                </p>
-              </div>
-            </div>
-
-            <div className="mt-3 flex items-center gap-2">
-              {candidate.recommendation ? (
-                <Button
-                  type="button"
-                  variant="secondary"
-                  size="sm"
-                  className="shrink-0"
-                  onClick={() => onShowRecommendation(candidate)}
-                  title={t('dailyReview.table.candidates.recommendationTitle')}
-                  aria-label={t('dailyReview.table.candidates.recommendationAria', { ticker: candidate.ticker })}
-                >
-                  <Info className="h-4 w-4" />
-                </Button>
-              ) : null}
-              <Button
-                variant="primary"
-                size="sm"
-                className="flex-1"
-                onClick={() => onCreateOrder(candidate)}
-                title={
-                  candidate.recommendation?.verdict === 'NOT_RECOMMENDED'
-                    ? t('dailyReview.table.candidates.createOrderNotRecommendedTitle')
-                    : t('dailyReview.table.candidates.createOrderTitle')
-                }
-              >
-                {t('dailyReview.table.candidates.createOrder')}
-              </Button>
-            </div>
-          </div>
-        ))}
-      </div>
-    );
-  }
-
-  return (
-    <TableShell
-      empty={candidates.length === 0}
-      emptyMessage={t('dailyReview.table.candidates.empty')}
-      tableClassName="text-sm"
-      headers={(
-        <tr>
-          <th className="text-left p-2">{t('dailyReview.table.candidates.headers.ticker')}</th>
-          <th className="text-right p-2">
-            <MetricHelpLabel metricKey="CONFIDENCE" className="justify-end w-full" />
-          </th>
-          <th className="text-left p-2">{t('dailyReview.table.candidates.headers.signal')}</th>
-          <th className="text-right p-2">{t('dailyReview.table.candidates.headers.entry')}</th>
-          <th className="text-right p-2">{t('dailyReview.table.candidates.headers.stop')}</th>
-          <th className="text-right p-2">{t('dailyReview.table.candidates.headers.shares')}</th>
-          <th className="text-right p-2">
-            <MetricHelpLabel metricKey="RR" labelOverride="R:R" className="justify-end w-full" />
-          </th>
-          <th className="text-left p-2">{t('dailyReview.table.candidates.headers.sector')}</th>
-          <th className="text-center p-2">{t('dailyReview.table.candidates.headers.info')}</th>
-          <th className="text-right p-2">{t('dailyReview.table.candidates.headers.action')}</th>
-        </tr>
-      )}
-    >
-      {candidates.map((candidate) => (
-        <tr key={candidate.ticker} className="border-b dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800">
-          <td className="p-2 font-mono font-bold">
-            <a
-              href={`https://finance.yahoo.com/quote/${candidate.ticker}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-blue-600 hover:text-blue-800 hover:underline"
-              title={t('dailyReview.table.candidates.yahooFinanceTooltip', { ticker: candidate.ticker })}
-            >
-              {candidate.ticker}
-            </a>
-            <WatchInlineBlock
-              ticker={candidate.ticker}
-              currentPrice={candidate.close}
-              source="daily_review_candidates"
-              watchItemsByTicker={watchItemsByTicker}
-              watchPending={watchPending}
-              onWatch={onWatch}
-              onUnwatch={onUnwatch}
-            />
-            <CachedSymbolPriceChart ticker={candidate.ticker} className="mt-1" />
-          </td>
-          <td className="p-2 text-right">
-            <span className="font-semibold text-purple-600">
-              {candidate.confidence != null ? formatNumber(candidate.confidence, 1) : '-'}
-            </span>
-          </td>
-          <td className="p-2">
-            <Badge variant="primary">{candidate.signal}</Badge>
-          </td>
-          <td className="p-2 text-right">{formatCurrency(candidate.entry)}</td>
-          <td className="p-2 text-right">{formatCurrency(candidate.stop)}</td>
-          <td className="p-2 text-right">{candidate.shares}</td>
-          <td className="p-2 text-right font-bold">
-            {t('common.units.rValue', { value: formatNumber(candidate.rReward, 1) })}
-          </td>
-          <td className="p-2 text-sm text-gray-600 dark:text-gray-400">
-            {candidate.sector || t('common.placeholders.dash')}
-          </td>
-          <td className="p-2 text-center">
-            {candidate.recommendation ? (
-              <button
-                onClick={() => onShowRecommendation(candidate)}
-                className="min-h-11 min-w-11 p-1 hover:bg-gray-200 dark:hover:bg-gray-700 rounded"
-                title={t('dailyReview.table.candidates.recommendationTitle')}
-                aria-label={t('dailyReview.table.candidates.recommendationAria', { ticker: candidate.ticker })}
-              >
-                <Info className="w-4 h-4" />
-              </button>
-            ) : null}
-          </td>
-          <td className="p-2 text-right">
-            <Button
-              variant="primary"
-              size="sm"
-              onClick={() => onCreateOrder(candidate)}
-              title={
-                candidate.recommendation?.verdict === 'NOT_RECOMMENDED'
-                  ? t('dailyReview.table.candidates.createOrderNotRecommendedTitle')
-                  : t('dailyReview.table.candidates.createOrderTitle')
-              }
-            >
-              {t('dailyReview.table.candidates.createOrder')}
-            </Button>
-          </td>
-        </tr>
-      ))}
-    </TableShell>
-  );
-}
-
-const TIME_EXIT_REASON_PATTERN = /Time exit:\s*(\d+)\s*bars since entry_date\s*>=\s*(\d+)/i;
-
-function formatDailyReviewReason(reason: string): string {
-  const timeExitMatch = reason.match(TIME_EXIT_REASON_PATTERN);
-  if (timeExitMatch) {
-    return t('dailyReview.reason.timeExit', {
-      barsSince: Number(timeExitMatch[1]),
-      maxBars: Number(timeExitMatch[2]),
-    });
-  }
-  return reason;
-}
-
-function UpdateStopTable({
-  positions,
-  onAction,
-  isCompactMobileLayout,
-  watchItemsByTicker,
-  watchPending,
-  onWatch,
-  onUnwatch,
-}: {
-  positions: DailyReviewPositionUpdate[];
-  onAction: (position: DailyReviewPositionUpdate) => void;
-  isCompactMobileLayout: boolean;
-} & DailyReviewWatchProps) {
-  if (isCompactMobileLayout) {
-    return (
-      <div className="space-y-3">
-        {positions.map((pos) => (
-          <div
-            key={pos.positionId}
-            className="rounded-xl border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800"
-          >
-            <div className="flex items-start justify-between gap-3">
-              <a
-                href={`https://finance.yahoo.com/quote/${pos.ticker}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="font-mono text-base font-bold text-blue-700 hover:underline"
-                title={t('dailyReview.table.update.yahooFinanceTooltip', { ticker: pos.ticker })}
-              >
-                {pos.ticker}
-              </a>
-              <WatchInlineBlock
-                ticker={pos.ticker}
-                currentPrice={pos.currentPrice}
-                source="daily_review_update_stop"
-                watchItemsByTicker={watchItemsByTicker}
-                watchPending={watchPending}
-                onWatch={onWatch}
-                onUnwatch={onUnwatch}
-              />
-              <Badge variant="warning">{t('dailyReview.table.update.actionLabel')}</Badge>
-            </div>
-
-            <CachedSymbolPriceChart ticker={pos.ticker} className="mt-2" />
-
-            <div className="mt-3 grid grid-cols-2 gap-2 text-xs">
-              <div className="rounded-md bg-gray-50 px-2 py-1 dark:bg-gray-700/70">
-                <p className="text-gray-500">{t('dailyReview.table.update.headers.entry')}</p>
-                <p className="font-semibold">{formatCurrency(pos.entryPrice)}</p>
-              </div>
-              <div className="rounded-md bg-gray-50 px-2 py-1 dark:bg-gray-700/70">
-                <p className="text-gray-500">{t('dailyReview.table.update.headers.current')}</p>
-                <p className="font-semibold">{formatCurrency(pos.currentPrice)}</p>
-              </div>
-              <div className="rounded-md bg-gray-50 px-2 py-1 dark:bg-gray-700/70">
-                <p className="text-gray-500">{t('dailyReview.table.update.headers.stopOld')}</p>
-                <p>{formatCurrency(pos.stopCurrent)}</p>
-              </div>
-              <div className="rounded-md bg-gray-50 px-2 py-1 dark:bg-gray-700/70">
-                <p className="text-gray-500">{t('dailyReview.table.update.headers.stopNew')}</p>
-                <p className="font-semibold text-green-700 dark:text-green-300">{formatCurrency(pos.stopSuggested)}</p>
-              </div>
-            </div>
-
-            <p className="mt-3 text-xs text-gray-600 dark:text-gray-300">{formatDailyReviewReason(pos.reason)}</p>
-
-            <div className="mt-3 flex items-center justify-between gap-3">
-              <span className={pos.rNow >= 0 ? 'text-sm font-semibold text-green-700 dark:text-green-300' : 'text-sm font-semibold text-red-700 dark:text-red-300'}>
-                {t('common.units.rValue', { value: formatNumber(pos.rNow, 2) })}
-              </span>
-              <Button
-                variant="secondary"
-                size="sm"
-                onClick={() => onAction(pos)}
-                title={t('dailyReview.table.update.actionTitle')}
-              >
-                {t('dailyReview.table.update.actionLabel')}
-              </Button>
-            </div>
-          </div>
-        ))}
-      </div>
-    );
-  }
-
-  return (
-    <TableShell
-      empty={positions.length === 0}
-      emptyMessage={t('dailyReview.table.update.empty')}
-      tableClassName="text-sm"
-      headers={(
-        <tr>
-          <th className="text-left p-2">{t('dailyReview.table.update.headers.ticker')}</th>
-          <th className="text-right p-2">{t('dailyReview.table.update.headers.entry')}</th>
-          <th className="text-right p-2">{t('dailyReview.table.update.headers.current')}</th>
-          <th className="text-right p-2">{t('dailyReview.table.update.headers.stopOld')}</th>
-          <th className="text-right p-2">{t('dailyReview.table.update.headers.stopNew')}</th>
-          <th className="text-right p-2">
-            <MetricHelpLabel metricKey="R_NOW" className="justify-end w-full" />
-          </th>
-          <th className="text-left p-2">{t('dailyReview.table.update.headers.reason')}</th>
-          <th className="text-right p-2">{t('dailyReview.table.update.headers.action')}</th>
-        </tr>
-      )}
-    >
-      {positions.map((pos) => (
-        <tr key={pos.positionId} className="border-b dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800">
-          <td className="p-2 font-mono font-bold">
-            <a
-              href={`https://finance.yahoo.com/quote/${pos.ticker}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-blue-600 hover:text-blue-800 hover:underline"
-              title={t('dailyReview.table.update.yahooFinanceTooltip', { ticker: pos.ticker })}
-            >
-              {pos.ticker}
-            </a>
-            <WatchInlineBlock
-              ticker={pos.ticker}
-              currentPrice={pos.currentPrice}
-              source="daily_review_update_stop"
-              watchItemsByTicker={watchItemsByTicker}
-              watchPending={watchPending}
-              onWatch={onWatch}
-              onUnwatch={onUnwatch}
-            />
-            <CachedSymbolPriceChart ticker={pos.ticker} className="mt-1" />
-          </td>
-          <td className="p-2 text-right">{formatCurrency(pos.entryPrice)}</td>
-          <td className="p-2 text-right">{formatCurrency(pos.currentPrice)}</td>
-          <td className="p-2 text-right text-gray-600 dark:text-gray-400">{formatCurrency(pos.stopCurrent)}</td>
-          <td className="p-2 text-right font-bold text-green-700 dark:text-green-300">{formatCurrency(pos.stopSuggested)}</td>
-          <td className="p-2 text-right">
-            <span className={pos.rNow >= 0 ? 'text-green-700 dark:text-green-300' : 'text-red-700 dark:text-red-300'}>
-              {t('common.units.rValue', { value: formatNumber(pos.rNow, 2) })}
-            </span>
-          </td>
-          <td className="p-2 text-sm">{formatDailyReviewReason(pos.reason)}</td>
-          <td className="p-2 text-right">
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={() => onAction(pos)}
-              title={t('dailyReview.table.update.actionTitle')}
-            >
-              {t('dailyReview.table.update.actionLabel')}
-            </Button>
-          </td>
-        </tr>
-      ))}
-    </TableShell>
-  );
-}
-
-function CloseTable({
-  positions,
-  onAction,
-  isCompactMobileLayout,
-  watchItemsByTicker,
-  watchPending,
-  onWatch,
-  onUnwatch,
-}: {
-  positions: DailyReviewPositionClose[];
-  onAction: (position: DailyReviewPositionClose) => void;
-  isCompactMobileLayout: boolean;
-} & DailyReviewWatchProps) {
-  if (isCompactMobileLayout) {
-    return (
-      <div className="space-y-3">
-        {positions.map((pos) => (
-          <div
-            key={pos.positionId}
-            className="rounded-xl border border-red-200 bg-red-50/60 p-3 dark:border-red-900 dark:bg-red-950/20"
-          >
-            <div className="flex items-start justify-between gap-3">
-              <a
-                href={`https://finance.yahoo.com/quote/${pos.ticker}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="font-mono text-base font-bold text-blue-700 hover:underline"
-                title={t('dailyReview.table.close.yahooFinanceTooltip', { ticker: pos.ticker })}
-              >
-                {pos.ticker}
-              </a>
-              <WatchInlineBlock
-                ticker={pos.ticker}
-                currentPrice={pos.currentPrice}
-                source="daily_review_close"
-                watchItemsByTicker={watchItemsByTicker}
-                watchPending={watchPending}
-                onWatch={onWatch}
-                onUnwatch={onUnwatch}
-              />
-              <Badge variant="error">{t('dailyReview.table.close.actionLabel')}</Badge>
-            </div>
-
-            <CachedSymbolPriceChart ticker={pos.ticker} className="mt-2" />
-
-            <div className="mt-3 grid grid-cols-3 gap-2 text-xs">
-              <div className="rounded-md bg-white px-2 py-1 dark:bg-gray-800/70">
-                <p className="text-gray-500">{t('dailyReview.table.close.headers.entry')}</p>
-                <p className="font-semibold">{formatCurrency(pos.entryPrice)}</p>
-              </div>
-              <div className="rounded-md bg-white px-2 py-1 dark:bg-gray-800/70">
-                <p className="text-gray-500">{t('dailyReview.table.close.headers.current')}</p>
-                <p className="font-semibold">{formatCurrency(pos.currentPrice)}</p>
-              </div>
-              <div className="rounded-md bg-white px-2 py-1 dark:bg-gray-800/70">
-                <p className="text-gray-500">{t('dailyReview.table.close.headers.stop')}</p>
-                <p>{formatCurrency(pos.stopPrice)}</p>
-              </div>
-            </div>
-
-            <p className="mt-3 text-xs text-gray-600 dark:text-gray-300">{formatDailyReviewReason(pos.reason)}</p>
-
-            <div className="mt-3 flex items-center justify-between gap-3">
-              <span className="text-sm font-semibold text-red-700 dark:text-red-300">
-                {t('common.units.rValue', { value: formatNumber(pos.rNow, 2) })}
-              </span>
-              <Button
-                variant="danger"
-                size="sm"
-                onClick={() => onAction(pos)}
-                title={t('dailyReview.table.close.actionTitle')}
-              >
-                {t('dailyReview.table.close.actionLabel')}
-              </Button>
-            </div>
-          </div>
-        ))}
-      </div>
-    );
-  }
-
-  return (
-    <TableShell
-      empty={positions.length === 0}
-      emptyMessage={t('dailyReview.table.close.empty')}
-      tableClassName="text-sm"
-      headers={(
-        <tr>
-          <th className="text-left p-2">{t('dailyReview.table.close.headers.ticker')}</th>
-          <th className="text-right p-2">{t('dailyReview.table.close.headers.entry')}</th>
-          <th className="text-right p-2">{t('dailyReview.table.close.headers.current')}</th>
-          <th className="text-right p-2">{t('dailyReview.table.close.headers.stop')}</th>
-          <th className="text-right p-2">
-            <MetricHelpLabel metricKey="R_NOW" className="justify-end w-full" />
-          </th>
-          <th className="text-left p-2">{t('dailyReview.table.close.headers.reason')}</th>
-          <th className="text-right p-2">{t('dailyReview.table.close.headers.action')}</th>
-        </tr>
-      )}
-    >
-      {positions.map((pos) => (
-        <tr key={pos.positionId} className="border-b dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800">
-          <td className="p-2 font-mono font-bold">
-            <a
-              href={`https://finance.yahoo.com/quote/${pos.ticker}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-blue-600 hover:text-blue-800 hover:underline"
-              title={t('dailyReview.table.close.yahooFinanceTooltip', { ticker: pos.ticker })}
-            >
-              {pos.ticker}
-            </a>
-            <WatchInlineBlock
-              ticker={pos.ticker}
-              currentPrice={pos.currentPrice}
-              source="daily_review_close"
-              watchItemsByTicker={watchItemsByTicker}
-              watchPending={watchPending}
-              onWatch={onWatch}
-              onUnwatch={onUnwatch}
-            />
-            <CachedSymbolPriceChart ticker={pos.ticker} className="mt-1" />
-          </td>
-          <td className="p-2 text-right">{formatCurrency(pos.entryPrice)}</td>
-          <td className="p-2 text-right">{formatCurrency(pos.currentPrice)}</td>
-          <td className="p-2 text-right">{formatCurrency(pos.stopPrice)}</td>
-          <td className="p-2 text-right">
-            <span className="text-red-700 dark:text-red-300 font-bold">
-              {t('common.units.rValue', { value: formatNumber(pos.rNow, 2) })}
-            </span>
-          </td>
-          <td className="p-2 text-sm">{formatDailyReviewReason(pos.reason)}</td>
-          <td className="p-2 text-right">
-            <Button
-              variant="danger"
-              size="sm"
-              onClick={() => onAction(pos)}
-              title={t('dailyReview.table.close.actionTitle')}
-            >
-              {t('dailyReview.table.close.actionLabel')}
-            </Button>
-          </td>
-        </tr>
-      ))}
-    </TableShell>
-  );
-}
-
-function HoldTable({
-  positions,
-  isCompactMobileLayout,
-  watchItemsByTicker,
-  watchPending,
-  onWatch,
-  onUnwatch,
-}: {
-  positions: DailyReviewPositionHold[];
-  isCompactMobileLayout: boolean;
-} & DailyReviewWatchProps) {
-  if (isCompactMobileLayout) {
-    return (
-      <div className="space-y-3">
-        {positions.map((pos) => (
-          <div
-            key={pos.positionId}
-            className="rounded-xl border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800"
-          >
-            <div className="flex items-start justify-between gap-3">
-              <a
-                href={`https://finance.yahoo.com/quote/${pos.ticker}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="font-mono text-base font-bold text-blue-700 hover:underline"
-                title={t('dailyReview.table.hold.yahooFinanceTooltip', { ticker: pos.ticker })}
-              >
-                {pos.ticker}
-              </a>
-              <WatchInlineBlock
-                ticker={pos.ticker}
-                currentPrice={pos.currentPrice}
-                source="daily_review_hold"
-                watchItemsByTicker={watchItemsByTicker}
-                watchPending={watchPending}
-                onWatch={onWatch}
-                onUnwatch={onUnwatch}
-              />
-              <Badge variant="success">{t('dailyReview.table.hold.holdBadge')}</Badge>
-            </div>
-
-            <CachedSymbolPriceChart ticker={pos.ticker} className="mt-2" />
-
-            <div className="mt-3 grid grid-cols-3 gap-2 text-xs">
-              <div className="rounded-md bg-gray-50 px-2 py-1 dark:bg-gray-700/70">
-                <p className="text-gray-500">{t('dailyReview.table.hold.headers.entry')}</p>
-                <p className="font-semibold">{formatCurrency(pos.entryPrice)}</p>
-              </div>
-              <div className="rounded-md bg-gray-50 px-2 py-1 dark:bg-gray-700/70">
-                <p className="text-gray-500">{t('dailyReview.table.hold.headers.current')}</p>
-                <p className="font-semibold">{formatCurrency(pos.currentPrice)}</p>
-              </div>
-              <div className="rounded-md bg-gray-50 px-2 py-1 dark:bg-gray-700/70">
-                <p className="text-gray-500">{t('dailyReview.table.hold.headers.stop')}</p>
-                <p>{formatCurrency(pos.stopPrice)}</p>
-              </div>
-            </div>
-
-            <div className="mt-3 flex items-center justify-between gap-3">
-              <p className="text-xs text-gray-600 dark:text-gray-300">{formatDailyReviewReason(pos.reason)}</p>
-              <span className={pos.rNow >= 0 ? 'text-sm font-semibold text-green-700 dark:text-green-300' : 'text-sm font-semibold text-red-700 dark:text-red-300'}>
-                {t('common.units.rValue', { value: formatNumber(pos.rNow, 2) })}
-              </span>
-            </div>
-          </div>
-        ))}
-      </div>
-    );
-  }
-
-  return (
-    <TableShell
-      empty={positions.length === 0}
-      emptyMessage={t('dailyReview.table.hold.empty')}
-      tableClassName="text-sm"
-      headers={(
-        <tr>
-          <th className="text-left p-2">{t('dailyReview.table.hold.headers.ticker')}</th>
-          <th className="text-right p-2">{t('dailyReview.table.hold.headers.entry')}</th>
-          <th className="text-right p-2">{t('dailyReview.table.hold.headers.current')}</th>
-          <th className="text-right p-2">{t('dailyReview.table.hold.headers.stop')}</th>
-          <th className="text-right p-2">
-            <MetricHelpLabel metricKey="R_NOW" className="justify-end w-full" />
-          </th>
-          <th className="text-left p-2">{t('dailyReview.table.hold.headers.reason')}</th>
-        </tr>
-      )}
-    >
-      {positions.map((pos) => (
-        <tr key={pos.positionId} className="border-b dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800">
-          <td className="p-2 font-mono font-bold">
-            <a
-              href={`https://finance.yahoo.com/quote/${pos.ticker}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-blue-600 hover:text-blue-800 hover:underline"
-              title={t('dailyReview.table.hold.yahooFinanceTooltip', { ticker: pos.ticker })}
-            >
-              {pos.ticker}
-            </a>
-            <WatchInlineBlock
-              ticker={pos.ticker}
-              currentPrice={pos.currentPrice}
-              source="daily_review_hold"
-              watchItemsByTicker={watchItemsByTicker}
-              watchPending={watchPending}
-              onWatch={onWatch}
-              onUnwatch={onUnwatch}
-            />
-            <CachedSymbolPriceChart ticker={pos.ticker} className="mt-1" />
-          </td>
-          <td className="p-2 text-right">{formatCurrency(pos.entryPrice)}</td>
-          <td className="p-2 text-right">{formatCurrency(pos.currentPrice)}</td>
-          <td className="p-2 text-right">{formatCurrency(pos.stopPrice)}</td>
-          <td className="p-2 text-right">
-            <span className={pos.rNow >= 0 ? 'text-green-700 dark:text-green-300' : 'text-red-700 dark:text-red-300'}>
-              {t('common.units.rValue', { value: formatNumber(pos.rNow, 2) })}
-            </span>
-          </td>
-          <td className="p-2 text-sm text-gray-600 dark:text-gray-400">{formatDailyReviewReason(pos.reason)}</td>
-        </tr>
-      ))}
-    </TableShell>
-  );
-}

--- a/web-ui/src/pages/Intelligence.tsx
+++ b/web-ui/src/pages/Intelligence.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useMemo, useState } from 'react';
 import { RefreshCw } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
+import { useLocalStorage } from '@/hooks/useLocalStorage';
 import Card, { CardContent, CardHeader, CardTitle } from '@/components/common/Card';
 import Button from '@/components/common/Button';
 import IntelligenceOpportunityCard from '@/components/domain/intelligence/IntelligenceOpportunityCard';
+import IntelligenceConfigPanel from '@/components/domain/intelligence/IntelligenceConfigPanel';
 import {
-  useCreateIntelligenceSymbolSetMutation,
-  useDeleteIntelligenceSymbolSetMutation,
   useIntelligenceConfigQuery,
   useIntelligenceEventsQuery,
   useIntelligenceMetricsQuery,
@@ -14,69 +14,52 @@ import {
   useIntelligenceProvidersQuery,
   useIntelligenceRunStatus,
   useIntelligenceSourcesHealthQuery,
-  useIntelligenceSymbolSetsQuery,
   useIntelligenceUpcomingCatalystsQuery,
   useRunIntelligenceMutation,
   useTestIntelligenceProviderMutation,
   useUpdateIntelligenceConfigMutation,
-  useUpdateIntelligenceSymbolSetMutation,
 } from '@/features/intelligence/hooks';
 import type {
   IntelligenceConfig,
-  IntelligenceLlmProvider,
   IntelligenceRunRequest,
 } from '@/features/intelligence/types';
+import { useIntelligenceSymbolSetEditor } from '@/features/intelligence/useIntelligenceSymbolSetEditor';
+import { PROVIDER_MODELS } from '@/content/intelligenceProviders';
 import { t } from '@/i18n/t';
 
-function normalizeSymbols(input: string): string[] {
-  const seen = new Set<string>();
-  return input
-    .split(',')
-    .map((value) => value.trim().toUpperCase())
-    .filter((value) => {
-      if (!value || seen.has(value)) return false;
-      seen.add(value);
-      return true;
-    });
-}
-
-const PROVIDER_MODELS: Record<IntelligenceLlmProvider, string[]> = {
-  ollama: ['mistral:7b-instruct', 'llama3.1:8b-instruct', 'qwen2.5:7b-instruct'],
-  openai: ['gpt-4o-mini', 'gpt-4.1-mini', 'gpt-4.1', 'o4-mini'],
-  mock: ['mock-classifier'],
-};
-
-const PROVIDER_DEFAULTS: Record<IntelligenceLlmProvider, { model: string; baseUrl: string }> = {
-  ollama: { model: 'mistral:7b-instruct', baseUrl: 'http://localhost:11434' },
-  openai: { model: 'gpt-4o-mini', baseUrl: 'https://api.openai.com/v1' },
-  mock: { model: 'mock-classifier', baseUrl: '' },
-};
 
 export default function IntelligencePage() {
   const navigate = useNavigate();
   const configQuery = useIntelligenceConfigQuery();
   const providersQuery = useIntelligenceProvidersQuery();
-  const symbolSetsQuery = useIntelligenceSymbolSetsQuery();
-
   const updateConfigMutation = useUpdateIntelligenceConfigMutation();
-  const createSymbolSetMutation = useCreateIntelligenceSymbolSetMutation();
-  const updateSymbolSetMutation = useUpdateIntelligenceSymbolSetMutation();
-  const deleteSymbolSetMutation = useDeleteIntelligenceSymbolSetMutation();
   const testProviderMutation = useTestIntelligenceProviderMutation();
 
   const [draftConfig, setDraftConfig] = useState<IntelligenceConfig | null>(null);
   const [jobId, setJobId] = useState<string>();
   const [asofDate, setAsofDate] = useState<string>();
   const [manualSymbolsInput, setManualSymbolsInput] = useState('');
-  const [selectedSymbolSetId, setSelectedSymbolSetId] = useState('');
-  const [symbolSetName, setSymbolSetName] = useState('');
-  const [symbolSetSymbolsInput, setSymbolSetSymbolsInput] = useState('');
-  const [showAdvancedConfig, setShowAdvancedConfig] = useState(() => {
-    if (typeof window === 'undefined') {
-      return false;
-    }
-    return window.localStorage.getItem('intelligence.showAdvancedConfig') === 'true';
-  });
+  const [showAdvancedConfig, setShowAdvancedConfig] = useLocalStorage(
+    'intelligence.showAdvancedConfig',
+    false,
+    // Handle both legacy raw-string ("true") and new JSON (true) formats
+    (val) => val === true || val === 'true',
+  );
+  const {
+    symbolSets,
+    selectedSymbolSetId,
+    setSelectedSymbolSetId,
+    selectedSymbolSet,
+    symbolSetName,
+    setSymbolSetName,
+    symbolSetSymbolsInput,
+    setSymbolSetSymbolsInput,
+    createSymbolSet,
+    updateSymbolSet,
+    deleteSymbolSet,
+    isCreating: isCreatingSymbolSet,
+    isUpdating: isUpdatingSymbolSet,
+  } = useIntelligenceSymbolSetEditor();
 
   useEffect(() => {
     if (configQuery.data) {
@@ -84,13 +67,14 @@ export default function IntelligencePage() {
     }
   }, [configQuery.data]);
 
-  useEffect(() => {
-    window.localStorage.setItem('intelligence.showAdvancedConfig', String(showAdvancedConfig));
-  }, [showAdvancedConfig]);
-
-  const symbolSets = symbolSetsQuery.data?.items ?? [];
-  const selectedSymbolSet = symbolSets.find((item) => item.id === selectedSymbolSetId);
-  const manualSymbols = useMemo(() => normalizeSymbols(manualSymbolsInput), [manualSymbolsInput]);
+  const manualSymbols = useMemo(
+    () => manualSymbolsInput
+      .split(',')
+      .map((v) => v.trim().toUpperCase())
+      .filter(Boolean)
+      .filter((v, i, arr) => arr.indexOf(v) === i),
+    [manualSymbolsInput],
+  );
   const llmModelOptions = useMemo(() => {
     if (!draftConfig) return [];
     const provider = draftConfig.llm.provider;
@@ -100,13 +84,6 @@ export default function IntelligencePage() {
     }
     return options.includes(draftConfig.llm.model) ? options : [draftConfig.llm.model, ...options];
   }, [draftConfig]);
-
-  useEffect(() => {
-    if (selectedSymbolSet) {
-      setSymbolSetName(selectedSymbolSet.name);
-      setSymbolSetSymbolsInput(selectedSymbolSet.symbols.join(', '));
-    }
-  }, [selectedSymbolSet]);
 
   const runMutation = useRunIntelligenceMutation((launch) => {
     setJobId(launch.jobId);
@@ -175,40 +152,6 @@ export default function IntelligencePage() {
     });
   };
 
-  const createSymbolSet = () => {
-    const symbols = normalizeSymbols(symbolSetSymbolsInput);
-    if (!symbolSetName.trim() || symbols.length === 0) return;
-    createSymbolSetMutation.mutate(
-      { name: symbolSetName.trim(), symbols },
-      {
-        onSuccess: (created) => {
-          setSelectedSymbolSetId(created.id);
-        },
-      }
-    );
-  };
-
-  const updateSymbolSet = () => {
-    if (!selectedSymbolSetId) return;
-    const symbols = normalizeSymbols(symbolSetSymbolsInput);
-    if (!symbolSetName.trim() || symbols.length === 0) return;
-    updateSymbolSetMutation.mutate({
-      id: selectedSymbolSetId,
-      payload: { name: symbolSetName.trim(), symbols },
-    });
-  };
-
-  const deleteSymbolSet = (id: string) => {
-    deleteSymbolSetMutation.mutate(id, {
-      onSuccess: () => {
-        if (selectedSymbolSetId === id) {
-          setSelectedSymbolSetId('');
-          setSymbolSetName('');
-          setSymbolSetSymbolsInput('');
-        }
-      },
-    });
-  };
 
   if (configQuery.isLoading || !draftConfig) {
     return <div className="text-sm text-gray-600 dark:text-gray-400">{t('intelligencePage.loading')}</div>;
@@ -295,10 +238,10 @@ export default function IntelligencePage() {
             />
           </div>
           <div className="mt-3 flex flex-wrap gap-2">
-            <Button onClick={createSymbolSetMutation.isPending ? undefined : createSymbolSet}>
+            <Button onClick={isCreatingSymbolSet ? undefined : createSymbolSet}>
               {t('intelligencePage.symbols.createSet')}
             </Button>
-            <Button variant="secondary" onClick={updateSymbolSetMutation.isPending ? undefined : updateSymbolSet}>
+            <Button variant="secondary" onClick={isUpdatingSymbolSet ? undefined : updateSymbolSet}>
               {t('intelligencePage.symbols.updateSet')}
             </Button>
             {selectedSymbolSetId && (
@@ -480,281 +423,16 @@ export default function IntelligencePage() {
       </Card>
 
       {showAdvancedConfig ? (
-        <Card variant="bordered">
-          <CardHeader>
-            <CardTitle>{t('intelligencePage.config.title')}</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-              <label className="text-sm">
-                <span className="mb-1 block text-xs text-gray-500">{t('intelligencePage.config.enabled')}</span>
-                <input
-                  type="checkbox"
-                  checked={draftConfig.enabled}
-                  onChange={(event) =>
-                    setDraftConfig({ ...draftConfig, enabled: event.target.checked })
-                  }
-                  aria-label={t('intelligencePage.config.enabled')}
-                  className="h-5 w-5 rounded border border-gray-300"
-                />
-              </label>
-              <label className="text-sm">
-                <span className="mb-1 block text-xs text-gray-500">{t('intelligencePage.config.providers')}</span>
-                <input
-                  value={draftConfig.providers.join(', ')}
-                  onChange={(event) =>
-                    setDraftConfig({
-                      ...draftConfig,
-                      providers: event.target.value
-                        .split(',')
-                        .map((value) => value.trim().toLowerCase())
-                        .filter((value, index, list) => value && list.indexOf(value) === index),
-                    })
-                  }
-                  className="w-full rounded border border-gray-300 px-3 py-2"
-                />
-              </label>
-              <label className="text-sm">
-                <span className="mb-1 block text-xs text-gray-500">{t('intelligencePage.config.llmProvider')}</span>
-                <select
-                  value={draftConfig.llm.provider}
-                  onChange={(event) => {
-                    const nextProvider = event.target.value as IntelligenceLlmProvider;
-                    const defaults = PROVIDER_DEFAULTS[nextProvider];
-                    const nextModel = PROVIDER_MODELS[nextProvider].includes(draftConfig.llm.model)
-                      ? draftConfig.llm.model
-                      : defaults.model;
-                    setDraftConfig({
-                      ...draftConfig,
-                      llm: {
-                        ...draftConfig.llm,
-                        provider: nextProvider,
-                        model: nextModel,
-                        baseUrl: defaults.baseUrl,
-                      },
-                    });
-                  }}
-                  aria-label={t('intelligencePage.config.llmProvider')}
-                  className="w-full rounded border border-gray-300 px-3 py-2"
-                >
-                  <option value="ollama">ollama</option>
-                  <option value="openai">openai</option>
-                  <option value="mock">mock</option>
-                </select>
-              </label>
-              <label className="text-sm">
-                <span className="mb-1 block text-xs text-gray-500">{t('intelligencePage.config.llmModel')}</span>
-                <select
-                  value={draftConfig.llm.model}
-                  onChange={(event) =>
-                    setDraftConfig({ ...draftConfig, llm: { ...draftConfig.llm, model: event.target.value } })
-                  }
-                  aria-label={t('intelligencePage.config.llmModel')}
-                  className="w-full rounded border border-gray-300 px-3 py-2"
-                >
-                  {llmModelOptions.map((modelName) => (
-                    <option key={modelName} value={modelName}>
-                      {modelName}
-                    </option>
-                  ))}
-                </select>
-              </label>
-              <label className="text-sm">
-                <span className="mb-1 block text-xs text-gray-500">{t('intelligencePage.config.llmBaseUrl')}</span>
-                <input
-                  value={draftConfig.llm.baseUrl}
-                  onChange={(event) =>
-                    setDraftConfig({ ...draftConfig, llm: { ...draftConfig.llm, baseUrl: event.target.value } })
-                  }
-                  className="w-full rounded border border-gray-300 px-3 py-2"
-                />
-              </label>
-              <label className="text-sm">
-                <span className="mb-1 block text-xs text-gray-500">{t('intelligencePage.config.llmApiKey')}</span>
-                <input
-                  type="password"
-                  autoComplete="off"
-                  value={draftConfig.llm.apiKey}
-                  onChange={(event) =>
-                    setDraftConfig({ ...draftConfig, llm: { ...draftConfig.llm, apiKey: event.target.value } })
-                  }
-                  className="w-full rounded border border-gray-300 px-3 py-2"
-                />
-              </label>
-              <label className="text-sm md:col-span-2">
-                <span className="mb-1 block text-xs text-gray-500">{t('intelligencePage.config.llmSystemPrompt')}</span>
-                <textarea
-                  value={draftConfig.llm.systemPrompt}
-                  onChange={(event) =>
-                    setDraftConfig({ ...draftConfig, llm: { ...draftConfig.llm, systemPrompt: event.target.value } })
-                  }
-                  rows={4}
-                  placeholder={t('intelligencePage.config.llmSystemPromptPlaceholder')}
-                  className="w-full rounded border border-gray-300 px-3 py-2 font-mono text-xs"
-                />
-              </label>
-              <label className="text-sm md:col-span-2">
-                <span className="mb-1 block text-xs text-gray-500">
-                  {t('intelligencePage.config.llmUserPromptTemplate')}
-                </span>
-                <textarea
-                  value={draftConfig.llm.userPromptTemplate}
-                  onChange={(event) =>
-                    setDraftConfig({
-                      ...draftConfig,
-                      llm: { ...draftConfig.llm, userPromptTemplate: event.target.value },
-                    })
-                  }
-                  rows={8}
-                  placeholder={t('intelligencePage.config.llmUserPromptTemplatePlaceholder')}
-                  className="w-full rounded border border-gray-300 px-3 py-2 font-mono text-xs"
-                />
-                <p className="mt-1 text-xs text-gray-500">{t('intelligencePage.config.llmPromptTemplateHint')}</p>
-              </label>
-              <label className="text-sm">
-                <span className="mb-1 block text-xs text-gray-500">{t('intelligencePage.config.maxConcurrency')}</span>
-                <input
-                  type="number"
-                  min={1}
-                  max={16}
-                  value={draftConfig.llm.maxConcurrency}
-                  onChange={(event) =>
-                    setDraftConfig({
-                      ...draftConfig,
-                      llm: {
-                        ...draftConfig.llm,
-                        maxConcurrency: Math.max(1, Math.min(16, Number(event.target.value) || 1)),
-                      },
-                    })
-                  }
-                  className="w-full rounded border border-gray-300 px-3 py-2"
-                />
-              </label>
-              <label className="text-sm">
-                <span className="mb-1 block text-xs text-gray-500">{t('intelligencePage.config.lookbackHours')}</span>
-                <input
-                  type="number"
-                  min={1}
-                  value={draftConfig.catalyst.lookbackHours}
-                  onChange={(event) =>
-                    setDraftConfig({
-                      ...draftConfig,
-                      catalyst: {
-                        ...draftConfig.catalyst,
-                        lookbackHours: Math.max(1, Number(event.target.value) || 1),
-                      },
-                    })
-                  }
-                  className="w-full rounded border border-gray-300 px-3 py-2"
-                />
-              </label>
-              <label className="text-sm">
-                <span className="mb-1 block text-xs text-gray-500">{t('intelligencePage.config.minScore')}</span>
-                <input
-                  type="number"
-                  step={0.01}
-                  min={0}
-                  max={1}
-                  value={draftConfig.opportunity.minOpportunityScore}
-                  onChange={(event) =>
-                    setDraftConfig({
-                      ...draftConfig,
-                      opportunity: {
-                        ...draftConfig.opportunity,
-                        minOpportunityScore: Math.max(0, Math.min(1, Number(event.target.value) || 0)),
-                      },
-                    })
-                  }
-                  className="w-full rounded border border-gray-300 px-3 py-2"
-                />
-              </label>
-              <label className="text-sm">
-                <span className="mb-1 block text-xs text-gray-500">Enable fallback scraping</span>
-                <input
-                  type="checkbox"
-                  checked={draftConfig.sources.scrapingEnabled}
-                  onChange={(event) =>
-                    setDraftConfig({
-                      ...draftConfig,
-                      sources: {
-                        ...draftConfig.sources,
-                        scrapingEnabled: event.target.checked,
-                      },
-                    })
-                  }
-                  className="h-5 w-5 rounded border border-gray-300"
-                />
-              </label>
-              <label className="text-sm">
-                <span className="mb-1 block text-xs text-gray-500">Allowed domains (comma-separated)</span>
-                <input
-                  value={draftConfig.sources.allowedDomains.join(', ')}
-                  onChange={(event) =>
-                    setDraftConfig({
-                      ...draftConfig,
-                      sources: {
-                        ...draftConfig.sources,
-                        allowedDomains: event.target.value
-                          .split(',')
-                          .map((value) => value.trim().toLowerCase())
-                          .filter((value, index, list) => value && list.indexOf(value) === index),
-                      },
-                    })
-                  }
-                  className="w-full rounded border border-gray-300 px-3 py-2"
-                />
-              </label>
-              <label className="text-sm">
-                <span className="mb-1 block text-xs text-gray-500">Binary event window (days)</span>
-                <input
-                  type="number"
-                  min={1}
-                  max={30}
-                  value={draftConfig.calendar.binaryEventWindowDays}
-                  onChange={(event) =>
-                    setDraftConfig({
-                      ...draftConfig,
-                      calendar: {
-                        ...draftConfig.calendar,
-                        binaryEventWindowDays: Math.max(1, Math.min(30, Number(event.target.value) || 1)),
-                      },
-                    })
-                  }
-                  className="w-full rounded border border-gray-300 px-3 py-2"
-                />
-              </label>
-            </div>
-
-            <div className="mt-4 flex flex-wrap gap-2">
-              <Button onClick={saveConfig} disabled={updateConfigMutation.isPending}>
-                {updateConfigMutation.isPending ? t('intelligencePage.config.saving') : t('intelligencePage.config.save')}
-              </Button>
-              <Button variant="secondary" onClick={testProvider}>
-                {t('intelligencePage.config.testProvider')}
-              </Button>
-            </div>
-
-            {testProviderMutation.data && (
-              <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
-                {t('intelligencePage.config.providerResult', {
-                  provider: testProviderMutation.data.provider,
-                  status: testProviderMutation.data.available ? 'OK' : 'UNAVAILABLE',
-                })}
-              </p>
-            )}
-
-            {providersQuery.data && (
-              <div className="mt-3 space-y-1 text-xs text-gray-500">
-                {providersQuery.data.map((provider) => (
-                  <p key={provider.provider}>
-                    {provider.provider}: {provider.available ? 'OK' : 'UNAVAILABLE'}
-                    {provider.detail ? ` (${provider.detail})` : ''}
-                  </p>
-                ))}
-              </div>
-            )}
-          </CardContent>
-        </Card>
+        <IntelligenceConfigPanel
+          draftConfig={draftConfig}
+          llmModelOptions={llmModelOptions}
+          isSaving={updateConfigMutation.isPending}
+          testProviderResult={testProviderMutation.data}
+          providersStatus={providersQuery.data}
+          onConfigChange={setDraftConfig}
+          onSave={saveConfig}
+          onTestProvider={testProvider}
+        />
       ) : null}
 
       <div

--- a/web-ui/src/pages/Onboarding.tsx
+++ b/web-ui/src/pages/Onboarding.tsx
@@ -1,97 +1,20 @@
-import { useEffect, useMemo, type ReactNode } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { CheckCircle, Calendar, Search, ShoppingCart } from 'lucide-react';
 import Button from '@/components/common/Button';
 import Card, { CardContent } from '@/components/common/Card';
-import OnboardingStrategySetupStep from '@/components/domain/onboarding/OnboardingStrategySetupStep';
 import { useStrategyReadiness } from '@/features/strategy/useStrategyReadiness';
 import { t } from '@/i18n/t';
 import { useBeginnerModeStore } from '@/stores/beginnerModeStore';
 import { useOnboardingStore } from '@/stores/onboardingStore';
+import { ONBOARDING_STEPS } from '@/content/onboardingSteps';
 
-type OnboardingStep = {
-  title: string;
-  description: string;
-  icon: typeof CheckCircle;
-  content: ReactNode;
-};
-
-const STEPS: OnboardingStep[] = [
-  {
-    title: t('onboardingPage.steps.welcome.title'),
-    description: t('onboardingPage.steps.welcome.description'),
-    icon: CheckCircle,
-    content: (
-      <div className="space-y-4 text-sm text-gray-700">
-        <p>{t('onboardingPage.steps.welcome.body')}</p>
-        <ol className="list-decimal space-y-2 pl-5">
-          <li>{t('onboardingPage.steps.welcome.items.configure')}</li>
-          <li>{t('onboardingPage.steps.welcome.items.review')}</li>
-          <li>{t('onboardingPage.steps.welcome.items.act')}</li>
-          <li>{t('onboardingPage.steps.welcome.items.verify')}</li>
-        </ol>
-      </div>
-    ),
-  },
-  {
-    title: t('onboardingPage.steps.strategy.title'),
-    description: t('onboardingPage.steps.strategy.description'),
-    icon: CheckCircle,
-    content: <OnboardingStrategySetupStep />,
-  },
-  {
-    title: t('onboardingPage.steps.dailyReview.title'),
-    description: t('onboardingPage.steps.dailyReview.description'),
-    icon: Calendar,
-    content: (
-      <div className="space-y-3 text-sm text-gray-700">
-        <p>{t('onboardingPage.steps.dailyReview.body')}</p>
-        <ul className="list-disc space-y-1 pl-5">
-          <li>{t('onboardingPage.steps.dailyReview.items.candidates')}</li>
-          <li>{t('onboardingPage.steps.dailyReview.items.updateStop')}</li>
-          <li>{t('onboardingPage.steps.dailyReview.items.close')}</li>
-          <li>{t('onboardingPage.steps.dailyReview.items.hold')}</li>
-        </ul>
-      </div>
-    ),
-  },
-  {
-    title: t('onboardingPage.steps.action.title'),
-    description: t('onboardingPage.steps.action.description'),
-    icon: ShoppingCart,
-    content: (
-      <div className="space-y-3 text-sm text-gray-700">
-        <p>{t('onboardingPage.steps.action.body')}</p>
-        <ul className="list-disc space-y-1 pl-5">
-          <li>{t('onboardingPage.steps.action.items.createOrder')}</li>
-          <li>{t('onboardingPage.steps.action.items.updatePosition')}</li>
-          <li>{t('onboardingPage.steps.action.items.noAction')}</li>
-        </ul>
-      </div>
-    ),
-  },
-  {
-    title: t('onboardingPage.steps.verify.title'),
-    description: t('onboardingPage.steps.verify.description'),
-    icon: Search,
-    content: (
-      <div className="space-y-3 text-sm text-gray-700">
-        <p>{t('onboardingPage.steps.verify.body')}</p>
-        <ul className="list-disc space-y-1 pl-5">
-          <li>{t('onboardingPage.steps.verify.items.orders')}</li>
-          <li>{t('onboardingPage.steps.verify.items.positions')}</li>
-        </ul>
-      </div>
-    ),
-  },
-];
 
 function parseStep(searchParams: URLSearchParams): number | null {
   const raw = searchParams.get('step');
   if (!raw) return null;
   const parsed = Number.parseInt(raw, 10);
   if (!Number.isFinite(parsed)) return null;
-  if (parsed < 1 || parsed > STEPS.length) return null;
+  if (parsed < 1 || parsed > ONBOARDING_STEPS.length) return null;
   return parsed - 1;
 }
 
@@ -110,8 +33,8 @@ export default function OnboardingPage() {
     setCurrentStep(requestedStep);
   }, [currentStep, searchParams, setCurrentStep]);
 
-  const stepIndex = Math.min(Math.max(currentStep, 0), STEPS.length - 1);
-  const step = STEPS[stepIndex];
+  const stepIndex = Math.min(Math.max(currentStep, 0), ONBOARDING_STEPS.length - 1);
+  const step = ONBOARDING_STEPS[stepIndex];
   const Icon = step.icon;
   const isStrategyStep = stepIndex === 1;
 
@@ -123,7 +46,7 @@ export default function OnboardingPage() {
   }, [isStrategyStep, strategyReady]);
 
   const handleNext = () => {
-    if (stepIndex >= STEPS.length - 1) {
+    if (stepIndex >= ONBOARDING_STEPS.length - 1) {
       completeOnboarding();
       navigate('/workspace');
       return;
@@ -165,7 +88,7 @@ export default function OnboardingPage() {
           </div>
 
           <div className="flex gap-2">
-            {STEPS.map((_, index) => (
+            {ONBOARDING_STEPS.map((_, index) => (
               <div
                 key={index}
                 className={`h-2 flex-1 rounded-full ${index <= stepIndex ? 'bg-blue-600' : 'bg-gray-200'}`}
@@ -173,7 +96,7 @@ export default function OnboardingPage() {
             ))}
           </div>
           <p className="text-xs text-gray-500">
-            {t('onboardingPage.progress', { step: stepIndex + 1, total: STEPS.length })}
+            {t('onboardingPage.progress', { step: stepIndex + 1, total: ONBOARDING_STEPS.length })}
           </p>
 
           {stepIndex === 0 ? (
@@ -220,7 +143,7 @@ export default function OnboardingPage() {
             </div>
 
             <Button onClick={handleNext} disabled={!canContinue}>
-              {stepIndex === STEPS.length - 1
+              {stepIndex === ONBOARDING_STEPS.length - 1
                 ? t('onboardingPage.actions.complete')
                 : t('onboardingPage.actions.next')}
             </Button>

--- a/web-ui/src/pages/Strategy.test.tsx
+++ b/web-ui/src/pages/Strategy.test.tsx
@@ -1,112 +1,43 @@
 import { describe, it, expect } from 'vitest';
-import { renderWithProviders, screen, within, waitForQueriesToSettle } from '@/test/utils';
-import { act } from '@testing-library/react';
+import { renderWithProviders, screen, waitForQueriesToSettle } from '@/test/utils';
 import StrategyPage from './Strategy';
-import { useBeginnerModeStore } from '@/stores/beginnerModeStore';
 
 describe('Strategy Page', () => {
-  it('renders strategy editor and loads options', async () => {
+  it('renders the read-only strategy overview', async () => {
     const { queryClient } = renderWithProviders(<StrategyPage />);
 
-    expect(
-      await screen.findByRole('heading', { name: /^Strategy$/ })
-    ).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: /^Strategy$/ })).toBeInTheDocument();
+    expect(await screen.findByText(/read-only strategy dashboard/i)).toBeInTheDocument();
+    expect(await screen.findByText('config/strategy.yaml')).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: /execution graph/i })).toBeInTheDocument();
 
-    const select = await screen.findByLabelText(/choose strategy/i);
-    expect(select).toBeInTheDocument();
-
-    expect(within(select).getByRole('option', { name: 'Default' })).toBeInTheDocument();
     await waitForQueriesToSettle(queryClient);
   });
 
-  it('toggles advanced settings via beginner mode', async () => {
-    const { user, queryClient } = renderWithProviders(<StrategyPage />);
+  it('shows validation summary and warnings', async () => {
+    renderWithProviders(<StrategyPage />);
 
-    // In beginner mode, advanced settings are hidden
-    expect(screen.queryByText('SMA Fast')).not.toBeInTheDocument();
-
-    // Find and toggle beginner mode off to access advanced settings
-    const beginnerModeCheckbox = await screen.findByRole('checkbox');
-    await act(async () => {
-      await user.click(beginnerModeCheckbox);
-    });
-
-    // Now advanced settings card should be visible, need to expand it
-    const advancedToggle = await screen.findByRole('button', { name: /show advanced/i });
-    await act(async () => {
-      await user.click(advancedToggle);
-    });
-
-    expect(await screen.findByText('SMA Fast')).toBeInTheDocument();
-    await waitForQueriesToSettle(queryClient);
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
+    expect(await screen.findByRole('heading', { name: /validation/i })).toBeInTheDocument();
+    expect(await screen.findByText(/safety score/i)).toBeInTheDocument();
+    expect(await screen.findByText(/breakoutlookback/i)).toBeInTheDocument();
+    expect(await screen.findByText(/false breakouts/i)).toBeInTheDocument();
   });
 
-  it('disables delete for default strategy', async () => {
-    const { queryClient } = renderWithProviders(<StrategyPage />);
+  it('groups plugins by category and shows override source', async () => {
+    renderWithProviders(<StrategyPage />);
 
-    const deleteButton = await screen.findByRole('button', { name: /delete/i });
-    expect(deleteButton).toBeDisabled();
-    await waitForQueriesToSettle(queryClient);
+    expect(await screen.findByRole('heading', { name: /filters/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: /qualification/i })).toBeInTheDocument();
+    expect(await screen.findByText('Volume Confirmation')).toBeInTheDocument();
+    expect(await screen.findByText('Root override')).toBeInTheDocument();
+    expect((await screen.findAllByText('Plugin default')).length).toBeGreaterThan(0);
+    expect((await screen.findAllByText(/depends on: breakout_signal/i)).length).toBeGreaterThan(0);
   });
 
-  it('can save a strategy as new', async () => {
-    const { user, queryClient } = renderWithProviders(<StrategyPage />);
+  it('shows enabled and disabled plugin badges', async () => {
+    renderWithProviders(<StrategyPage />);
 
-    const idInput = await screen.findByLabelText(/new id/i);
-    const nameInput = screen.getByLabelText(/new name/i);
-
-    await act(async () => {
-      await user.type(idInput, 'breakout_v2');
-      await user.type(nameInput, 'Breakout v2');
-    });
-
-    const saveButton = screen.getByRole('button', { name: /save as new/i });
-    await act(async () => {
-      await user.click(saveButton);
-    });
-
-    expect(await screen.findByText(/saved as new strategy/i)).toBeInTheDocument();
-    expect(await screen.findByRole('option', { name: 'Breakout v2' })).toBeInTheDocument();
-    await waitForQueriesToSettle(queryClient);
-  });
-
-  it('renders currency filter selector', async () => {
-    const { queryClient } = renderWithProviders(<StrategyPage />);
-
-    expect(await screen.findByRole('combobox', { name: /currencies/i })).toBeInTheDocument();
-    await waitForQueriesToSettle(queryClient);
-  });
-
-  it('shows strategy management toggle in beginner mobile layout', async () => {
-    const originalMatchMedia = window.matchMedia;
-    useBeginnerModeStore.setState({ isBeginnerMode: true });
-    window.matchMedia = ((query: string) => ({
-      matches: query === '(max-width: 767px)',
-      media: query,
-      onchange: null,
-      addListener: () => {},
-      removeListener: () => {},
-      addEventListener: () => {},
-      removeEventListener: () => {},
-      dispatchEvent: () => false,
-    })) as typeof window.matchMedia;
-
-    try {
-      const { user } = renderWithProviders(<StrategyPage />);
-      const showManagementButton = await screen.findByRole('button', { name: /show management/i });
-      expect(showManagementButton).toBeInTheDocument();
-
-      await act(async () => {
-        await user.click(showManagementButton);
-      });
-
-      expect(await screen.findByLabelText(/choose strategy/i)).toBeInTheDocument();
-    } finally {
-      window.matchMedia = originalMatchMedia;
-      useBeginnerModeStore.setState({ isBeginnerMode: false });
-    }
+    expect(await screen.findAllByText('Enabled')).not.toHaveLength(0);
+    expect(await screen.findAllByText('Disabled')).not.toHaveLength(0);
   });
 });

--- a/web-ui/src/pages/Strategy.test.tsx
+++ b/web-ui/src/pages/Strategy.test.tsx
@@ -1,3 +1,4 @@
+import { fireEvent } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import { renderWithProviders, screen, waitForQueriesToSettle } from '@/test/utils';
 import StrategyPage from './Strategy';
@@ -28,9 +29,12 @@ describe('Strategy Page', () => {
 
     expect(await screen.findByRole('heading', { name: /filters/i })).toBeInTheDocument();
     expect(await screen.findByRole('heading', { name: /qualification/i })).toBeInTheDocument();
-    expect(await screen.findByText('Volume Confirmation')).toBeInTheDocument();
+    fireEvent.click(await screen.findByRole('button', { name: /social overlay/i }));
     expect(await screen.findByText('Root override')).toBeInTheDocument();
     expect((await screen.findAllByText('Plugin default')).length).toBeGreaterThan(0);
+
+    fireEvent.click(await screen.findByRole('button', { name: /volume confirmation/i }));
+    expect(await screen.findByText('Volume Confirmation')).toBeInTheDocument();
     expect((await screen.findAllByText(/depends on: breakout_signal/i)).length).toBeGreaterThan(0);
   });
 
@@ -39,5 +43,20 @@ describe('Strategy Page', () => {
 
     expect(await screen.findAllByText('Enabled')).not.toHaveLength(0);
     expect(await screen.findAllByText('Disabled')).not.toHaveLength(0);
+  });
+
+  it('keeps only one plugin panel open at a time', async () => {
+    renderWithProviders(<StrategyPage />);
+
+    const priceFilterButton = await screen.findByRole('button', { name: /price filter/i });
+    const socialOverlayButton = await screen.findByRole('button', { name: /social overlay/i });
+
+    expect(priceFilterButton).toHaveAttribute('aria-expanded', 'true');
+    expect(socialOverlayButton).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.click(socialOverlayButton);
+
+    expect(priceFilterButton).toHaveAttribute('aria-expanded', 'false');
+    expect(socialOverlayButton).toHaveAttribute('aria-expanded', 'true');
   });
 });

--- a/web-ui/src/pages/Strategy.tsx
+++ b/web-ui/src/pages/Strategy.tsx
@@ -1,614 +1,215 @@
-import { useEffect, useMemo, useState } from 'react';
-import Card, { CardHeader, CardTitle, CardContent } from '@/components/common/Card';
-import Button from '@/components/common/Button';
-import { useStrategyEditor } from '@/features/strategy/useStrategyEditor';
-import { useStrategyValidationQuery } from '@/features/strategy/hooks';
-import { toStrategyUpdateRequest } from '@/features/strategy/types';
-import StrategyAdvancedSettingsCard from '@/components/domain/strategy/StrategyAdvancedSettingsCard';
-import StrategyCoreSettingsCards from '@/components/domain/strategy/StrategyCoreSettingsCards';
-import StrategyPhilosophyCard from '@/components/domain/strategy/StrategyPhilosophyCard';
-import StrategySafetyScore from '@/components/domain/strategy/StrategySafetyScore';
-import BeginnerModeToggle from '@/components/domain/strategy/BeginnerModeToggle';
-import StrategyPresets, { applyPresetToStrategy } from '@/components/domain/strategy/StrategyPresets';
-import { useI18n } from '@/i18n/I18nProvider';
+import { useMemo } from 'react';
+import Card, { CardContent, CardHeader, CardTitle } from '@/components/common/Card';
+import Badge from '@/components/common/Badge';
+import StrategyPluginCard from '@/components/domain/strategy/StrategyPluginCard';
 import {
-  buildHelp,
-  strategyFieldClass,
-  TextInput,
-} from '@/components/domain/strategy/StrategyFieldControls';
-import { getStrategyInfo } from '@/content/strategy_docs/loader';
-import { useBeginnerModeStore } from '@/stores/beginnerModeStore';
+  useResolvedStrategyValidationQuery,
+  useStrategyConfigQuery,
+  useStrategyPluginsQuery,
+} from '@/features/strategy/hooks';
+import type {
+  StrategyPluginCategory,
+  StrategyPluginDefinition,
+  StrategyPluginResolvedState,
+} from '@/features/strategy/types';
 
-const MOBILE_LAYOUT_MEDIA_QUERY = '(max-width: 767px)';
+const CATEGORY_LABELS: Record<string, string> = {
+  filters: 'Filters',
+  ranking: 'Ranking',
+  signals: 'Signals',
+  risk: 'Risk',
+  qualification: 'Qualification',
+  management: 'Management',
+  intelligence: 'Intelligence',
+  education: 'Education',
+};
 
-function getMobileLayoutMatch() {
-  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
-    return false;
-  }
-  return window.matchMedia(MOBILE_LAYOUT_MEDIA_QUERY).matches;
+function categoryLabel(category: StrategyPluginCategory): string {
+  return CATEGORY_LABELS[category] ?? category.charAt(0).toUpperCase() + category.slice(1);
+}
+
+function warningVariant(level: 'danger' | 'warning' | 'info') {
+  if (level === 'danger') return 'error' as const;
+  if (level === 'warning') return 'warning' as const;
+  return 'default' as const;
 }
 
 export default function StrategyPage() {
-  const { locale, t } = useI18n();
-  const { isBeginnerMode, setBeginnerMode } = useBeginnerModeStore();
+  const configQuery = useStrategyConfigQuery();
+  const pluginsQuery = useStrategyPluginsQuery();
+  const validationQuery = useResolvedStrategyValidationQuery();
 
-  const help = useMemo(
-    () => ({
-      module: buildHelp(
-        t('strategyPage.help.items.module.title'),
-        t('strategyPage.help.items.module.short'),
-        t('strategyPage.help.items.module.what'),
-        t('strategyPage.help.items.module.why'),
-        t('strategyPage.help.items.module.how')
-      ),
-      breakoutLookback: buildHelp(
-        t('strategyPage.help.items.breakoutLookback.title'),
-        t('strategyPage.help.items.breakoutLookback.short'),
-        t('strategyPage.help.items.breakoutLookback.what'),
-        t('strategyPage.help.items.breakoutLookback.why'),
-        t('strategyPage.help.items.breakoutLookback.how'),
-        t('strategyPage.help.items.breakoutLookback.execution')
-      ),
-      pullbackMa: buildHelp(
-        t('strategyPage.help.items.pullbackMa.title'),
-        t('strategyPage.help.items.pullbackMa.short'),
-        t('strategyPage.help.items.pullbackMa.what'),
-        t('strategyPage.help.items.pullbackMa.why'),
-        t('strategyPage.help.items.pullbackMa.how'),
-        t('strategyPage.help.items.pullbackMa.execution')
-      ),
-      minHistory: buildHelp(
-        t('strategyPage.help.items.minHistory.title'),
-        t('strategyPage.help.items.minHistory.short'),
-        t('strategyPage.help.items.minHistory.what'),
-        t('strategyPage.help.items.minHistory.why'),
-        t('strategyPage.help.items.minHistory.how')
-      ),
-      smaFast: buildHelp(
-        t('strategyPage.help.items.smaFast.title'),
-        t('strategyPage.help.items.smaFast.short'),
-        t('strategyPage.help.items.smaFast.what'),
-        t('strategyPage.help.items.smaFast.why'),
-        t('strategyPage.help.items.smaFast.how')
-      ),
-      smaMid: buildHelp(
-        t('strategyPage.help.items.smaMid.title'),
-        t('strategyPage.help.items.smaMid.short'),
-        t('strategyPage.help.items.smaMid.what'),
-        t('strategyPage.help.items.smaMid.why'),
-        t('strategyPage.help.items.smaMid.how')
-      ),
-      smaLong: buildHelp(
-        t('strategyPage.help.items.smaLong.title'),
-        t('strategyPage.help.items.smaLong.short'),
-        t('strategyPage.help.items.smaLong.what'),
-        t('strategyPage.help.items.smaLong.why'),
-        t('strategyPage.help.items.smaLong.how')
-      ),
-      atrWindow: buildHelp(
-        t('strategyPage.help.items.atrWindow.title'),
-        t('strategyPage.help.items.atrWindow.short'),
-        t('strategyPage.help.items.atrWindow.what'),
-        t('strategyPage.help.items.atrWindow.why'),
-        t('strategyPage.help.items.atrWindow.how')
-      ),
-      atrMultiplier: buildHelp(
-        t('strategyPage.help.items.atrMultiplier.title'),
-        t('strategyPage.help.items.atrMultiplier.short'),
-        t('strategyPage.help.items.atrMultiplier.what'),
-        t('strategyPage.help.items.atrMultiplier.why'),
-        t('strategyPage.help.items.atrMultiplier.how')
-      ),
-      minRr: buildHelp(
-        t('strategyPage.help.items.minRr.title'),
-        t('strategyPage.help.items.minRr.short'),
-        t('strategyPage.help.items.minRr.what'),
-        t('strategyPage.help.items.minRr.why'),
-        t('strategyPage.help.items.minRr.how')
-      ),
-      maxFeeRiskPct: buildHelp(
-        t('strategyPage.help.items.maxFeeRiskPct.title'),
-        t('strategyPage.help.items.maxFeeRiskPct.short'),
-        t('strategyPage.help.items.maxFeeRiskPct.what'),
-        t('strategyPage.help.items.maxFeeRiskPct.why'),
-        t('strategyPage.help.items.maxFeeRiskPct.how')
-      ),
-      maxAtrPct: buildHelp(
-        t('strategyPage.help.items.maxAtrPct.title'),
-        t('strategyPage.help.items.maxAtrPct.short'),
-        t('strategyPage.help.items.maxAtrPct.what'),
-        t('strategyPage.help.items.maxAtrPct.why'),
-        t('strategyPage.help.items.maxAtrPct.how')
-      ),
-      requireTrendOk: buildHelp(
-        t('strategyPage.help.items.requireTrendOk.title'),
-        t('strategyPage.help.items.requireTrendOk.short'),
-        t('strategyPage.help.items.requireTrendOk.what'),
-        t('strategyPage.help.items.requireTrendOk.why'),
-        t('strategyPage.help.items.requireTrendOk.how')
-      ),
-      requireRsPositive: buildHelp(
-        t('strategyPage.help.items.requireRsPositive.title'),
-        t('strategyPage.help.items.requireRsPositive.short'),
-        t('strategyPage.help.items.requireRsPositive.what'),
-        t('strategyPage.help.items.requireRsPositive.why'),
-        t('strategyPage.help.items.requireRsPositive.how')
-      ),
-      currencies: buildHelp(
-        t('strategyPage.help.items.currencies.title'),
-        t('strategyPage.help.items.currencies.short'),
-        t('strategyPage.help.items.currencies.what'),
-        t('strategyPage.help.items.currencies.why'),
-        t('strategyPage.help.items.currencies.how')
-      ),
-      momentum6m: buildHelp(
-        t('strategyPage.help.items.momentum6m.title'),
-        t('strategyPage.help.items.momentum6m.short'),
-        t('strategyPage.help.items.momentum6m.what'),
-        t('strategyPage.help.items.momentum6m.why'),
-        t('strategyPage.help.items.momentum6m.how')
-      ),
-      momentum12m: buildHelp(
-        t('strategyPage.help.items.momentum12m.title'),
-        t('strategyPage.help.items.momentum12m.short'),
-        t('strategyPage.help.items.momentum12m.what'),
-        t('strategyPage.help.items.momentum12m.why'),
-        t('strategyPage.help.items.momentum12m.how')
-      ),
-      benchmark: buildHelp(
-        t('strategyPage.help.items.benchmark.title'),
-        t('strategyPage.help.items.benchmark.short'),
-        t('strategyPage.help.items.benchmark.what'),
-        t('strategyPage.help.items.benchmark.why'),
-        t('strategyPage.help.items.benchmark.how')
-      ),
-      weightMom6m: buildHelp(
-        t('strategyPage.help.items.weightMom6m.title'),
-        t('strategyPage.help.items.weightMom6m.short'),
-        t('strategyPage.help.items.weightMom6m.what'),
-        t('strategyPage.help.items.weightMom6m.why'),
-        t('strategyPage.help.items.weightMom6m.how')
-      ),
-      weightMom12m: buildHelp(
-        t('strategyPage.help.items.weightMom12m.title'),
-        t('strategyPage.help.items.weightMom12m.short'),
-        t('strategyPage.help.items.weightMom12m.what'),
-        t('strategyPage.help.items.weightMom12m.why'),
-        t('strategyPage.help.items.weightMom12m.how')
-      ),
-      weightRs: buildHelp(
-        t('strategyPage.help.items.weightRs.title'),
-        t('strategyPage.help.items.weightRs.short'),
-        t('strategyPage.help.items.weightRs.what'),
-        t('strategyPage.help.items.weightRs.why'),
-        t('strategyPage.help.items.weightRs.how')
-      ),
-      trailSma: buildHelp(
-        t('strategyPage.help.items.trailSma.title'),
-        t('strategyPage.help.items.trailSma.short'),
-        t('strategyPage.help.items.trailSma.what'),
-        t('strategyPage.help.items.trailSma.why'),
-        t('strategyPage.help.items.trailSma.how')
-      ),
-      smaBuffer: buildHelp(
-        t('strategyPage.help.items.smaBuffer.title'),
-        t('strategyPage.help.items.smaBuffer.short'),
-        t('strategyPage.help.items.smaBuffer.what'),
-        t('strategyPage.help.items.smaBuffer.why'),
-        t('strategyPage.help.items.smaBuffer.how')
-      ),
-      regimeEnabled: buildHelp(
-        t('strategyPage.help.items.regimeEnabled.title'),
-        t('strategyPage.help.items.regimeEnabled.short'),
-        t('strategyPage.help.items.regimeEnabled.what'),
-        t('strategyPage.help.items.regimeEnabled.why'),
-        t('strategyPage.help.items.regimeEnabled.how')
-      ),
-      regimeTrendSma: buildHelp(
-        t('strategyPage.help.items.regimeTrendSma.title'),
-        t('strategyPage.help.items.regimeTrendSma.short'),
-        t('strategyPage.help.items.regimeTrendSma.what'),
-        t('strategyPage.help.items.regimeTrendSma.why'),
-        t('strategyPage.help.items.regimeTrendSma.how')
-      ),
-      regimeTrendMultiplier: buildHelp(
-        t('strategyPage.help.items.regimeTrendMultiplier.title'),
-        t('strategyPage.help.items.regimeTrendMultiplier.short'),
-        t('strategyPage.help.items.regimeTrendMultiplier.what'),
-        t('strategyPage.help.items.regimeTrendMultiplier.why'),
-        t('strategyPage.help.items.regimeTrendMultiplier.how')
-      ),
-      regimeVolAtrWindow: buildHelp(
-        t('strategyPage.help.items.regimeVolAtrWindow.title'),
-        t('strategyPage.help.items.regimeVolAtrWindow.short'),
-        t('strategyPage.help.items.regimeVolAtrWindow.what'),
-        t('strategyPage.help.items.regimeVolAtrWindow.why'),
-        t('strategyPage.help.items.regimeVolAtrWindow.how')
-      ),
-      regimeVolAtrPctThreshold: buildHelp(
-        t('strategyPage.help.items.regimeVolAtrPctThreshold.title'),
-        t('strategyPage.help.items.regimeVolAtrPctThreshold.short'),
-        t('strategyPage.help.items.regimeVolAtrPctThreshold.what'),
-        t('strategyPage.help.items.regimeVolAtrPctThreshold.why'),
-        t('strategyPage.help.items.regimeVolAtrPctThreshold.how')
-      ),
-      regimeVolMultiplier: buildHelp(
-        t('strategyPage.help.items.regimeVolMultiplier.title'),
-        t('strategyPage.help.items.regimeVolMultiplier.short'),
-        t('strategyPage.help.items.regimeVolMultiplier.what'),
-        t('strategyPage.help.items.regimeVolMultiplier.why'),
-        t('strategyPage.help.items.regimeVolMultiplier.how')
-      ),
-      socialOverlayEnabled: buildHelp(
-        t('strategyPage.help.items.socialOverlayEnabled.title'),
-        t('strategyPage.help.items.socialOverlayEnabled.short'),
-        t('strategyPage.help.items.socialOverlayEnabled.what'),
-        t('strategyPage.help.items.socialOverlayEnabled.why'),
-        t('strategyPage.help.items.socialOverlayEnabled.how')
-      ),
-      lookbackHours: buildHelp(
-        t('strategyPage.help.items.lookbackHours.title'),
-        t('strategyPage.help.items.lookbackHours.short'),
-        t('strategyPage.help.items.lookbackHours.what'),
-        t('strategyPage.help.items.lookbackHours.why'),
-        t('strategyPage.help.items.lookbackHours.how')
-      ),
-      attentionZThreshold: buildHelp(
-        t('strategyPage.help.items.attentionZThreshold.title'),
-        t('strategyPage.help.items.attentionZThreshold.short'),
-        t('strategyPage.help.items.attentionZThreshold.what'),
-        t('strategyPage.help.items.attentionZThreshold.why'),
-        t('strategyPage.help.items.attentionZThreshold.how')
-      ),
-      minSampleSize: buildHelp(
-        t('strategyPage.help.items.minSampleSize.title'),
-        t('strategyPage.help.items.minSampleSize.short'),
-        t('strategyPage.help.items.minSampleSize.what'),
-        t('strategyPage.help.items.minSampleSize.why'),
-        t('strategyPage.help.items.minSampleSize.how')
-      ),
-      negativeSentThreshold: buildHelp(
-        t('strategyPage.help.items.negativeSentThreshold.title'),
-        t('strategyPage.help.items.negativeSentThreshold.short'),
-        t('strategyPage.help.items.negativeSentThreshold.what'),
-        t('strategyPage.help.items.negativeSentThreshold.why'),
-        t('strategyPage.help.items.negativeSentThreshold.how')
-      ),
-      sentimentConfThreshold: buildHelp(
-        t('strategyPage.help.items.sentimentConfThreshold.title'),
-        t('strategyPage.help.items.sentimentConfThreshold.short'),
-        t('strategyPage.help.items.sentimentConfThreshold.what'),
-        t('strategyPage.help.items.sentimentConfThreshold.why'),
-        t('strategyPage.help.items.sentimentConfThreshold.how')
-      ),
-      hypePercentileThreshold: buildHelp(
-        t('strategyPage.help.items.hypePercentileThreshold.title'),
-        t('strategyPage.help.items.hypePercentileThreshold.short'),
-        t('strategyPage.help.items.hypePercentileThreshold.what'),
-        t('strategyPage.help.items.hypePercentileThreshold.why'),
-        t('strategyPage.help.items.hypePercentileThreshold.how')
-      ),
-    }),
-    [locale, t]
-  );
-
-  const {
-    canCreate,
-    createDescription,
-    createId,
-    createMutation,
-    createName,
-    deleteMutation,
-    draft,
-    handleCreate,
-    handleDelete,
-    handleReset,
-    handleSave,
-    handleSetActive,
-    highFeeWarning,
-    idAlreadyExists,
-    isActive,
-    lowRrWarning,
-    selectedId,
-    selectedStrategy,
-    setCreateDescription,
-    setCreateId,
-    setCreateName,
-    setDraft,
-    setSelectedId,
-    setShowAdvanced,
-    showAdvanced,
-    statusMessage,
-    strategies,
-    strategiesQuery,
-    updateMutation,
-  } = useStrategyEditor();
-
-  const validationPayload = useMemo(
-    () => (draft ? toStrategyUpdateRequest(draft) : null),
-    [draft],
-  );
-  const strategyValidationQuery = useStrategyValidationQuery(validationPayload);
-  const validationResult = strategyValidationQuery.data;
-  const validationWarnings = validationResult?.warnings ?? [];
-  const [isCompactMobileLayout, setIsCompactMobileLayout] = useState(getMobileLayoutMatch);
-  const [showStrategyManagement, setShowStrategyManagement] = useState(() => {
-    if (typeof window === 'undefined') {
-      return true;
+  const definitionsById = useMemo(() => {
+    const map = new Map<string, StrategyPluginDefinition>();
+    for (const plugin of pluginsQuery.data ?? []) {
+      map.set(plugin.id, plugin);
     }
-    const stored = window.localStorage.getItem('strategy.showManagement');
-    if (stored == null) {
-      return !(isBeginnerMode && getMobileLayoutMatch());
+    return map;
+  }, [pluginsQuery.data]);
+
+  const groupedPlugins = useMemo(() => {
+    const groups = new Map<string, StrategyPluginResolvedState[]>();
+    for (const plugin of configQuery.data?.plugins ?? []) {
+      const category = plugin.category ?? 'education';
+      const existing = groups.get(category) ?? [];
+      existing.push(plugin);
+      groups.set(category, existing);
     }
-    return stored === 'true';
-  });
+    return Array.from(groups.entries()).sort(([a], [b]) => categoryLabel(a).localeCompare(categoryLabel(b)));
+  }, [configQuery.data?.plugins]);
 
-  useEffect(() => {
-    window.localStorage.setItem('strategy.showManagement', String(showStrategyManagement));
-  }, [showStrategyManagement]);
-
-  useEffect(() => {
-    if (!isBeginnerMode || !isCompactMobileLayout) {
-      setShowStrategyManagement(true);
-    }
-  }, [isBeginnerMode, isCompactMobileLayout]);
-
-  useEffect(() => {
-    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
-      return;
-    }
-
-    const mediaQueryList = window.matchMedia(MOBILE_LAYOUT_MEDIA_QUERY);
-    const handleChange = (event: MediaQueryListEvent) => {
-      setIsCompactMobileLayout(event.matches);
-    };
-
-    setIsCompactMobileLayout(mediaQueryList.matches);
-    mediaQueryList.addEventListener('change', handleChange);
-    return () => mediaQueryList.removeEventListener('change', handleChange);
-  }, []);
-
-  return (
-    <div className={`mx-auto max-w-5xl space-y-6 ${draft ? 'pb-28 md:pb-0' : ''}`}>
-      <div className="flex flex-wrap items-center justify-between gap-4">
-        <div>
-          <h1 className="text-3xl font-bold">{t('strategyPage.header.title')}</h1>
-          <p className="text-sm text-gray-500 mt-1">{t('strategyPage.header.subtitle')}</p>
-        </div>
-        <div className="flex w-full flex-wrap gap-2 sm:w-auto">
-          <Button
-            variant="secondary"
-            onClick={handleReset}
-            disabled={!draft || updateMutation.isPending}
-            className="flex-1 sm:flex-none"
-          >
-            {t('strategyPage.actions.resetChanges')}
-          </Button>
-          <Button
-            onClick={handleSave}
-            disabled={!draft || updateMutation.isPending}
-            className="flex-1 sm:flex-none"
-          >
-            {updateMutation.isPending ? t('strategyPage.actions.saving') : t('strategyPage.actions.saveChanges')}
-          </Button>
-        </div>
+  if (configQuery.isLoading || pluginsQuery.isLoading || validationQuery.isLoading) {
+    return (
+      <div className="space-y-6">
+        <h1 className="text-2xl font-bold">Strategy</h1>
+        <Card variant="bordered">
+          <CardContent className="text-sm text-gray-600 dark:text-gray-300">Loading strategy configuration…</CardContent>
+        </Card>
       </div>
+    );
+  }
 
-      {draft && isBeginnerMode ? (
-        <Card variant="bordered" className="border-emerald-200 bg-emerald-50/70 dark:border-emerald-900 dark:bg-emerald-950/20">
-          <CardHeader>
-            <CardTitle>{t('strategyPage.quickStart.title')}</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            <ol className="space-y-1 text-sm text-gray-700 dark:text-gray-200">
-              <li>{t('strategyPage.quickStart.step1')}</li>
-              <li>{t('strategyPage.quickStart.step2')}</li>
-              <li>{t('strategyPage.quickStart.step3')}</li>
-            </ol>
-            <Button onClick={handleSave} disabled={!draft || updateMutation.isPending} className="w-full sm:w-auto">
-              {updateMutation.isPending ? t('strategyPage.actions.saving') : t('strategyPage.quickStart.primaryAction')}
-            </Button>
+  const error = configQuery.error ?? pluginsQuery.error ?? validationQuery.error;
+  if (error) {
+    return (
+      <div className="space-y-6">
+        <h1 className="text-2xl font-bold">Strategy</h1>
+        <Card variant="bordered">
+          <CardContent className="text-sm text-red-600 dark:text-red-300">
+            {error instanceof Error ? error.message : 'Failed to load strategy configuration.'}
           </CardContent>
         </Card>
-      ) : null}
+      </div>
+    );
+  }
+
+  const config = configQuery.data;
+  const validation = validationQuery.data;
+
+  if (!config || !validation) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <h1 className="text-2xl font-bold">Strategy</h1>
+        <p className="text-sm text-gray-600 dark:text-gray-300">
+          Read-only strategy dashboard backed by YAML plugin configuration.
+        </p>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-[minmax(0,2fr),minmax(320px,1fr)]">
+        <Card variant="bordered">
+          <CardHeader>
+            <CardTitle>{config.name}</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm">
+            {config.description ? (
+              <p className="text-gray-700 dark:text-gray-300">{config.description}</p>
+            ) : null}
+            <div className="flex flex-wrap gap-2">
+              <Badge variant="primary">{config.module}</Badge>
+              {config.configPath ? <Badge variant="default">{config.configPath}</Badge> : null}
+              <Badge variant="default">{config.plugins.length} plugins</Badge>
+            </div>
+            <p className="text-gray-600 dark:text-gray-400">
+              Values shown here are resolved from plugin defaults plus root YAML overrides.
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card variant="bordered">
+          <CardHeader>
+            <CardTitle>Validation</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <div className="flex flex-wrap gap-2">
+              <Badge variant={validation.isValid ? 'success' : 'error'}>
+                {validation.isValid ? 'Valid' : 'Needs attention'}
+              </Badge>
+              <Badge variant="default">Safety score {validation.safetyScore}</Badge>
+              <Badge variant="default">{validation.safetyLevel}</Badge>
+            </div>
+            {validation.warnings.length ? (
+              <div className="space-y-2">
+                {validation.warnings.map((warning) => (
+                  <div
+                    key={`${warning.parameter}-${warning.message}`}
+                    className="rounded-lg border border-gray-200 p-3 dark:border-gray-700"
+                  >
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Badge variant={warningVariant(warning.level)}>{warning.level}</Badge>
+                      <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                        {warning.parameter}
+                      </span>
+                    </div>
+                    <p className="mt-2 text-sm text-gray-700 dark:text-gray-300">{warning.message}</p>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="text-sm text-gray-600 dark:text-gray-300">No validation warnings.</p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
 
       <Card variant="bordered">
-        <CardHeader className="flex flex-row items-center justify-between gap-2">
-          <CardTitle>{t('strategyPage.selection.title')}</CardTitle>
-          {isBeginnerMode && isCompactMobileLayout ? (
-            <Button
-              type="button"
-              size="sm"
-              variant="secondary"
-              onClick={() => setShowStrategyManagement((current) => !current)}
-            >
-              {showStrategyManagement
-                ? t('strategyPage.selection.hideManagement')
-                : t('strategyPage.selection.showManagement')}
-            </Button>
-          ) : null}
+        <CardHeader>
+          <CardTitle>Execution Graph</CardTitle>
         </CardHeader>
-        <CardContent>
-          {showStrategyManagement ? (
-            <>
-              <div className="grid grid-cols-1 md:grid-cols-3 gap-4 items-end">
-                <label className="text-sm font-medium md:col-span-2">
-                  <div className="mb-2">{t('strategyPage.selection.chooseStrategy')}</div>
-                  <select
-                    value={selectedId}
-                    onChange={(e) => setSelectedId(e.target.value)}
-                    className={strategyFieldClass}
-                    disabled={strategiesQuery.isLoading}
+        <CardContent className="space-y-3 text-sm">
+          <p className="text-gray-600 dark:text-gray-300">
+            Execution order is resolved from plugin phases plus declared capabilities and dependencies.
+          </p>
+          {config.executionOrder.length ? (
+            <ol className="grid gap-2 md:grid-cols-2 xl:grid-cols-3">
+              {config.executionOrder.map((pluginId, index) => {
+                const plugin = config.plugins.find((entry) => entry.id === pluginId);
+                return (
+                  <li
+                    key={pluginId}
+                    className="rounded-lg border border-gray-200 p-3 dark:border-gray-700"
                   >
-                    {!strategies.length && (
-                      <option value="">
-                        {strategiesQuery.isLoading
-                          ? t('strategyPage.selection.loadingStrategies')
-                          : t('strategyPage.selection.noStrategies')}
-                      </option>
-                    )}
-                    {strategies.map((strategy) => (
-                      <option key={strategy.id} value={strategy.id}>
-                        {strategy.name}
-                      </option>
-                    ))}
-                  </select>
-                </label>
-                <div className="flex items-center gap-2">
-                  <Button variant="secondary" onClick={handleSetActive} disabled={!selectedStrategy || isActive}>
-                    {isActive ? t('strategyPage.selection.active') : t('strategyPage.selection.setActive')}
-                  </Button>
-                  <Button
-                    variant="danger"
-                    onClick={handleDelete}
-                    disabled={!selectedStrategy || selectedStrategy?.isDefault || deleteMutation.isPending}
-                  >
-                    {deleteMutation.isPending ? t('strategyPage.selection.deleting') : t('common.actions.delete')}
-                  </Button>
-                  {selectedStrategy?.isDefault && (
-                    <span className="text-xs text-gray-500">{t('strategyPage.selection.default')}</span>
-                  )}
-                </div>
-              </div>
-              <div className="mt-5 border-t border-border pt-4 space-y-3">
-                <div className="text-sm font-semibold">{t('strategyPage.create.title')}</div>
-                <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                  <TextInput
-                    label={t('strategyPage.create.newId')}
-                    value={createId}
-                    onChange={(value) => setCreateId(value)}
-                    placeholder={t('strategyPage.create.newIdPlaceholder')}
-                  />
-                  <TextInput
-                    label={t('strategyPage.create.newName')}
-                    value={createName}
-                    onChange={(value) => setCreateName(value)}
-                    placeholder={t('strategyPage.create.newNamePlaceholder')}
-                  />
-                  <TextInput
-                    label={t('strategyPage.create.newDescription')}
-                    value={createDescription}
-                    onChange={(value) => setCreateDescription(value)}
-                    placeholder={t('strategyPage.create.newDescriptionPlaceholder')}
-                  />
-                </div>
-                {idAlreadyExists && (
-                  <div className="text-xs text-red-600">{t('strategyPage.create.idAlreadyExists')}</div>
-                )}
-                <div className="flex items-center gap-2">
-                  <Button onClick={handleCreate} disabled={!canCreate}>
-                    {createMutation.isPending ? t('strategyPage.actions.saving') : t('strategyPage.create.saveAsNew')}
-                  </Button>
-                  <div className="text-xs text-gray-500">
-                    {t('strategyPage.create.idHint')}
-                  </div>
-                </div>
-              </div>
-              {statusMessage && <div className="mt-3 text-sm text-green-600">{statusMessage}</div>}
-              {updateMutation.isError && (
-                <div className="mt-3 text-sm text-red-600">{t('strategyPage.errors.saveFailed')}</div>
-              )}
-              {createMutation.isError && (
-                <div className="mt-3 text-sm text-red-600">
-                  {(createMutation.error as Error)?.message || t('strategyPage.errors.createFailed')}
-                </div>
-              )}
-              {deleteMutation.isError && (
-                <div className="mt-3 text-sm text-red-600">
-                  {(deleteMutation.error as Error)?.message || t('strategyPage.errors.deleteFailed')}
-                </div>
-              )}
-            </>
+                    <div className="flex items-center justify-between gap-3">
+                      <span className="font-medium text-gray-900 dark:text-gray-100">
+                        {index + 1}. {plugin?.displayName ?? pluginId}
+                      </span>
+                      <Badge variant="default">{plugin?.phase ?? 'qualification'}</Badge>
+                    </div>
+                    {plugin?.dependsOn.length ? (
+                      <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+                        Depends on: {plugin.dependsOn.join(', ')}
+                      </p>
+                    ) : null}
+                  </li>
+                );
+              })}
+            </ol>
           ) : (
-            <div className="text-sm text-gray-500">{t('strategyPage.selection.managementHiddenHint')}</div>
+            <p className="text-gray-600 dark:text-gray-300">No enabled plugins found.</p>
           )}
         </CardContent>
       </Card>
 
-      {!draft && (
-        <Card variant="bordered">
-          <CardContent>
-            <div className="text-sm text-gray-500">{t('strategyPage.selection.selectToEdit')}</div>
-          </CardContent>
-        </Card>
-      )}
-
-      {draft && (
-        <>
-          {/* Strategy Philosophy Card - Shows the "Why" before the "What" */}
-          {(() => {
-            const strategyInfo = getStrategyInfo(draft.module ?? 'momentum');
-            return strategyInfo ? <StrategyPhilosophyCard strategyInfo={strategyInfo} /> : null;
-          })()}
-
-          {/* Beginner Mode Toggle */}
-          <BeginnerModeToggle
-            isBeginnerMode={isBeginnerMode}
-            onToggle={setBeginnerMode}
-          />
-
-          {/* Presets - Only show in beginner mode */}
-          {isBeginnerMode && (
-            <StrategyPresets
-              currentStrategy={draft}
-              onApplyPreset={(preset) => {
-                const updated = applyPresetToStrategy(draft, preset);
-                setDraft(updated);
-              }}
-            />
-          )}
-
-          {/* Safety Score - Provides feedback on configuration quality */}
-          <StrategySafetyScore
-            validation={validationResult}
-            isLoading={strategyValidationQuery.isLoading || strategyValidationQuery.isFetching}
-            isError={strategyValidationQuery.isError}
-          />
-
-          <StrategyCoreSettingsCards
-            draft={draft}
-            setDraft={setDraft}
-            help={help}
-            validationWarnings={validationWarnings}
-            useEnhancedEducation={isBeginnerMode}
-          />
-
-          {/* Advanced Settings - Hidden in beginner mode */}
-          {!isBeginnerMode && (
-            <StrategyAdvancedSettingsCard
-              draft={draft}
-              setDraft={setDraft}
-              showAdvanced={showAdvanced}
-              setShowAdvanced={setShowAdvanced}
-              lowRrWarning={lowRrWarning}
-              highFeeWarning={highFeeWarning}
-              help={help}
-            />
-          )}
-        </>
-      )}
-
-      {draft ? (
-        <div className="fixed inset-x-0 z-30 border-t border-gray-200 bg-white/95 px-3 py-3 shadow-[0_-8px_20px_rgba(0,0,0,0.08)] md:hidden dark:border-gray-700 dark:bg-gray-900/95" style={{ bottom: 'calc(env(safe-area-inset-bottom) + 5.2rem)' }}>
-          <div className="mx-auto flex max-w-5xl items-center gap-2">
-            <Button
-              variant="secondary"
-              onClick={handleReset}
-              disabled={!draft || updateMutation.isPending}
-              className="flex-1"
-            >
-              {t('strategyPage.actions.resetChanges')}
-            </Button>
-            <Button
-              onClick={handleSave}
-              disabled={!draft || updateMutation.isPending}
-              className="flex-[1.35]"
-            >
-              {updateMutation.isPending ? t('strategyPage.actions.saving') : t('strategyPage.actions.saveChanges')}
-            </Button>
+      {groupedPlugins.map(([category, plugins]) => (
+        <section key={category} className="space-y-4">
+          <div className="flex items-center justify-between">
+            <h2 className="text-xl font-semibold">{categoryLabel(category)}</h2>
+            <Badge variant="default">{plugins.length}</Badge>
           </div>
-        </div>
-      ) : null}
+          <div className="grid gap-4 xl:grid-cols-2">
+            {plugins.map((plugin) => (
+              <StrategyPluginCard
+                key={plugin.id}
+                plugin={plugin}
+                definition={definitionsById.get(plugin.id)}
+              />
+            ))}
+          </div>
+        </section>
+      ))}
     </div>
   );
 }

--- a/web-ui/src/pages/Strategy.tsx
+++ b/web-ui/src/pages/Strategy.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import Card, { CardContent, CardHeader, CardTitle } from '@/components/common/Card';
 import Badge from '@/components/common/Badge';
 import StrategyPluginCard from '@/components/domain/strategy/StrategyPluginCard';
@@ -38,6 +38,7 @@ export default function StrategyPage() {
   const configQuery = useStrategyConfigQuery();
   const pluginsQuery = useStrategyPluginsQuery();
   const validationQuery = useResolvedStrategyValidationQuery();
+  const [openPluginId, setOpenPluginId] = useState<string | null>(null);
 
   const definitionsById = useMemo(() => {
     const map = new Map<string, StrategyPluginDefinition>();
@@ -57,6 +58,12 @@ export default function StrategyPage() {
     }
     return Array.from(groups.entries()).sort(([a], [b]) => categoryLabel(a).localeCompare(categoryLabel(b)));
   }, [configQuery.data?.plugins]);
+
+  useEffect(() => {
+    if (!configQuery.data?.plugins?.length) return;
+    if (openPluginId && configQuery.data.plugins.some((plugin) => plugin.id === openPluginId)) return;
+    setOpenPluginId(configQuery.data.plugins[0].id);
+  }, [configQuery.data?.plugins, openPluginId]);
 
   if (configQuery.isLoading || pluginsQuery.isLoading || validationQuery.isLoading) {
     return (
@@ -199,12 +206,14 @@ export default function StrategyPage() {
             <h2 className="text-xl font-semibold">{categoryLabel(category)}</h2>
             <Badge variant="default">{plugins.length}</Badge>
           </div>
-          <div className="grid gap-4 xl:grid-cols-2">
+          <div className="space-y-4">
             {plugins.map((plugin) => (
               <StrategyPluginCard
                 key={plugin.id}
                 plugin={plugin}
                 definition={definitionsById.get(plugin.id)}
+                isOpen={openPluginId === plugin.id}
+                onToggle={() => setOpenPluginId((current) => (current === plugin.id ? null : plugin.id))}
               />
             ))}
           </div>

--- a/web-ui/src/pages/Strategy.tsx
+++ b/web-ui/src/pages/Strategy.tsx
@@ -12,20 +12,23 @@ import type {
   StrategyPluginDefinition,
   StrategyPluginResolvedState,
 } from '@/features/strategy/types';
+import { t } from '@/i18n/t';
 
-const CATEGORY_LABELS: Record<string, string> = {
-  filters: 'Filters',
-  ranking: 'Ranking',
-  signals: 'Signals',
-  risk: 'Risk',
-  qualification: 'Qualification',
-  management: 'Management',
-  intelligence: 'Intelligence',
-  education: 'Education',
+const CATEGORY_I18N_KEYS: Partial<Record<StrategyPluginCategory, string>> = {
+  filters: 'strategyPage.categories.filters',
+  ranking: 'strategyPage.categories.ranking',
+  signals: 'strategyPage.categories.signals',
+  risk: 'strategyPage.categories.risk',
+  qualification: 'strategyPage.categories.qualification',
+  management: 'strategyPage.categories.management',
+  intelligence: 'strategyPage.categories.intelligence',
+  education: 'strategyPage.categories.education',
 };
 
 function categoryLabel(category: StrategyPluginCategory): string {
-  return CATEGORY_LABELS[category] ?? category.charAt(0).toUpperCase() + category.slice(1);
+  const key = CATEGORY_I18N_KEYS[category];
+  if (key) return t(key as Parameters<typeof t>[0]);
+  return category.charAt(0).toUpperCase() + category.slice(1);
 }
 
 function warningVariant(level: 'danger' | 'warning' | 'info') {

--- a/web-ui/src/pages/Strategy.tsx
+++ b/web-ui/src/pages/Strategy.tsx
@@ -71,9 +71,9 @@ export default function StrategyPage() {
   if (configQuery.isLoading || pluginsQuery.isLoading || validationQuery.isLoading) {
     return (
       <div className="space-y-6">
-        <h1 className="text-2xl font-bold">Strategy</h1>
+        <h1 className="text-2xl font-bold">{t('strategyPage.header.title')}</h1>
         <Card variant="bordered">
-          <CardContent className="text-sm text-gray-600 dark:text-gray-300">Loading strategy configuration…</CardContent>
+          <CardContent className="text-sm text-gray-600 dark:text-gray-300">{t('strategyPage.pluginDashboard.loading')}</CardContent>
         </Card>
       </div>
     );
@@ -83,10 +83,10 @@ export default function StrategyPage() {
   if (error) {
     return (
       <div className="space-y-6">
-        <h1 className="text-2xl font-bold">Strategy</h1>
+        <h1 className="text-2xl font-bold">{t('strategyPage.header.title')}</h1>
         <Card variant="bordered">
           <CardContent className="text-sm text-red-600 dark:text-red-300">
-            {error instanceof Error ? error.message : 'Failed to load strategy configuration.'}
+            {error instanceof Error ? error.message : t('strategyPage.pluginDashboard.loadFailed')}
           </CardContent>
         </Card>
       </div>
@@ -103,9 +103,9 @@ export default function StrategyPage() {
   return (
     <div className="space-y-6">
       <div className="space-y-2">
-        <h1 className="text-2xl font-bold">Strategy</h1>
+        <h1 className="text-2xl font-bold">{t('strategyPage.header.title')}</h1>
         <p className="text-sm text-gray-600 dark:text-gray-300">
-          Read-only strategy dashboard backed by YAML plugin configuration.
+          {t('strategyPage.pluginDashboard.subtitle')}
         </p>
       </div>
 
@@ -121,24 +121,24 @@ export default function StrategyPage() {
             <div className="flex flex-wrap gap-2">
               <Badge variant="primary">{config.module}</Badge>
               {config.configPath ? <Badge variant="default">{config.configPath}</Badge> : null}
-              <Badge variant="default">{config.plugins.length} plugins</Badge>
+              <Badge variant="default">{t('strategyPage.pluginDashboard.pluginsCount', { count: config.plugins.length })}</Badge>
             </div>
             <p className="text-gray-600 dark:text-gray-400">
-              Values shown here are resolved from plugin defaults plus root YAML overrides.
+              {t('strategyPage.pluginDashboard.resolvedValuesNote')}
             </p>
           </CardContent>
         </Card>
 
         <Card variant="bordered">
           <CardHeader>
-            <CardTitle>Validation</CardTitle>
+            <CardTitle>{t('strategyPage.pluginDashboard.validation.title')}</CardTitle>
           </CardHeader>
           <CardContent className="space-y-3">
             <div className="flex flex-wrap gap-2">
               <Badge variant={validation.isValid ? 'success' : 'error'}>
-                {validation.isValid ? 'Valid' : 'Needs attention'}
+                {validation.isValid ? t('strategyPage.pluginDashboard.validation.valid') : t('strategyPage.pluginDashboard.validation.needsAttention')}
               </Badge>
-              <Badge variant="default">Safety score {validation.safetyScore}</Badge>
+              <Badge variant="default">{t('strategyPage.pluginDashboard.validation.safetyScore', { score: validation.safetyScore })}</Badge>
               <Badge variant="default">{validation.safetyLevel}</Badge>
             </div>
             {validation.warnings.length ? (
@@ -159,7 +159,7 @@ export default function StrategyPage() {
                 ))}
               </div>
             ) : (
-              <p className="text-sm text-gray-600 dark:text-gray-300">No validation warnings.</p>
+              <p className="text-sm text-gray-600 dark:text-gray-300">{t('strategyPage.pluginDashboard.validation.noWarnings')}</p>
             )}
           </CardContent>
         </Card>
@@ -167,11 +167,11 @@ export default function StrategyPage() {
 
       <Card variant="bordered">
         <CardHeader>
-          <CardTitle>Execution Graph</CardTitle>
+          <CardTitle>{t('strategyPage.pluginDashboard.executionGraph.title')}</CardTitle>
         </CardHeader>
         <CardContent className="space-y-3 text-sm">
           <p className="text-gray-600 dark:text-gray-300">
-            Execution order is resolved from plugin phases plus declared capabilities and dependencies.
+            {t('strategyPage.pluginDashboard.executionGraph.description')}
           </p>
           {config.executionOrder.length ? (
             <ol className="grid gap-2 md:grid-cols-2 xl:grid-cols-3">
@@ -190,7 +190,7 @@ export default function StrategyPage() {
                     </div>
                     {plugin?.dependsOn.length ? (
                       <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
-                        Depends on: {plugin.dependsOn.join(', ')}
+                        {t('strategyPage.pluginDashboard.executionGraph.dependsOn', { items: plugin.dependsOn.join(', ') })}
                       </p>
                     ) : null}
                   </li>
@@ -198,7 +198,7 @@ export default function StrategyPage() {
               })}
             </ol>
           ) : (
-            <p className="text-gray-600 dark:text-gray-300">No enabled plugins found.</p>
+            <p className="text-gray-600 dark:text-gray-300">{t('strategyPage.pluginDashboard.executionGraph.noPlugins')}</p>
           )}
         </CardContent>
       </Card>

--- a/web-ui/src/test/mocks/handlers.ts
+++ b/web-ui/src/test/mocks/handlers.ts
@@ -155,6 +155,227 @@ type StrategyPayload = (typeof mockStrategies)[number]
 let activeStrategyId = mockStrategies[0].id
 let strategies: StrategyPayload[] = [...mockStrategies]
 
+export const mockStrategyPlugins = [
+  {
+    id: 'price_filter',
+    category: 'filters',
+    display_name: 'Price Filter',
+    description: 'Limits the universe to tradable price ranges.',
+    enabled_by_default: true,
+    phase: 'universe',
+    provides: ['price_filtered_universe'],
+    requires: [],
+    modifies: ['eligible_universe'],
+    conflicts: [],
+    config_fields: [
+      { key: 'min_price', label: 'Min Price', description: 'Minimum allowed price.' },
+      { key: 'max_price', label: 'Max Price', description: 'Maximum allowed price.' },
+    ],
+    read_only_sections: [
+      { title: 'Why it matters', body: 'Avoids names outside the intended price envelope.' },
+    ],
+  },
+  {
+    id: 'breakout_signal',
+    category: 'signals',
+    display_name: 'Breakout Signal',
+    description: 'Detects strength when price clears prior highs.',
+    enabled_by_default: true,
+    phase: 'signals',
+    provides: ['breakout_signal', 'signal_candidates'],
+    requires: [],
+    modifies: ['signal_candidates'],
+    conflicts: [],
+    config_fields: [
+      { key: 'breakout_lookback', label: 'Breakout Lookback' },
+      { key: 'min_history', label: 'Minimum History' },
+    ],
+    read_only_sections: [
+      { title: 'How it affects trades', body: 'Longer lookbacks reduce noise but generate fewer entries.' },
+    ],
+  },
+  {
+    id: 'atr_position_sizing',
+    category: 'risk',
+    display_name: 'ATR Position Sizing',
+    description: 'Uses ATR and account constraints to size trades.',
+    enabled_by_default: true,
+    phase: 'risk',
+    provides: ['position_size'],
+    requires: ['signal_candidates'],
+    modifies: ['risk_budget'],
+    conflicts: [],
+    config_fields: [
+      { key: 'risk_pct', label: 'Risk %' },
+      { key: 'k_atr', label: 'ATR Multiplier' },
+    ],
+    read_only_sections: [
+      { title: 'Default guidance', body: 'Position size should stay systematic as volatility changes.' },
+    ],
+  },
+  {
+    id: 'social_overlay',
+    category: 'qualification',
+    display_name: 'Social Overlay',
+    description: 'Adds contextual awareness from attention and sentiment.',
+    enabled_by_default: false,
+    phase: 'qualification',
+    provides: ['social_signal_boost'],
+    requires: ['signal_candidates'],
+    modifies: ['candidate_score'],
+    conflicts: [],
+    config_fields: [
+      { key: 'lookback_hours', label: 'Lookback Hours' },
+      { key: 'attention_z_threshold', label: 'Attention Z Threshold' },
+    ],
+    read_only_sections: [
+      { title: 'Tradeoffs', body: 'Useful as context, but not as the main reason to enter.' },
+    ],
+  },
+  {
+    id: 'volume_confirmation',
+    category: 'qualification',
+    display_name: 'Volume Confirmation',
+    description: 'Validates breakouts only when volume exceeds the configured threshold.',
+    enabled_by_default: false,
+    phase: 'qualification',
+    provides: ['volume_breakout_confirmation'],
+    requires: ['breakout_signal'],
+    modifies: ['signal_validation'],
+    conflicts: [],
+    config_fields: [
+      { key: 'volume_ma_window', label: 'Volume MA Window' },
+      { key: 'min_breakout_volume_ratio', label: 'Min Breakout Volume Ratio' },
+      { key: 'apply_to_breakout', label: 'Apply to Breakout' },
+      { key: 'apply_to_pullback', label: 'Apply to Pullback' },
+    ],
+    read_only_sections: [
+      { title: 'Why it matters', body: 'A breakout with weak volume is easier to fade.' },
+    ],
+  },
+]
+
+export const mockStrategyConfig = {
+  name: 'Default',
+  description: 'Read-only strategy config resolved from YAML plugin defaults and root overrides.',
+  module: 'momentum',
+  config_path: 'config/strategy.yaml',
+  execution_order: ['price_filter', 'breakout_signal', 'social_overlay', 'atr_position_sizing'],
+  graph_edges: {
+    price_filter: ['breakout_signal', 'social_overlay', 'atr_position_sizing'],
+    breakout_signal: ['social_overlay', 'atr_position_sizing'],
+    social_overlay: ['atr_position_sizing'],
+    atr_position_sizing: [],
+  },
+  plugins: [
+    {
+      id: 'price_filter',
+      category: 'filters',
+      display_name: 'Price Filter',
+      description: 'Limits the universe to tradable price ranges.',
+      enabled: true,
+      default_enabled: true,
+      phase: 'universe',
+      provides: ['price_filtered_universe'],
+      requires: [],
+      modifies: ['eligible_universe'],
+      conflicts: [],
+      depends_on: [],
+      read_only_sections: [
+        { title: 'Why it matters', body: 'Keeps the universe inside the intended price envelope.' },
+      ],
+      values: [
+        { key: 'min_price', label: 'Min Price', default_value: 5.0, effective_value: 5.0, overridden: false, source: 'plugin_default' },
+        { key: 'max_price', label: 'Max Price', default_value: 500.0, effective_value: 500.0, overridden: false, source: 'plugin_default' },
+      ],
+    },
+    {
+      id: 'breakout_signal',
+      category: 'signals',
+      display_name: 'Breakout Signal',
+      description: 'Detects strength when price clears prior highs.',
+      enabled: true,
+      default_enabled: true,
+      phase: 'signals',
+      provides: ['breakout_signal', 'signal_candidates'],
+      requires: [],
+      modifies: ['signal_candidates'],
+      conflicts: [],
+      depends_on: ['price_filter'],
+      read_only_sections: [
+        { title: 'How it affects trades', body: 'Higher lookbacks make the signal stricter.' },
+      ],
+      values: [
+        { key: 'breakout_lookback', label: 'Breakout Lookback', default_value: 50, effective_value: 50, overridden: false, source: 'plugin_default' },
+        { key: 'min_history', label: 'Minimum History', default_value: 260, effective_value: 260, overridden: false, source: 'plugin_default' },
+      ],
+    },
+    {
+      id: 'atr_position_sizing',
+      category: 'risk',
+      display_name: 'ATR Position Sizing',
+      description: 'Uses ATR and account constraints to size trades.',
+      enabled: true,
+      default_enabled: true,
+      phase: 'risk',
+      provides: ['position_size'],
+      requires: ['signal_candidates'],
+      modifies: ['risk_budget'],
+      conflicts: [],
+      depends_on: ['breakout_signal', 'social_overlay'],
+      read_only_sections: [
+        { title: 'Default guidance', body: 'The strategy sizes risk first, not conviction first.' },
+      ],
+      values: [
+        { key: 'risk_pct', label: 'Risk %', default_value: 0.01, effective_value: 0.01, overridden: false, source: 'plugin_default' },
+        { key: 'k_atr', label: 'ATR Multiplier', default_value: 2.0, effective_value: 2.0, overridden: false, source: 'plugin_default' },
+      ],
+    },
+    {
+      id: 'social_overlay',
+      category: 'qualification',
+      display_name: 'Social Overlay',
+      description: 'Adds contextual awareness from attention and sentiment.',
+      enabled: true,
+      default_enabled: false,
+      phase: 'qualification',
+      provides: ['social_signal_boost'],
+      requires: ['signal_candidates'],
+      modifies: ['candidate_score'],
+      conflicts: [],
+      depends_on: ['breakout_signal'],
+      read_only_sections: [
+        { title: 'Tradeoffs', body: 'Context can help, but hype should not become the thesis.' },
+      ],
+      values: [
+        { key: 'lookback_hours', label: 'Lookback Hours', default_value: 24, effective_value: 24, overridden: false, source: 'plugin_default' },
+        { key: 'attention_z_threshold', label: 'Attention Z Threshold', default_value: 3.0, effective_value: 3.5, overridden: true, source: 'root_override' },
+      ],
+    },
+    {
+      id: 'volume_confirmation',
+      category: 'qualification',
+      display_name: 'Volume Confirmation',
+      description: 'Validates breakouts only when volume exceeds the configured threshold.',
+      enabled: false,
+      default_enabled: false,
+      phase: 'qualification',
+      provides: ['volume_breakout_confirmation'],
+      requires: ['breakout_signal'],
+      modifies: ['signal_validation'],
+      conflicts: [],
+      depends_on: ['breakout_signal'],
+      read_only_sections: [
+        { title: 'Why it matters', body: 'Volume helps distinguish strong breakouts from thin ones.' },
+      ],
+      values: [
+        { key: 'volume_ma_window', label: 'Volume MA Window', default_value: 20, effective_value: 20, overridden: false, source: 'plugin_default' },
+        { key: 'min_breakout_volume_ratio', label: 'Min Breakout Volume Ratio', default_value: 1.5, effective_value: 1.5, overridden: false, source: 'plugin_default' },
+      ],
+    },
+  ],
+}
+
 const asObject = (value: unknown): Record<string, any> => (
   value && typeof value === 'object' ? (value as Record<string, any>) : {}
 )
@@ -655,6 +876,33 @@ export const handlers = [
   }),
 
   // Strategy endpoints
+  http.get(`${API_BASE_URL}/api/strategy/config`, () => {
+    return HttpResponse.json(mockStrategyConfig)
+  }),
+
+  http.get(`${API_BASE_URL}/api/strategy/plugins`, () => {
+    return HttpResponse.json(mockStrategyPlugins)
+  }),
+
+  http.get(`${API_BASE_URL}/api/strategy/validation`, () => {
+    return HttpResponse.json({
+      is_valid: false,
+      warnings: [
+        {
+          parameter: 'breakoutLookback',
+          level: 'warning',
+          message: 'Breakout Lookback below 40 increases the chance of false breakouts.',
+        },
+      ],
+      safety_score: 92,
+      safety_level: 'beginner-safe',
+      total_warnings: 1,
+      danger_count: 0,
+      warning_count: 1,
+      info_count: 0,
+    })
+  }),
+
   http.get(`${API_BASE_URL}/api/strategy`, () => {
     return HttpResponse.json(strategies)
   }),

--- a/web-ui/src/types/recommendation.ts
+++ b/web-ui/src/types/recommendation.ts
@@ -194,7 +194,74 @@ export interface RecommendationAPI {
   costs: RecommendationCostsAPI;
   checklist: ChecklistGateAPI[];
   education: RecommendationEducationAPI;
-  thesis?: any;  // Thesis comes as dict from backend
+  thesis?: TradeThesisAPI;
+}
+
+// Internal API types for thesis transformation
+interface InvalidationRuleAPI {
+  rule_id: string;
+  condition: string;
+  metric?: string;
+  threshold?: number;
+}
+
+interface GeneratedEducationErrorAPI {
+  view: string;
+  code: string;
+  message: string;
+  retryable: boolean;
+  provider_error_id?: string;
+}
+
+interface TradePersonalityAPI {
+  trend_strength: 1 | 2 | 3 | 4 | 5;
+  volatility_rating: 1 | 2 | 3 | 4 | 5;
+  conviction: 1 | 2 | 3 | 4 | 5;
+  complexity: string;
+}
+
+interface StructuredExplanationAPI {
+  why_qualified: string[];
+  what_could_go_wrong: string[];
+  setup_type: string;
+  key_insight: string;
+}
+
+interface TradeThesisAPI {
+  ticker: string;
+  strategy: string;
+  entry_type: string;
+  trend_status: string;
+  relative_strength: string;
+  regime_alignment: boolean;
+  volatility_state: string;
+  risk_reward: number;
+  setup_quality_score: number;
+  setup_quality_tier: string;
+  institutional_signal: boolean;
+  price_action_quality: string;
+  safety_label: string;
+  personality: TradePersonalityAPI;
+  explanation: StructuredExplanationAPI;
+  invalidation_rules: InvalidationRuleAPI[];
+  professional_insight?: string;
+  beginner_explanation?: {
+    text: string;
+    source: 'llm' | 'deterministic_fallback';
+    model?: string | null;
+    generated_at?: string | null;
+  };
+  education_generated?: {
+    recommendation?: unknown;
+    thesis?: unknown;
+    learn?: unknown;
+    status?: string | null;
+    source?: string | null;
+    template_version?: string | null;
+    deterministic_facts?: Record<string, string>;
+    errors?: GeneratedEducationErrorAPI[];
+    generated_at?: string | null;
+  };
 }
 
 export function transformRecommendation(api: RecommendationAPI): Recommendation {
@@ -241,7 +308,7 @@ export function transformRecommendation(api: RecommendationAPI): Recommendation 
   };
 }
 
-function transformThesis(apiThesis: any): TradeThesis {
+function transformThesis(apiThesis: TradeThesisAPI): TradeThesis {
   const apiEducation = apiThesis.education_generated;
   return {
     ticker: apiThesis.ticker,
@@ -269,7 +336,7 @@ function transformThesis(apiThesis: any): TradeThesis {
       setupType: apiThesis.explanation.setup_type,
       keyInsight: apiThesis.explanation.key_insight,
     },
-    invalidationRules: apiThesis.invalidation_rules.map((rule: any) => ({
+    invalidationRules: apiThesis.invalidation_rules.map((rule: InvalidationRuleAPI) => ({
       ruleId: rule.rule_id,
       condition: rule.condition,
       metric: rule.metric,
@@ -289,12 +356,12 @@ function transformThesis(apiThesis: any): TradeThesis {
           recommendation: transformGeneratedEducationView(apiEducation.recommendation),
           thesis: transformGeneratedEducationView(apiEducation.thesis),
           learn: transformGeneratedEducationView(apiEducation.learn),
-          status: apiEducation.status ?? undefined,
-          source: apiEducation.source ?? undefined,
+          status: (apiEducation.status ?? undefined) as GeneratedEducationPayload['status'],
+          source: (apiEducation.source ?? undefined) as GeneratedEducationPayload['source'],
           templateVersion: apiEducation.template_version ?? undefined,
           deterministicFacts: apiEducation.deterministic_facts ?? {},
-          errors: (apiEducation.errors ?? []).map((error: any) => ({
-            view: error.view,
+          errors: (apiEducation.errors ?? []).map((error: GeneratedEducationErrorAPI) => ({
+            view: error.view as GeneratedEducationViewName,
             code: error.code,
             message: error.message,
             retryable: Boolean(error.retryable),
@@ -306,27 +373,31 @@ function transformThesis(apiThesis: any): TradeThesis {
   };
 }
 
-function transformGeneratedEducationView(apiView: any): GeneratedEducationView | undefined {
+function transformGeneratedEducationView(apiView: unknown): GeneratedEducationView | undefined {
   if (!apiView || typeof apiView !== 'object') {
     return undefined;
   }
+  const view = apiView as Record<string, unknown>;
   return {
-    title: String(apiView.title ?? ''),
-    summary: String(apiView.summary ?? ''),
-    bullets: Array.isArray(apiView.bullets) ? apiView.bullets.map((value: unknown) => String(value)) : [],
-    watchouts: Array.isArray(apiView.watchouts) ? apiView.watchouts.map((value: unknown) => String(value)) : [],
-    nextSteps: Array.isArray(apiView.next_steps ?? apiView.nextSteps)
-      ? (apiView.next_steps ?? apiView.nextSteps).map((value: unknown) => String(value))
-      : [],
-    glossaryLinks: Array.isArray(apiView.glossary_links ?? apiView.glossaryLinks)
-      ? (apiView.glossary_links ?? apiView.glossaryLinks).map((value: unknown) => String(value))
-      : [],
-    factsUsed: Array.isArray(apiView.facts_used ?? apiView.factsUsed)
-      ? (apiView.facts_used ?? apiView.factsUsed).map((value: unknown) => String(value))
-      : [],
-    source: apiView.source === 'llm' ? 'llm' : 'deterministic_fallback',
-    templateVersion: String(apiView.template_version ?? apiView.templateVersion ?? 'v1'),
-    generatedAt: String(apiView.generated_at ?? apiView.generatedAt ?? ''),
-    debugRef: apiView.debug_ref ?? apiView.debugRef ?? undefined,
+    title: String(view.title ?? ''),
+    summary: String(view.summary ?? ''),
+    bullets: Array.isArray(view.bullets) ? (view.bullets as unknown[]).map((value: unknown) => String(value)) : [],
+    watchouts: Array.isArray(view.watchouts) ? (view.watchouts as unknown[]).map((value: unknown) => String(value)) : [],
+    nextSteps: (() => {
+      const raw = view.next_steps ?? view.nextSteps;
+      return Array.isArray(raw) ? (raw as unknown[]).map((value: unknown) => String(value)) : [];
+    })(),
+    glossaryLinks: (() => {
+      const raw = view.glossary_links ?? view.glossaryLinks;
+      return Array.isArray(raw) ? (raw as unknown[]).map((value: unknown) => String(value)) : [];
+    })(),
+    factsUsed: (() => {
+      const raw = view.facts_used ?? view.factsUsed;
+      return Array.isArray(raw) ? (raw as unknown[]).map((value: unknown) => String(value)) : [];
+    })(),
+    source: view.source === 'llm' ? 'llm' : 'deterministic_fallback',
+    templateVersion: String(view.template_version ?? view.templateVersion ?? 'v1'),
+    generatedAt: String(view.generated_at ?? view.generatedAt ?? ''),
+    debugRef: (view.debug_ref ?? view.debugRef) as string | undefined,
   };
 }

--- a/web-ui/src/utils/dailyReviewFormatters.ts
+++ b/web-ui/src/utils/dailyReviewFormatters.ts
@@ -1,0 +1,14 @@
+import { t } from '@/i18n/t';
+
+const TIME_EXIT_REASON_PATTERN = /Time exit:\s*(\d+)\s*bars since entry_date\s*>=\s*(\d+)/i;
+
+export function formatDailyReviewReason(reason: string): string {
+  const timeExitMatch = reason.match(TIME_EXIT_REASON_PATTERN);
+  if (timeExitMatch) {
+    return t('dailyReview.reason.timeExit', {
+      barsSince: Number(timeExitMatch[1]),
+      maxBars: Number(timeExitMatch[2]),
+    });
+  }
+  return reason;
+}


### PR DESCRIPTION
This pull request introduces significant enhancements to the strategy plugin system by implementing a read-only, plugin-based strategy configuration and validation interface. It also adds new fields and logic to the screener candidate and recommendation pipeline to support volume confirmation checks. The changes are grouped into two main themes: strategy plugin system improvements and screener enhancements.

**Strategy Plugin System Improvements:**

* Introduced new read-only models for plugin-based strategy configuration, plugin definitions, and validation results in `api/models/strategy_runtime.py`, and updated `api/models/__init__.py` to export these models. [[1]](diffhunk://#diff-b4b60a55cda277bba28b60e0916a197d18ab2a6303b7548681e6ca62054a4ba9R1-R71) [[2]](diffhunk://#diff-beb3cbd98627983f90284c36d2bd1a7a44fecc6ef7d7f03ee1f8bb249f3f9893R22-R26) [[3]](diffhunk://#diff-beb3cbd98627983f90284c36d2bd1a7a44fecc6ef7d7f03ee1f8bb249f3f9893R105-R107)
* Refactored `StrategyRepository` to use a plugin-based, YAML-driven approach for reading strategies, resolving configs, listing plugin definitions, and performing validation. Editing and activation of strategies are now explicitly unsupported in read-only mode.
* Updated `StrategyService` to expose new methods for getting resolved configs, listing plugins, and validating the current strategy, while disallowing all editing operations.
* Added new API endpoints in `api/routers/strategy.py` for retrieving resolved strategy config, listing plugin definitions, and validating the current strategy configuration.

**Screener and Recommendation Enhancements:**

* Added new volume-related fields (`today_volume`, `average_volume`, `volume_ratio`, `volume_confirmation_passed`) to the `ScreenerCandidate` model and integrated logic in the screener service to populate these fields and include volume confirmation gates, reasons, and suggestions in recommendations. [[1]](diffhunk://#diff-6c25f5f81872b94599245f66ee5eb1d4e9ac7ad7cbec2228a09bb9520660142eR41-R44) [[2]](diffhunk://#diff-97a88fc161d76e495eb85fb22732bf0a8aa31f8de177b87bc0e1ac94808be9bbR550-R589) [[3]](diffhunk://#diff-97a88fc161d76e495eb85fb22732bf0a8aa31f8de177b87bc0e1ac94808be9bbR616-R618) [[4]](diffhunk://#diff-97a88fc161d76e495eb85fb22732bf0a8aa31f8de177b87bc0e1ac94808be9bbR650-R653)

These changes collectively modernize the strategy configuration system for plugin-based extensibility and improve the screener's ability to communicate volume confirmation checks to users.