### PR TITLE
Polish analysis canvas follow-up UX

### DIFF
--- a/web-ui/src/components/domain/fundamentals/FundamentalsSnapshotCard.tsx
+++ b/web-ui/src/components/domain/fundamentals/FundamentalsSnapshotCard.tsx
@@ -39,6 +39,10 @@ function formatSeriesValue(value: number, unit: 'number' | 'currency' | 'percent
   return formatNumber(value);
 }
 
+function comparePeriodDesc(left: string, right: string) {
+  return right.localeCompare(left);
+}
+
 function pillStatusClass(status: FundamentalSnapshot['coverageStatus'] | 'strong' | 'neutral' | 'weak' | 'unavailable') {
   if (status === 'supported' || status === 'strong') return 'bg-emerald-100 text-emerald-800';
   if (status === 'partial' || status === 'neutral') return 'bg-amber-100 text-amber-800';
@@ -257,15 +261,33 @@ export default function FundamentalsSnapshotCard({ snapshot }: FundamentalsSnaps
                       .filter(Boolean)
                       .join(' · ') || 'metadata unavailable'}
                   </div>
-                  <div className="mt-3 flex flex-wrap gap-2">
-                    {series.points.map((point) => (
-                      <div key={`${key}-${point.periodEnd}`} className="rounded-md bg-gray-50 px-2 py-1 text-xs">
-                        <div className="text-gray-500">{point.periodEnd}</div>
-                        <div className="mt-1 font-medium text-gray-800">
-                          {formatSeriesValue(point.value, series.unit)}
-                        </div>
-                      </div>
-                    ))}
+                  <div className="mt-3 overflow-hidden rounded-md border border-gray-200">
+                    <table className="min-w-full divide-y divide-gray-200 text-sm">
+                      <thead className="bg-gray-50">
+                        <tr>
+                          <th className="px-3 py-2 text-left text-[11px] font-medium uppercase tracking-wide text-gray-500">
+                            Date
+                          </th>
+                          <th className="px-3 py-2 text-right text-[11px] font-medium uppercase tracking-wide text-gray-500">
+                            Value
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody className="divide-y divide-gray-100 bg-white">
+                        {[...series.points]
+                          .sort((left, right) => comparePeriodDesc(left.periodEnd, right.periodEnd))
+                          .map((point) => (
+                            <tr key={`${key}-${point.periodEnd}`}>
+                              <td className="px-3 py-2 font-mono text-xs text-gray-500">
+                                {point.periodEnd}
+                              </td>
+                              <td className="px-3 py-2 text-right font-medium text-gray-800">
+                                {formatSeriesValue(point.value, series.unit)}
+                              </td>
+                            </tr>
+                          ))}
+                      </tbody>
+                    </table>
                   </div>
                 </div>
               ))}

--- a/web-ui/src/components/domain/market/CachedSymbolPriceChart.tsx
+++ b/web-ui/src/components/domain/market/CachedSymbolPriceChart.tsx
@@ -12,10 +12,14 @@ import { cn } from '@/utils/cn';
 interface CachedSymbolPriceChartProps {
   ticker: string;
   className?: string;
+  defaultOpen?: boolean;
+  showToggle?: boolean;
+  width?: number;
+  height?: number;
 }
 
-const CHART_WIDTH = 220;
-const CHART_HEIGHT = 72;
+const DEFAULT_CHART_WIDTH = 220;
+const DEFAULT_CHART_HEIGHT = 72;
 const CHART_PADDING = 4;
 const EMPTY_HISTORY: never[] = [];
 
@@ -31,7 +35,7 @@ function toShortDate(raw: string): string {
   });
 }
 
-function buildPolyline(points: number[]): string {
+function buildPolyline(points: number[], chartWidth: number, chartHeight: number): string {
   if (points.length === 0) {
     return '';
   }
@@ -39,8 +43,8 @@ function buildPolyline(points: number[]): string {
   const minValue = Math.min(...points);
   const maxValue = Math.max(...points);
   const valueRange = maxValue - minValue;
-  const usableWidth = CHART_WIDTH - CHART_PADDING * 2;
-  const usableHeight = CHART_HEIGHT - CHART_PADDING * 2;
+  const usableWidth = chartWidth - CHART_PADDING * 2;
+  const usableHeight = chartHeight - CHART_PADDING * 2;
 
   return points
     .map((value, idx) => {
@@ -52,16 +56,27 @@ function buildPolyline(points: number[]): string {
     .join(' ');
 }
 
-export default function CachedSymbolPriceChart({ ticker, className }: CachedSymbolPriceChartProps) {
+export default function CachedSymbolPriceChart({
+  ticker,
+  className,
+  defaultOpen = false,
+  showToggle = true,
+  width = DEFAULT_CHART_WIDTH,
+  height = DEFAULT_CHART_HEIGHT,
+}: CachedSymbolPriceChartProps) {
   const history = useScreenerStore((state) => {
     const symbol = ticker.trim().toUpperCase();
     const candidate = state.lastResult?.candidates.find((item) => item.ticker.toUpperCase() === symbol);
     return candidate?.priceHistory ?? EMPTY_HISTORY;
   });
 
-  const [isOpen, setIsOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(defaultOpen);
   const availableRanges = useMemo(() => getAvailablePriceRanges(history), [history]);
   const [range, setRange] = useState<PriceRangeKey>('MAX');
+
+  useEffect(() => {
+    setIsOpen(defaultOpen);
+  }, [defaultOpen, ticker]);
 
   useEffect(() => {
     if (availableRanges.length === 0) {
@@ -73,12 +88,19 @@ export default function CachedSymbolPriceChart({ ticker, className }: CachedSymb
   }, [availableRanges, range]);
 
   if (history.length < 2) {
+    if (!showToggle) {
+      return (
+        <div className={cn('rounded-md border border-dashed border-gray-300 p-4 text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400', className)}>
+          No cached chart is available for {ticker} yet.
+        </div>
+      );
+    }
     return null;
   }
 
   const visibleHistory = slicePriceHistory(history, range);
   const prices = visibleHistory.map((point) => point.close);
-  const polyline = buildPolyline(prices);
+  const polyline = buildPolyline(prices, width, height);
   const firstPrice = prices[0] ?? 0;
   const lastPrice = prices[prices.length - 1] ?? 0;
   const changePct = firstPrice > 0 ? ((lastPrice - firstPrice) / firstPrice) * 100 : 0;
@@ -87,16 +109,18 @@ export default function CachedSymbolPriceChart({ ticker, className }: CachedSymb
   return (
     <div className={cn('mt-1', className)}>
       <div className="flex items-center gap-2">
-        <button
-          type="button"
-          onClick={() => setIsOpen((value) => !value)}
-          className="inline-flex items-center gap-1 rounded border border-gray-300 px-2 py-0.5 text-[11px] font-medium text-gray-700 hover:bg-gray-100 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
-          title={`Toggle cached chart for ${ticker}`}
-          aria-label={`Toggle cached chart for ${ticker}`}
-        >
-          <LineChart className="h-3 w-3" />
-          Chart
-        </button>
+        {showToggle ? (
+          <button
+            type="button"
+            onClick={() => setIsOpen((value) => !value)}
+            className="inline-flex items-center gap-1 rounded border border-gray-300 px-2 py-0.5 text-[11px] font-medium text-gray-700 hover:bg-gray-100 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+            title={`Toggle cached chart for ${ticker}`}
+            aria-label={`Toggle cached chart for ${ticker}`}
+          >
+            <LineChart className="h-3 w-3" />
+            Chart
+          </button>
+        ) : null}
 
         {isOpen && availableRanges.length > 1 ? (
           <label className="inline-flex items-center gap-1 text-[11px] text-gray-600 dark:text-gray-400">
@@ -118,7 +142,10 @@ export default function CachedSymbolPriceChart({ ticker, className }: CachedSymb
       </div>
 
       {isOpen ? (
-        <div className="mt-2 w-[230px] rounded-md border border-gray-200 bg-white p-2 shadow-sm dark:border-gray-700 dark:bg-gray-900">
+        <div className={cn(
+          'mt-2 rounded-md border border-gray-200 bg-white p-2 shadow-sm dark:border-gray-700 dark:bg-gray-900',
+          showToggle ? 'w-[230px]' : 'w-full',
+        )}>
           <div className="mb-2 flex items-baseline justify-between text-[11px]">
             <span className="font-mono text-gray-500 dark:text-gray-400">{firstPrice.toFixed(2)}</span>
             <span className="font-mono text-sm font-semibold text-gray-900 dark:text-gray-100">{lastPrice.toFixed(2)}</span>
@@ -129,8 +156,9 @@ export default function CachedSymbolPriceChart({ ticker, className }: CachedSymb
           </div>
 
           <svg
-            viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`}
-            className="h-[72px] w-full"
+            viewBox={`0 0 ${width} ${height}`}
+            className="w-full"
+            style={{ height }}
             role="img"
             aria-label={`Cached price chart for ${ticker}`}
           >

--- a/web-ui/src/components/domain/orders/OrderReviewExperience.tsx
+++ b/web-ui/src/components/domain/orders/OrderReviewExperience.tsx
@@ -167,7 +167,7 @@ export default function OrderReviewExperience({
   const limitPrice = form.watch('limitPrice') ?? 0;
   const stopPrice = form.watch('stopPrice') ?? 0;
   const hasOrderTypeMismatch = hasSuggestedOrderType && orderType !== normalizedSuggestedOrderType;
-  const needsOverrideConfirmation = hasSkipSuggestion || hasOrderTypeMismatch;
+  const needsOverrideConfirmation = hasOrderTypeMismatch || (hasSkipSuggestion && !isRecommended);
   const invalidBuyStopPrice = orderType === 'BUY_STOP' && knownCurrentPrice != null && limitPrice <= knownCurrentPrice;
   const triggerPriceLabel =
     orderType === 'BUY_STOP' ? t('order.candidateModal.triggerPrice') : t('order.candidateModal.limitPrice');

--- a/web-ui/src/components/domain/workspace/ActionPanel.test.tsx
+++ b/web-ui/src/components/domain/workspace/ActionPanel.test.tsx
@@ -154,6 +154,17 @@ describe('ActionPanel', () => {
     expect(submit).toBeEnabled();
   });
 
+  it('does not require override confirmation when verdict is recommended but backend guidance is SKIP', () => {
+    setCandidate({
+      suggestedOrderType: 'SKIP',
+    });
+    renderWithProviders(<ActionPanel ticker="AAPL" />);
+
+    expect(screen.getAllByText(/currently not an actionable entry/i).length).toBeGreaterThan(0);
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Create Order' })).toBeEnabled();
+  });
+
   it('keeps form values while switching review sections', async () => {
     const user = userEvent.setup();
     renderWithProviders(<ActionPanel ticker="AAPL" />);

--- a/web-ui/src/components/domain/workspace/SymbolAnalysisContent.tsx
+++ b/web-ui/src/components/domain/workspace/SymbolAnalysisContent.tsx
@@ -103,34 +103,14 @@ export default function SymbolAnalysisContent({
             {candidate?.decisionSummary ? (
               <DecisionSummaryCard summary={candidate.decisionSummary} currency={candidate.currency} />
             ) : null}
-            <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white p-3">
-              <div className="flex items-center justify-between gap-3 mb-2">
-                <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">{ticker}</span>
-                {onRunSymbolIntelligence ? (
-                  <Button
-                    size="sm"
-                    variant="secondary"
-                    onClick={() => onRunSymbolIntelligence(ticker)}
-                    disabled={symbolIntelligenceStatus?.stage === 'queued' || symbolIntelligenceStatus?.stage === 'running'}
-                  >
-                    {symbolIntelligenceStatus?.stage === 'queued' || symbolIntelligenceStatus?.stage === 'running'
-                      ? t('screener.symbolIntelligence.running')
-                      : t('screener.symbolIntelligence.runAction')}
-                  </Button>
-                ) : null}
-              </div>
-              {symbolIntelligenceStatus?.stage === 'completed' ? (
-                <p className="text-xs text-gray-500 mb-2">
-                  {t('screener.symbolIntelligence.updatedAt', {
-                    at: formatDateTime(
-                      symbolIntelligenceStatus.explanationGeneratedAt || symbolIntelligenceStatus.updatedAt
-                    ),
-                  })}
-                </p>
-              ) : symbolIntelligenceStatus?.stage === 'error' ? (
-                <p className="text-xs text-rose-600 mb-2">{symbolIntelligenceStatus.error || t('screener.error.unknown')}</p>
-              ) : null}
-              <CachedSymbolPriceChart ticker={ticker} />
+            <div className="rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-700">
+              <CachedSymbolPriceChart
+                ticker={ticker}
+                defaultOpen
+                showToggle={false}
+                width={820}
+                height={180}
+              />
             </div>
             {candidate ? <TechnicalMetricsGrid candidate={candidate} /> : null}
           </>


### PR DESCRIPTION
## Summary
- replace the overview header CTA block with a chart-first surface that opens by default
- compress fundamentals recent-history cards into compact date/value tables sorted newest-first
- stop forcing the order override checkbox when a trade is still marked recommended but backend guidance resolves to `SKIP`

## Validation
- `cd web-ui && npm run typecheck`
- `cd web-ui && npx vitest run ActionPanel CandidateOrderModal AnalysisCanvasPanel FundamentalsSnapshotCard`
- local browser QA against `http://127.0.0.1:5173/today` to confirm the app shell still loads cleanly