### PR TITLE
Fix position size not respecting maxPositionPct cap

### DIFF
--- a/web-ui/src/components/domain/orders/OrderReviewExperience.tsx
+++ b/web-ui/src/components/domain/orders/OrderReviewExperience.tsx
@@ -127,7 +127,12 @@ export default function OrderReviewExperience({
   const suggestedEntry = Number.isFinite(initialEntry) && initialEntry > 0 ? initialEntry : fallbackEntry;
   const initialStop = recRisk?.stop ?? context.stop ?? suggestedEntry * 0.95;
   const suggestedStop = Math.max(0.01, Math.min(initialStop, suggestedEntry - 0.01));
-  const suggestedShares = recRisk?.shares ?? context.shares ?? Math.max(1, risk.minShares);
+  const rawSuggestedShares = recRisk?.shares ?? context.shares ?? Math.max(1, risk.minShares);
+  const maxSharesByPositionCap =
+    risk.maxPositionPct > 0 && suggestedEntry > 0
+      ? Math.floor((risk.accountSize * risk.maxPositionPct) / suggestedEntry)
+      : rawSuggestedShares;
+  const suggestedShares = Math.max(1, Math.min(rawSuggestedShares, maxSharesByPositionCap));
   const verdict = context.recommendation?.verdict ?? 'UNKNOWN';
   const isRecommended = verdict === 'RECOMMENDED';
   const reasonsDetailed = context.recommendation?.reasonsDetailed;


### PR DESCRIPTION
suggestedShares came from the backend recommendation verbatim and was never checked against the strategy's maxPositionPct limit. For a €800 account with 50% max, EXAS at $104.91 was suggesting 9 shares ($944 = 118% of account) instead of the correct 3 shares (~39%).

Cap is applied after resolving the raw share count:
  maxSharesByPositionCap = floor(accountSize * maxPositionPct / entry)
  suggestedShares = max(1, min(raw, cap))

Existing tests unaffected (large account, few shares, cap not reached).