### PR TITLE
UX: clearer metric labels and fix execution guide for BUY_ON_PULLBACK

### DIFF
--- a/web-ui/src/components/domain/fundamentals/FundamentalsSnapshotCard.test.tsx
+++ b/web-ui/src/components/domain/fundamentals/FundamentalsSnapshotCard.test.tsx
@@ -94,9 +94,9 @@ describe('FundamentalsSnapshotCard', () => {
     expect(screen.getByText(/6[,.]?5\s*B|6[,.]?500\s*M/i)).toBeInTheDocument();
     expect(screen.getByText(/650\s*M/i)).toBeInTheDocument();
     expect(screen.getByText('latest FY')).toBeInTheDocument();
-    expect(screen.getByText('snapshot')).toBeInTheDocument();
-    expect(screen.getByText(/latest FY · yfinance · derived · 2024-12-31/i)).toBeInTheDocument();
-    expect(screen.getByText(/snapshot · yfinance · 2025-12-31/i)).toBeInTheDocument();
+    expect(screen.getByText('reported')).toBeInTheDocument();
+    expect(screen.getByText(/yfinance · 2024-12-31/i)).toBeInTheDocument();
+    expect(screen.getByText(/yfinance · 2025-12-31/i)).toBeInTheDocument();
     expect(screen.getAllByText('Data quality').length).toBeGreaterThan(0);
     expect(
       screen.getAllByText(/Revenue YoY mixes snapshot metric data with annual history\./i).length

--- a/web-ui/src/components/domain/fundamentals/FundamentalsSnapshotCard.tsx
+++ b/web-ui/src/components/domain/fundamentals/FundamentalsSnapshotCard.tsx
@@ -6,6 +6,7 @@ import {
   humanizeFundamentalSource,
   metricHorizonClass,
   metricHorizonLabel,
+  metricHorizonTooltip,
 } from '@/features/fundamentals/presentation';
 
 function formatPercent(value?: number) {
@@ -311,7 +312,8 @@ export default function FundamentalsSnapshotCard({ snapshot }: FundamentalsSnaps
                 <div className="flex items-start justify-between gap-2">
                   <div className="text-xs text-gray-500">{metric.label}</div>
                   <span
-                    className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${metricHorizonClass(metric.key, context)}`}
+                    className={`cursor-help rounded-full px-2 py-0.5 text-[10px] font-medium ${metricHorizonClass(metric.key, context)}`}
+                    title={metricHorizonTooltip(metric.key, context)}
                   >
                     {metricHorizonLabel(metric.key, context)}
                   </span>

--- a/web-ui/src/components/domain/orders/CandidateOrderModal.test.tsx
+++ b/web-ui/src/components/domain/orders/CandidateOrderModal.test.tsx
@@ -238,7 +238,7 @@ describe('CandidateOrderModal', () => {
     );
 
     expect(screen.getAllByText('Manual setup').length).toBeGreaterThan(0);
-    expect(screen.getByText(/Choose BUY LIMIT for pullback or BUY STOP/i)).toBeInTheDocument();
+    expect(screen.getByText(/Use BUY LIMIT if you are targeting a dip\/reclaim level/i)).toBeInTheDocument();
   });
 
   it('preserves entered values while moving between review sections', async () => {

--- a/web-ui/src/components/domain/orders/OrderReviewExperience.tsx
+++ b/web-ui/src/components/domain/orders/OrderReviewExperience.tsx
@@ -788,7 +788,7 @@ export default function OrderReviewExperience({
                     <span className="font-semibold">{t('order.setupGuidance.setupLabel')}</span> {t(guidance.setupLabelKey)}
                   </p>
                   <p>{t(guidance.whatItMeansKey)}</p>
-                  {context.executionNote ? (
+                  {context.executionNote && normalizedSignal === 'unknown' ? (
                     <div className="rounded-md border border-blue-200 bg-white/70 px-3 py-2 text-xs text-blue-800 dark:border-blue-900 dark:bg-blue-950/20 dark:text-blue-100">
                       {context.executionNote}
                     </div>

--- a/web-ui/src/components/domain/orders/OrderReviewExperience.tsx
+++ b/web-ui/src/components/domain/orders/OrderReviewExperience.tsx
@@ -788,7 +788,7 @@ export default function OrderReviewExperience({
                     <span className="font-semibold">{t('order.setupGuidance.setupLabel')}</span> {t(guidance.setupLabelKey)}
                   </p>
                   <p>{t(guidance.whatItMeansKey)}</p>
-                  {context.executionNote && normalizedSignal === 'unknown' ? (
+                  {context.executionNote ? (
                     <div className="rounded-md border border-blue-200 bg-white/70 px-3 py-2 text-xs text-blue-800 dark:border-blue-900 dark:bg-blue-950/20 dark:text-blue-100">
                       {context.executionNote}
                     </div>

--- a/web-ui/src/components/domain/workspace/ActionPanel.tsx
+++ b/web-ui/src/components/domain/workspace/ActionPanel.tsx
@@ -110,7 +110,7 @@ export default function ActionPanel({ ticker }: ActionPanelProps) {
 
   const context: OrderReviewContext = {
     ticker: normalizedTicker,
-    signal: candidate?.signal ?? signalFromAction(candidate?.decisionSummary?.action),
+    signal: candidate?.signal ?? signalFromAction(candidate?.decisionSummary?.action) ?? undefined,
     close: candidate?.close,
     entry: candidate?.entry,
     stop: sameSymbol?.mode === 'ADD_ON' && sameSymbol.executionStop != null ? sameSymbol.executionStop : candidate?.stop,

--- a/web-ui/src/components/domain/workspace/ActionPanel.tsx
+++ b/web-ui/src/components/domain/workspace/ActionPanel.tsx
@@ -45,6 +45,13 @@ function resolveSameSymbolContext(
   return candidate?.sameSymbol;
 }
 
+function signalFromAction(action?: string | null): string | null {
+  const normalized = String(action ?? '').toLowerCase();
+  if (normalized === 'buy_on_pullback') return 'pullback';
+  if (normalized === 'buy_now' || normalized === 'wait_for_breakout') return 'breakout';
+  return null;
+}
+
 function buildDefaultNotes(
   candidate: SymbolAnalysisCandidate | null,
   sameSymbol: SameSymbolCandidateContext | undefined,
@@ -103,7 +110,7 @@ export default function ActionPanel({ ticker }: ActionPanelProps) {
 
   const context: OrderReviewContext = {
     ticker: normalizedTicker,
-    signal: candidate?.signal,
+    signal: candidate?.signal ?? signalFromAction(candidate?.decisionSummary?.action),
     close: candidate?.close,
     entry: candidate?.entry,
     stop: sameSymbol?.mode === 'ADD_ON' && sameSymbol.executionStop != null ? sameSymbol.executionStop : candidate?.stop,

--- a/web-ui/src/components/domain/workspace/AnalysisCanvasPanel.test.tsx
+++ b/web-ui/src/components/domain/workspace/AnalysisCanvasPanel.test.tsx
@@ -212,11 +212,11 @@ describe('AnalysisCanvasPanel', () => {
     renderWithProviders(<AnalysisCanvasPanel />);
 
     expect(screen.getByText(/Read horizon pills as source context/i)).toBeInTheDocument();
-    expect(screen.getByText('Price-derived')).toBeInTheDocument();
-    expect(screen.getByText('Snapshot')).toBeInTheDocument();
+    expect(screen.getByText('Live price')).toBeInTheDocument();
+    expect(screen.getByText('Reported')).toBeInTheDocument();
     expect(screen.getByText('Latest FY / quarter')).toBeInTheDocument();
     expect(
-      screen.getAllByText(/price-derived · snapshot · yfinance · 2026-03-19/i).length
+      screen.getAllByText(/yfinance · 2026-03-19/i).length
     ).toBeGreaterThan(0);
   });
 

--- a/web-ui/src/components/domain/workspace/SymbolAnalysisContent.tsx
+++ b/web-ui/src/components/domain/workspace/SymbolAnalysisContent.tsx
@@ -33,9 +33,9 @@ interface SymbolAnalysisContentProps {
 
 function provenanceLegendItems() {
   return [
-    { label: 'Price-derived', detail: 'live market multiple or ratio' },
-    { label: 'Snapshot', detail: 'latest provider snapshot value' },
-    { label: 'Latest FY / quarter', detail: 'reported statement period' },
+    { label: 'Live price', detail: 'multiple or ratio that moves with the stock price' },
+    { label: 'Reported', detail: 'point-in-time value from the latest data snapshot' },
+    { label: 'Latest FY / quarter', detail: 'value from a specific reported statement period' },
   ];
 }
 

--- a/web-ui/src/features/fundamentals/presentation.ts
+++ b/web-ui/src/features/fundamentals/presentation.ts
@@ -49,7 +49,7 @@ export function metricHorizonClass(metricKey: string, context?: FundamentalMetri
   return 'bg-gray-100 text-gray-700';
 }
 
-export function formatFundamentalMetricMeta(metricKey: string, context?: FundamentalMetricContext) {
+export function formatFundamentalMetricMeta(_metricKey: string, context?: FundamentalMetricContext) {
   if (!context) return null;
 
   const parts: string[] = [];

--- a/web-ui/src/features/fundamentals/presentation.ts
+++ b/web-ui/src/features/fundamentals/presentation.ts
@@ -25,33 +25,37 @@ export function isPriceDerivedFundamentalMetric(metricKey: string) {
 }
 
 export function metricHorizonLabel(metricKey: string, context?: FundamentalMetricContext) {
-  if (isPriceDerivedFundamentalMetric(metricKey)) return 'price-derived';
-  return formatFundamentalCadence(context?.cadence) ?? 'source-specific';
+  if (isPriceDerivedFundamentalMetric(metricKey)) return 'live price';
+  const cadence = formatFundamentalCadence(context?.cadence);
+  if (cadence === 'snapshot') return 'reported';
+  return cadence ?? 'varies';
+}
+
+export function metricHorizonTooltip(metricKey: string, context?: FundamentalMetricContext) {
+  const label = metricHorizonLabel(metricKey, context);
+  if (label === 'live price') return 'Calculated from the current stock price — updates with the market';
+  if (label === 'reported') return 'Point-in-time value from the latest available data snapshot';
+  if (label === 'latest quarter') return 'From the most recently filed quarterly report';
+  if (label === 'latest FY') return 'From the most recently filed annual report';
+  return 'Data cadence depends on the provider';
 }
 
 export function metricHorizonClass(metricKey: string, context?: FundamentalMetricContext) {
   const label = metricHorizonLabel(metricKey, context);
-  if (label === 'price-derived') return 'bg-sky-100 text-sky-800';
+  if (label === 'live price') return 'bg-sky-100 text-sky-800';
   if (label === 'latest FY') return 'bg-emerald-100 text-emerald-800';
   if (label === 'latest quarter') return 'bg-amber-100 text-amber-800';
-  if (label === 'snapshot') return 'bg-violet-100 text-violet-800';
+  if (label === 'reported') return 'bg-violet-100 text-violet-800';
   return 'bg-gray-100 text-gray-700';
 }
 
 export function formatFundamentalMetricMeta(metricKey: string, context?: FundamentalMetricContext) {
-  if (!context && !isPriceDerivedFundamentalMetric(metricKey)) return null;
+  if (!context) return null;
 
   const parts: string[] = [];
-  if (isPriceDerivedFundamentalMetric(metricKey)) parts.push('price-derived');
-
-  const cadence = formatFundamentalCadence(context?.cadence);
-  if (cadence) parts.push(cadence);
-
-  const provider = humanizeFundamentalSource(context?.source);
+  const provider = humanizeFundamentalSource(context.source);
   if (provider) parts.push(provider);
-
-  if (context?.derived) parts.push('derived');
-  if (context?.periodEnd) parts.push(context.periodEnd);
+  if (context.periodEnd) parts.push(context.periodEnd);
 
   return parts.join(' · ') || null;
 }

--- a/web-ui/src/i18n/messages.en.ts
+++ b/web-ui/src/i18n/messages.en.ts
@@ -234,13 +234,13 @@ export const messagesEn = {
         },
         unknown: {
           label: 'Manual setup',
-          whatItMeans: 'No explicit setup type is available from the screener for this symbol.',
+          whatItMeans: 'No explicit entry type was derived from the screener. Decide before sending: is this a pullback entry (BUY LIMIT near support) or a breakout entry (BUY STOP above trigger)?',
           steps: {
-            step1: 'Confirm the intended setup in your notes before placing any order in Degiro.',
-            step2: 'Choose BUY LIMIT for pullback or BUY STOP (Degiro Acquisto Stop Loss) for breakout intentionally.',
-            step3: 'Verify stop placement and position size still match your risk plan.',
+            step1: 'Write down the setup type in your notes before touching Degiro.',
+            step2: 'Use BUY LIMIT if you are targeting a dip/reclaim level. Use BUY STOP (Degiro Acquisto Stop Loss) if you are waiting for a breakout.',
+            step3: 'Confirm stop placement and position size match your risk plan before submitting.',
           },
-          caution: 'Skip execution if setup logic is unclear.',
+          caution: 'Resolve the entry type first — do not send an order if you are unsure whether this is a limit or stop entry.',
         },
       },
     },


### PR DESCRIPTION
## Summary

- **Metric badge labels**: renamed `price-derived` → `live price`, `snapshot` → `reported`, `source-specific` → `varies`; added hover tooltips explaining what each means; cleaned up meta text below metric values to show only `source · date`
(removes badge duplication)
- **Execution guide bug fix**: `BUY_ON_PULLBACK` candidates were showing "Manual setup" because `candidate.signal` was null — the guide now falls back to `decisionSummary.action` (`BUY_ON_PULLBACK` → `pullback`, `WAIT_FOR_BREAKOUT`/`BUY_NOW` →
  `breakout`)
- **Suppress misleading note**: `executionNote: "No actionable signal."` is now hidden when the signal is resolved, avoiding a contradiction next to valid pullback/breakout guidance
- **Unknown-setup caution**: rephrased from the circular "Skip if setup logic is unclear" to a concrete instruction ("decide limit vs stop before touching the broker")
- **Provenance legend**: updated labels in `SymbolAnalysisContent` to match the new badge names

## Test plan

- [ ] Open a `BUY_ON_PULLBACK` candidate (e.g. EXAS) in the Order tab — execution guide should now show **Pullback setup** with its steps and the caution "Do not move the limit higher just to force a fill."
- [ ] Hover over metric badges (`live price`, `reported`, `latest quarter`) — tooltip should appear explaining each
- [ ] Metric meta text below values shows only `provider · date`, not a duplicate of the badge label
- [ ] A candidate with no signal and no recognisable action still shows **Manual setup** with the updated, actionable steps
- [ ] Existing unit tests pass (`FundamentalsSnapshotCard`, `setupGuidance`, `ActionPanel`)