### PR TITLE
[codex] Add edge breakdown by trade tag

### DIFF
--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -22,6 +22,7 @@ from api.services.intelligence_service import IntelligenceService
 from api.services.portfolio_service import PortfolioService
 from api.services.screener_service import ScreenerService
 from api.services.strategy_service import StrategyService
+from api.services.watchlist_service import WatchlistService
 from api.services.workspace_context_service import WorkspaceContextService
 from api.utils.files import read_json_file, write_json_file, get_today_str
 from swing_screener.settings import data_dir, get_settings_manager, project_root
@@ -77,6 +78,13 @@ def get_watchlist_repo() -> WatchlistRepository:
 
 def get_strategy_repo() -> StrategyRepository:
     return StrategyRepository()
+
+
+def get_watchlist_service(
+    watchlist_repo: WatchlistRepository = Depends(get_watchlist_repo),
+    strategy_repo: StrategyRepository = Depends(get_strategy_repo),
+) -> WatchlistService:
+    return WatchlistService(repo=watchlist_repo, strategy_repo=strategy_repo)
 
 
 def get_intelligence_config_repo() -> IntelligenceConfigRepository:

--- a/api/models/config.py
+++ b/api/models/config.py
@@ -1,6 +1,8 @@
 """Config models."""
 from __future__ import annotations
 
+from typing import Literal
+
 from pydantic import BaseModel, Field
 
 
@@ -12,6 +14,16 @@ class RiskConfig(BaseModel):
     k_atr: float = Field(gt=0, description="ATR multiplier for stops")
     min_rr: float = Field(gt=0, default=2.0, description="Minimum reward-to-risk required")
     max_fee_risk_pct: float = Field(ge=0, le=1, default=0.2, description="Max fees as % of planned risk")
+    max_concentration_pct: float = Field(
+        ge=0,
+        le=100,
+        default=60.0,
+        description="Warn when one country/exchange exceeds this share of open risk",
+    )
+    account_size_mode: Literal["base", "equity"] = Field(
+        default="equity",
+        description="Whether risk calculations use base account size or equity adjusted for realized P&L",
+    )
 
 
 class IndicatorConfig(BaseModel):
@@ -33,6 +45,8 @@ class ManageConfig(BaseModel):
     trail_sma: int = Field(gt=0, description="SMA to trail under")
     sma_buffer_pct: float = Field(ge=0, description="Buffer below SMA (e.g., 0.005 = 0.5%)")
     max_holding_days: int = Field(gt=0, description="Max days to hold position")
+    time_stop_days: int = Field(default=15, gt=0, description="Days open before stale-trade nudge appears")
+    time_stop_min_r: float = Field(default=0.5, ge=0, description="Minimum R that suppresses stale-trade nudge")
 
 
 class AppConfig(BaseModel):

--- a/api/models/daily_review.py
+++ b/api/models/daily_review.py
@@ -6,6 +6,7 @@ from api.models.recommendation import Recommendation
 from api.models.portfolio import Position
 from api.models.screener import SameSymbolCandidateContext
 from api.models.strategy import Strategy
+from api.models.watchlist import WatchlistItemView
 from swing_screener.recommendation.models import DecisionSummary
 
 
@@ -48,6 +49,8 @@ class DailyReviewPositionHold(BaseModel):
     stop_price: float
     current_price: float
     r_now: float
+    days_open: int = 0
+    time_stop_warning: bool = False
     reason: str = Field(..., description="Why no action is needed")
 
 
@@ -60,6 +63,8 @@ class DailyReviewPositionUpdate(BaseModel):
     stop_suggested: float
     current_price: float
     r_now: float
+    days_open: int = 0
+    time_stop_warning: bool = False
     reason: str = Field(..., description="Why stop should be updated")
 
 
@@ -71,6 +76,8 @@ class DailyReviewPositionClose(BaseModel):
     stop_price: float
     current_price: float
     r_now: float
+    days_open: int = 0
+    time_stop_warning: bool = False
     reason: str = Field(..., description="Why position should be closed")
 
 
@@ -82,11 +89,13 @@ class DailyReviewSummary(BaseModel):
     close_positions: int
     new_candidates: int
     add_on_candidates: int = 0
+    watchlist_near_trigger: int = 0
     review_date: date
 
 
 class DailyReview(BaseModel):
     """Complete daily review with action items."""
+    watchlist_near_trigger: list[WatchlistItemView] = Field(default_factory=list)
     new_candidates: list[DailyReviewCandidate]
     positions_add_on_candidates: list[DailyReviewCandidate] = Field(default_factory=list)
     positions_hold: list[DailyReviewPositionHold]

--- a/api/models/portfolio.py
+++ b/api/models/portfolio.py
@@ -109,6 +109,8 @@ class StopSuggestionManageConfig(BaseModel):
     trail_sma: int = Field(default=20, gt=0)
     sma_buffer_pct: float = Field(default=0.005, ge=0)
     max_holding_days: int = Field(default=20, gt=0)
+    time_stop_days: int = Field(default=15, gt=0)
+    time_stop_min_r: float = Field(default=0.5, ge=0)
 
 
 class StopSuggestionComputeRequest(BaseModel):
@@ -251,6 +253,21 @@ class DegiroStatus(BaseModel):
     detail: str
 
 
+class EarningsProximityResponse(BaseModel):
+    ticker: str
+    next_earnings_date: Optional[str] = Field(default=None, description="Next earnings date as YYYY-MM-DD")
+    days_until: Optional[int] = Field(default=None, description="Calendar days until next earnings")
+    warning: bool = Field(default=False, description="True when earnings are within the warning window")
+
+
+class ConcentrationGroup(BaseModel):
+    country: str = Field(..., description="Derived country or market group")
+    risk_amount: float = Field(..., description="Open risk amount in this group")
+    risk_pct: float = Field(..., description="Share of total open risk as a percentage")
+    position_count: int = Field(..., description="Number of open positions in this group")
+    warning: bool = Field(..., description="True when concentration exceeds configured threshold")
+
+
 class PositionsResponse(BaseModel):
     positions: list[Position]
     asof: str
@@ -267,6 +284,11 @@ class PositionWithMetrics(Position):
     current_value: float = Field(..., description="Current market value (shares × current_price)")
     per_share_risk: float = Field(..., description="Risk per share in dollars")
     total_risk: float = Field(..., description="Total position risk (per_share_risk × shares)")
+    days_open: int = Field(default=0, description="Calendar days since entry date")
+    time_stop_warning: bool = Field(
+        default=False,
+        description="True when an open trade is stale and below the configured R threshold",
+    )
 
 
 class PositionsWithMetricsResponse(BaseModel):
@@ -311,6 +333,12 @@ class PortfolioSummary(BaseModel):
     positions_profitable: int = Field(..., description="Number of positions in profit")
     positions_losing: int = Field(..., description="Number of positions at loss")
     win_rate: float = Field(..., description="Percentage of positions profitable")
+    concentration: list[ConcentrationGroup] = Field(default_factory=list)
+    realized_pnl: float = Field(default=0.0, description="Total realized P&L from closed positions")
+    effective_account_size: float = Field(
+        default=0.0,
+        description="Account size adjusted for realized P&L when mode=equity",
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/api/models/strategy.py
+++ b/api/models/strategy.py
@@ -68,6 +68,7 @@ class StrategyRisk(BaseModel):
     rr_target: float = Field(gt=0, default=2.0)
     commission_pct: float = Field(ge=0, default=0.0)
     max_fee_risk_pct: float = Field(ge=0, le=1, default=0.2)
+    account_size_mode: Literal["base", "equity"] = "equity"
     regime_enabled: bool = False
     regime_trend_sma: int = Field(gt=1, default=200)
     regime_trend_multiplier: float = Field(gt=0, le=1, default=0.5)
@@ -77,12 +78,14 @@ class StrategyRisk(BaseModel):
 
 
 class StrategyManage(BaseModel):
-    breakeven_at_r: float = Field(ge=0)
-    trail_after_r: float = Field(ge=0)
-    trail_sma: int = Field(gt=0)
-    sma_buffer_pct: float = Field(ge=0)
-    max_holding_days: int = Field(gt=0)
-    benchmark: str
+    breakeven_at_r: float = Field(default=1.0, ge=0)
+    trail_after_r: float = Field(default=2.0, ge=0)
+    trail_sma: int = Field(default=20, gt=0)
+    sma_buffer_pct: float = Field(default=0.005, ge=0)
+    max_holding_days: int = Field(default=20, gt=0)
+    time_stop_days: int = Field(default=15, gt=0)
+    time_stop_min_r: float = Field(default=0.5, ge=0)
+    benchmark: str = "SPY"
 
 
 class StrategyIntelligenceLLM(BaseModel):

--- a/api/models/watchlist.py
+++ b/api/models/watchlist.py
@@ -8,6 +8,8 @@ from typing import Optional
 
 from pydantic import BaseModel, Field, field_validator
 
+from api.models.screener import PriceHistoryPoint
+
 
 class WatchItemUpsertRequest(BaseModel):
     watch_price: Optional[float] = Field(default=None, description="Price captured when watch is created.")
@@ -75,10 +77,18 @@ class WatchItem(BaseModel):
         return WatchItemUpsertRequest._normalize_source(value)
 
 
+class WatchlistItemView(WatchItem):
+    current_price: Optional[float] = None
+    last_bar: Optional[str] = None
+    signal: Optional[str] = None
+    signal_trigger_price: Optional[float] = None
+    distance_to_trigger_pct: Optional[float] = None
+    price_history: list[PriceHistoryPoint] = Field(default_factory=list)
+
+
 class WatchlistResponse(BaseModel):
-    items: list[WatchItem] = Field(default_factory=list)
+    items: list[WatchlistItemView] = Field(default_factory=list)
 
 
 class WatchlistDeleteResponse(BaseModel):
     deleted: bool
-

--- a/api/routers/daily_review.py
+++ b/api/routers/daily_review.py
@@ -5,7 +5,9 @@ from api.models.daily_review import DailyReview, DailyReviewComputeRequest
 from api.services.daily_review_service import DailyReviewService
 from api.services.screener_service import ScreenerService
 from api.services.portfolio_service import PortfolioService
+from api.services.watchlist_service import WatchlistService
 from api.dependencies import (
+    get_watchlist_service,
     get_screener_service,
     get_portfolio_service,
 )
@@ -24,9 +26,10 @@ def _dump_payload_item(item):
 def get_daily_review_service(
     screener_service: ScreenerService = Depends(get_screener_service),
     portfolio_service: PortfolioService = Depends(get_portfolio_service),
+    watchlist_service: WatchlistService = Depends(get_watchlist_service),
 ) -> DailyReviewService:
     """Dependency injection for DailyReviewService."""
-    return DailyReviewService(screener_service, portfolio_service)
+    return DailyReviewService(screener_service, portfolio_service, watchlist_service=watchlist_service)
 
 
 @router.get("", response_model=DailyReview)

--- a/api/routers/portfolio.py
+++ b/api/routers/portfolio.py
@@ -26,6 +26,7 @@ from api.models.portfolio import (
     DegiroSyncPreviewResponse,
     DegiroApplyResponse,
     DegiroStatus,
+    EarningsProximityResponse,
 )
 from api.dependencies import get_config_repo, get_portfolio_service
 from api.dependencies import get_strategy_repo
@@ -42,9 +43,25 @@ router = APIRouter()
 async def get_positions(
     status: Optional[str] = None,
     service: PortfolioService = Depends(get_portfolio_service),
+    config_repo: ConfigRepository = Depends(get_config_repo),
+    strategy_repo: StrategyRepository = Depends(get_strategy_repo),
 ):
     """Get all positions, optionally filtered by status."""
-    return service.list_positions(status=status)
+    manage = config_repo.get().manage
+    time_stop_days = int(manage.time_stop_days)
+    time_stop_min_r = float(manage.time_stop_min_r)
+    try:
+        active_strategy = strategy_repo.get_active_strategy()
+        strategy_manage = active_strategy.get("manage", {})
+        time_stop_days = int(strategy_manage.get("time_stop_days", time_stop_days))
+        time_stop_min_r = float(strategy_manage.get("time_stop_min_r", time_stop_min_r))
+    except (TypeError, ValueError):
+        pass
+    return service.list_positions(
+        status=status,
+        time_stop_days=time_stop_days,
+        time_stop_min_r=time_stop_min_r,
+    )
 
 
 @router.post("/positions", response_model=Position)
@@ -123,6 +140,7 @@ async def get_portfolio_summary(
 ):
     """Get aggregated portfolio metrics for all open positions."""
     config_account_size = float(config_repo.get().risk.account_size)
+    account_size_mode = getattr(config_repo.get().risk, "account_size_mode", "equity")
     default_config_account_size = float(ConfigRepository.get_defaults().risk.account_size)
     account_size = config_account_size
 
@@ -132,10 +150,20 @@ async def get_portfolio_summary(
             strategy_account_size = float(active_strategy.get("risk", {}).get("account_size", 0.0))
             if strategy_account_size > 0:
                 account_size = strategy_account_size
+                account_size_mode = str(active_strategy.get("risk", {}).get("account_size_mode", account_size_mode))
         except (TypeError, ValueError):
             pass
 
-    return service.get_portfolio_summary(account_size=account_size)
+    return service.get_portfolio_summary(account_size=account_size, account_size_mode=account_size_mode)
+
+
+@router.get("/earnings-proximity/{ticker}", response_model=EarningsProximityResponse)
+async def get_earnings_proximity(
+    ticker: str,
+    service: PortfolioService = Depends(get_portfolio_service),
+):
+    """Check whether a ticker has earnings within the warning window."""
+    return service.get_earnings_proximity(ticker)
 
 
 # ===== Orders =====

--- a/api/routers/watchlist.py
+++ b/api/routers/watchlist.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import ValidationError
 
-from api.dependencies import get_watchlist_repo
+from api.dependencies import get_watchlist_repo, get_watchlist_service
 from api.models.watchlist import (
     WatchItem,
     WatchItemUpsertRequest,
@@ -12,15 +12,16 @@ from api.models.watchlist import (
     WatchlistResponse,
 )
 from api.repositories.watchlist_repo import WatchlistRepository
+from api.services.watchlist_service import WatchlistService
 
 router = APIRouter()
 
 
 @router.get("", response_model=WatchlistResponse)
 async def list_watchlist(
-    repo: WatchlistRepository = Depends(get_watchlist_repo),
+    service: WatchlistService = Depends(get_watchlist_service),
 ):
-    return WatchlistResponse(items=repo.list_items())
+    return WatchlistResponse(items=service.list_items())
 
 
 @router.put("/{ticker}", response_model=WatchItem)

--- a/api/services/daily_review_service.py
+++ b/api/services/daily_review_service.py
@@ -17,6 +17,7 @@ from api.models.daily_review import (
 from api.models.screener import ScreenerRequest
 from api.services.screener_service import ScreenerService
 from api.services.portfolio_service import PortfolioService
+from api.services.watchlist_service import WatchlistService
 from swing_screener.portfolio.state import ManageConfig as ManageStateConfig
 
 logger = logging.getLogger(__name__)
@@ -29,10 +30,12 @@ class DailyReviewService:
         self,
         screener_service: ScreenerService,
         portfolio_service: PortfolioService,
+        watchlist_service: WatchlistService | None = None,
         data_dir: Path = Path("data"),
     ):
         self.screener = screener_service
         self.portfolio = portfolio_service
+        self.watchlist = watchlist_service
         self.data_dir = data_dir
         self.daily_reviews_dir = data_dir / "daily_reviews"
         self.daily_reviews_dir.mkdir(parents=True, exist_ok=True)
@@ -93,9 +96,15 @@ class DailyReviewService:
             )
         new_candidates = [_to_daily_candidate(c) for c in candidates if c.same_symbol is None or c.same_symbol.mode == "NEW_ENTRY"]
         add_on_candidates = [_to_daily_candidate(c) for c in candidates if c.same_symbol is not None and c.same_symbol.mode == "ADD_ON"]
+        watchlist_near_trigger = self._watchlist_near_trigger_items()
         
         # 2. Analyze all open positions
-        positions_response = self.portfolio.list_positions(status="open")
+        active_manage = self._active_manage_cfg_payload()
+        positions_response = self.portfolio.list_positions(
+            status="open",
+            time_stop_days=int(active_manage.get("time_stop_days", 15)),
+            time_stop_min_r=float(active_manage.get("time_stop_min_r", 0.5)),
+        )
         positions = positions_response.positions
         
         positions_hold: list[DailyReviewPositionHold] = []
@@ -121,6 +130,7 @@ class DailyReviewService:
                         stop_price=pos.stop_price,
                         current_price=pos.current_price or pos.entry_price,
                         r_now=0.0,
+                        **self._time_stop_payload_from_position(pos, 0.0, active_manage),
                         reason=f"Stop suggestion unavailable: {reason}",
                     )
                 )
@@ -138,6 +148,7 @@ class DailyReviewService:
                         stop_price=pos.stop_price,
                         current_price=pos.current_price or pos.entry_price,
                         r_now=0.0,
+                        **self._time_stop_payload_from_position(pos, 0.0, active_manage),
                         reason=f"Stop suggestion unavailable: {exc}",
                     )
                 )
@@ -153,6 +164,7 @@ class DailyReviewService:
                         stop_price=pos.stop_price,
                         current_price=suggestion.last,
                         r_now=suggestion.r_now,
+                        **self._time_stop_payload_from_position(pos, suggestion.r_now, active_manage),
                         reason=suggestion.reason,
                     )
                 )
@@ -167,6 +179,7 @@ class DailyReviewService:
                         stop_suggested=suggestion.stop_suggested,
                         current_price=suggestion.last,
                         r_now=suggestion.r_now,
+                        **self._time_stop_payload_from_position(pos, suggestion.r_now, active_manage),
                         reason=suggestion.reason,
                     )
                 )
@@ -180,6 +193,7 @@ class DailyReviewService:
                         stop_price=pos.stop_price,
                         current_price=suggestion.last,
                         r_now=suggestion.r_now,
+                        **self._time_stop_payload_from_position(pos, suggestion.r_now, active_manage),
                         reason=suggestion.reason,
                     )
                 )
@@ -192,10 +206,12 @@ class DailyReviewService:
             close_positions=len(positions_close),
             new_candidates=len(new_candidates),
             add_on_candidates=len(add_on_candidates),
+            watchlist_near_trigger=len(watchlist_near_trigger),
             review_date=date.today(),
         )
-        
+
         review = DailyReview(
+            watchlist_near_trigger=watchlist_near_trigger,
             new_candidates=new_candidates,
             positions_add_on_candidates=add_on_candidates,
             positions_hold=positions_hold,
@@ -209,6 +225,64 @@ class DailyReviewService:
         
         return review
 
+    def _watchlist_near_trigger_items(self) -> list:
+        if self.watchlist is None:
+            return []
+        try:
+            items = self.watchlist.list_items()
+        except Exception:
+            logger.exception("Unable to build watchlist near-trigger section for daily review")
+            return []
+        near_trigger = []
+        for item in items:
+            distance = (
+                item.distance_to_trigger_pct
+                if hasattr(item, "distance_to_trigger_pct")
+                else item.get("distance_to_trigger_pct")
+            )
+            if distance is not None and -3.0 <= float(distance) <= 0.0:
+                near_trigger.append(item)
+        return near_trigger
+
+    def _active_manage_cfg_payload(self) -> dict:
+        strategy_repo = getattr(self.screener, "_strategy_repo", None)
+        if strategy_repo is None:
+            return {}
+        try:
+            strategy = strategy_repo.get_active_strategy()
+        except Exception:
+            logger.exception("Unable to resolve active strategy manage config for daily review")
+            return {}
+        manage = strategy.get("manage", {}) if isinstance(strategy, dict) else {}
+        return manage if isinstance(manage, dict) else {}
+
+    @staticmethod
+    def _time_stop_payload(position: dict, r_now: float, manage_payload: dict) -> dict:
+        try:
+            entry_dt = date.fromisoformat(str(position.get("entry_date") or ""))
+            days_open = max((date.today() - entry_dt).days, 0)
+        except ValueError:
+            days_open = 0
+        time_stop_days = int(manage_payload.get("time_stop_days", 15))
+        time_stop_min_r = float(manage_payload.get("time_stop_min_r", 0.5))
+        return {
+            "days_open": days_open,
+            "time_stop_warning": (
+                position.get("status") == "open"
+                and days_open >= time_stop_days
+                and r_now < time_stop_min_r
+            ),
+        }
+
+    def _time_stop_payload_from_position(self, position, r_now: float, manage_payload: dict) -> dict:
+        days_open = getattr(position, "days_open", None)
+        time_stop_warning = getattr(position, "time_stop_warning", None)
+        if days_open is not None and time_stop_warning is not None:
+            return {"days_open": int(days_open), "time_stop_warning": bool(time_stop_warning)}
+        model_dump = getattr(position, "model_dump", None)
+        payload = model_dump() if callable(model_dump) else dict(position)
+        return self._time_stop_payload(payload, r_now, manage_payload)
+
     @staticmethod
     def _manage_cfg_payload_from_strategy(strategy: dict) -> dict:
         manage = strategy.get("manage", {}) if isinstance(strategy, dict) else {}
@@ -218,6 +292,8 @@ class DailyReviewService:
             trail_after_R=float(manage.get("trail_after_r", 2.0)),
             sma_buffer_pct=float(manage.get("sma_buffer_pct", 0.005)),
             max_holding_days=int(manage.get("max_holding_days", 20)),
+            time_stop_days=int(manage.get("time_stop_days", 15)),
+            time_stop_min_r=float(manage.get("time_stop_min_r", 0.5)),
         )
         return {
             "breakeven_at_r": cfg.breakeven_at_R,
@@ -225,6 +301,8 @@ class DailyReviewService:
             "trail_sma": cfg.trail_sma,
             "sma_buffer_pct": cfg.sma_buffer_pct,
             "max_holding_days": cfg.max_holding_days,
+            "time_stop_days": cfg.time_stop_days,
+            "time_stop_min_r": cfg.time_stop_min_r,
         }
 
     def compute_daily_review_from_state(
@@ -314,6 +392,7 @@ class DailyReviewService:
                         stop_price=float(pos.get("stop_price", 0.0)),
                         current_price=float(pos.get("current_price") or pos.get("entry_price") or 0.0),
                         r_now=0.0,
+                        **self._time_stop_payload(pos, 0.0, manage_payload),
                         reason=f"Stop suggestion unavailable: {reason}",
                     )
                 )
@@ -331,6 +410,7 @@ class DailyReviewService:
                         stop_price=float(pos.get("stop_price", 0.0)),
                         current_price=float(pos.get("current_price") or pos.get("entry_price") or 0.0),
                         r_now=0.0,
+                        **self._time_stop_payload(pos, 0.0, manage_payload),
                         reason=f"Stop suggestion unavailable: {exc}",
                     )
                 )
@@ -345,6 +425,7 @@ class DailyReviewService:
                         stop_price=suggestion.stop_old,
                         current_price=suggestion.last,
                         r_now=suggestion.r_now,
+                        **self._time_stop_payload(pos, suggestion.r_now, manage_payload),
                         reason=suggestion.reason,
                     )
                 )
@@ -358,6 +439,7 @@ class DailyReviewService:
                         stop_suggested=suggestion.stop_suggested,
                         current_price=suggestion.last,
                         r_now=suggestion.r_now,
+                        **self._time_stop_payload(pos, suggestion.r_now, manage_payload),
                         reason=suggestion.reason,
                     )
                 )
@@ -370,11 +452,13 @@ class DailyReviewService:
                         stop_price=suggestion.stop_old,
                         current_price=suggestion.last,
                         r_now=suggestion.r_now,
+                        **self._time_stop_payload(pos, suggestion.r_now, manage_payload),
                         reason=suggestion.reason,
                     )
                 )
 
         return DailyReview(
+            watchlist_near_trigger=[],
             new_candidates=new_candidates,
             positions_add_on_candidates=add_on_candidates,
             positions_hold=positions_hold,
@@ -387,6 +471,7 @@ class DailyReviewService:
                 close_positions=len(positions_close),
                 new_candidates=len(new_candidates),
                 add_on_candidates=len(add_on_candidates),
+                watchlist_near_trigger=0,
                 review_date=date.today(),
             ),
         )

--- a/api/services/portfolio_service.py
+++ b/api/services/portfolio_service.py
@@ -11,10 +11,12 @@ import pandas as pd
 from fastapi import HTTPException
 
 from api.models.portfolio import (
+    ConcentrationGroup,
     CreateOrderRequest,
     CreatePositionRequest,
     DegiroOrder,
     DegiroOrdersResponse,
+    EarningsProximityResponse,
     FillOrderRequest,
     FillOrderResponse,
     FillFromDegiroResponse,
@@ -76,6 +78,44 @@ def _resolve_isin(ticker: str) -> Optional[str]:
 # Simple cache for EURUSD rate with 5-minute TTL
 _eurusd_cache: dict[str, tuple[float, float]] = {}  # {"eurusd": (rate, timestamp)}
 _CACHE_TTL_SECONDS = 300  # 5 minutes
+_earnings_cache: dict[str, tuple[str, EarningsProximityResponse]] = {}
+
+
+def _parse_earnings_date(raw) -> Optional[dt.date]:
+    if raw is None or pd.isna(raw):
+        return None
+    if isinstance(raw, pd.Timestamp):
+        raw = raw.to_pydatetime()
+    if isinstance(raw, dt.datetime):
+        return raw.date()
+    if isinstance(raw, dt.date):
+        return raw
+    try:
+        return dt.date.fromisoformat(str(raw)[:10])
+    except (TypeError, ValueError):
+        return None
+
+
+def _country_from_ticker(ticker: str) -> str:
+    suffix_map = {
+        ".AS": "NL",
+        ".PA": "FR",
+        ".DE": "DE",
+        ".MC": "ES",
+        ".MI": "IT",
+        ".ST": "SE",
+        ".L": "UK",
+        ".BR": "BE",
+        ".LS": "PT",
+        ".HE": "FI",
+        ".CO": "DK",
+        ".OL": "NO",
+    }
+    upper = ticker.strip().upper()
+    for suffix, country in suffix_map.items():
+        if upper.endswith(suffix):
+            return country
+    return "US"
 
 
 def _to_iso(ts) -> Optional[str]:
@@ -128,6 +168,8 @@ def _manage_cfg_from_app() -> ManageStateConfig:
         trail_after_R=manage.trail_after_r,
         sma_buffer_pct=manage.sma_buffer_pct,
         max_holding_days=manage.max_holding_days,
+        time_stop_days=manage.time_stop_days,
+        time_stop_min_r=manage.time_stop_min_r,
     )
 
 
@@ -276,6 +318,9 @@ class PortfolioService:
         position: dict,
         current_prices: dict[str, float],
         eurusd_rate: float,
+        *,
+        time_stop_days: int | None = None,
+        time_stop_min_r: float | None = None,
     ) -> PositionWithMetrics:
         state_position = _to_state_position(position)
         ticker = state_position.ticker.upper()
@@ -292,19 +337,46 @@ class PortfolioService:
         if state_position.status == "open" and live_price is not None:
             payload["current_price"] = live_price
 
+        days_open = self._days_open(state_position.entry_date)
+        r_now = calculate_r_now(state_position, current_price_for_metrics)
+        manage_defaults = ManageStateConfig()
+        stale_days = int(time_stop_days or manage_defaults.time_stop_days)
+        min_progress_r = float(time_stop_min_r if time_stop_min_r is not None else manage_defaults.time_stop_min_r)
+        time_stop_warning = (
+            state_position.status == "open"
+            and days_open >= stale_days
+            and r_now < min_progress_r
+        )
+
         return PositionWithMetrics(
             **payload,
             pnl=pnl,
             fees_eur=entry_fee_eur,
             pnl_percent=pnl_percent,
-            r_now=calculate_r_now(state_position, current_price_for_metrics),
+            r_now=r_now,
             entry_value=entry_value,
             current_value=calculate_current_position_value(current_price_for_metrics, state_position.shares),
             per_share_risk=per_share_risk,
             total_risk=per_share_risk * state_position.shares,
+            days_open=days_open,
+            time_stop_warning=time_stop_warning,
         )
 
-    def list_positions(self, status: Optional[str] = None) -> PositionsWithMetricsResponse:
+    @staticmethod
+    def _days_open(entry_date: str) -> int:
+        try:
+            entry_dt = dt.date.fromisoformat(str(entry_date))
+        except ValueError:
+            return 0
+        return max((dt.date.today() - entry_dt).days, 0)
+
+    def list_positions(
+        self,
+        status: Optional[str] = None,
+        *,
+        time_stop_days: int | None = None,
+        time_stop_min_r: float | None = None,
+    ) -> PositionsWithMetricsResponse:
         positions, asof = self._positions_repo.list_positions(status=status)
         current_prices = self._attach_live_prices(positions)
         has_usd_positions = any(
@@ -314,7 +386,13 @@ class PortfolioService:
         eurusd_rate = self._eurusd_rate() if has_usd_positions else 1.0
 
         positions_with_metrics = [
-            self._build_position_with_metrics(position, current_prices, eurusd_rate)
+            self._build_position_with_metrics(
+                position,
+                current_prices,
+                eurusd_rate,
+                time_stop_days=time_stop_days,
+                time_stop_min_r=time_stop_min_r,
+            )
             for position in positions
         ]
         return PositionsWithMetricsResponse(positions=positions_with_metrics, asof=asof)
@@ -360,7 +438,25 @@ class PortfolioService:
             total_risk=per_share_risk * state_position.shares,
         )
 
-    def get_portfolio_summary(self, account_size: float) -> PortfolioSummary:
+    def _realized_pnl(self) -> float:
+        positions, _ = self._positions_repo.list_positions(status=None)
+        realized_pnl = 0.0
+        for position in positions:
+            if position.get("status") != "closed" or position.get("exit_price") is None:
+                continue
+
+            realized_pnl += (
+                (float(position.get("exit_price")) - float(position.get("entry_price", 0.0)))
+                * int(position.get("shares", 0))
+            )
+            exit_fee_eur = position.get("exit_fee_eur")
+            if exit_fee_eur is not None:
+                realized_pnl -= abs(float(exit_fee_eur))
+        return realized_pnl
+
+    def get_portfolio_summary(self, account_size: float, account_size_mode: str = "equity") -> PortfolioSummary:
+        realized_pnl = self._realized_pnl()
+        effective_account_size = account_size + realized_pnl if account_size_mode == "equity" else account_size
         positions_response = self.list_positions(status="open")
         positions = positions_response.positions
         if not positions:
@@ -374,7 +470,7 @@ class PortfolioService:
                 open_risk=0.0,
                 open_risk_percent=0.0,
                 account_size=account_size,
-                available_capital=account_size,
+                available_capital=effective_account_size,
                 largest_position_value=0.0,
                 largest_position_ticker="",
                 best_performer_ticker="",
@@ -385,6 +481,9 @@ class PortfolioService:
                 positions_profitable=0,
                 positions_losing=0,
                 win_rate=0.0,
+                concentration=[],
+                realized_pnl=realized_pnl,
+                effective_account_size=effective_account_size,
             )
 
         total_value = 0.0
@@ -432,9 +531,10 @@ class PortfolioService:
                 positions_losing += 1
 
         total_pnl_percent = (total_pnl / total_cost_basis * 100.0) if total_cost_basis > 0 else 0.0
-        open_risk_percent = (open_risk / account_size * 100.0) if account_size > 0 else 0.0
+        open_risk_percent = (open_risk / effective_account_size * 100.0) if effective_account_size > 0 else 0.0
         avg_r_now = (total_r_now / r_count) if r_count > 0 else 0.0
         win_rate = (positions_profitable / len(positions) * 100.0) if positions else 0.0
+        concentration = self._concentration_groups(positions, open_risk)
 
         return PortfolioSummary(
             total_positions=len(positions),
@@ -446,7 +546,7 @@ class PortfolioService:
             open_risk=open_risk,
             open_risk_percent=open_risk_percent,
             account_size=account_size,
-            available_capital=account_size - total_value,
+            available_capital=effective_account_size - total_value,
             largest_position_value=largest_position_value,
             largest_position_ticker=largest_position_ticker,
             best_performer_ticker=best_performer_ticker,
@@ -457,7 +557,80 @@ class PortfolioService:
             positions_profitable=positions_profitable,
             positions_losing=positions_losing,
             win_rate=win_rate,
+            concentration=concentration,
+            realized_pnl=realized_pnl,
+            effective_account_size=effective_account_size,
         )
+
+    def _concentration_groups(
+        self,
+        positions: list[PositionWithMetrics],
+        open_risk: float,
+    ) -> list[ConcentrationGroup]:
+        country_risk: dict[str, float] = {}
+        country_count: dict[str, int] = {}
+        for position in positions:
+            if position.total_risk <= 0:
+                continue
+            country = _country_from_ticker(position.ticker)
+            country_risk[country] = country_risk.get(country, 0.0) + position.total_risk
+            country_count[country] = country_count.get(country, 0) + 1
+
+        threshold = float(getattr(ConfigRepository().get().risk, "max_concentration_pct", 60.0))
+        groups: list[ConcentrationGroup] = []
+        for country, risk_amount in sorted(country_risk.items(), key=lambda item: item[1], reverse=True):
+            risk_pct = (risk_amount / open_risk * 100.0) if open_risk > 0 else 0.0
+            groups.append(
+                ConcentrationGroup(
+                    country=country,
+                    risk_amount=risk_amount,
+                    risk_pct=risk_pct,
+                    position_count=country_count[country],
+                    warning=risk_pct >= threshold,
+                )
+            )
+        return groups
+
+    def get_earnings_proximity(self, ticker: str) -> EarningsProximityResponse:
+        normalized_ticker = ticker.strip().upper()
+        today = get_today_str()
+        cached = _earnings_cache.get(normalized_ticker)
+        if cached is not None:
+            cached_date, cached_response = cached
+            if cached_date == today:
+                return cached_response
+
+        try:
+            import yfinance
+
+            calendar = yfinance.Ticker(normalized_ticker).calendar or {}
+            earnings_dates = calendar.get("Earnings Date", [])
+            if not isinstance(earnings_dates, list):
+                earnings_dates = [earnings_dates]
+
+            today_dt = dt.date.fromisoformat(today)
+            upcoming = sorted(
+                parsed
+                for raw_date in earnings_dates
+                if (parsed := _parse_earnings_date(raw_date)) is not None and parsed >= today_dt
+            )
+            if not upcoming:
+                result = EarningsProximityResponse(ticker=normalized_ticker)
+            else:
+                next_date = upcoming[0]
+                days_until = (next_date - today_dt).days
+                result = EarningsProximityResponse(
+                    ticker=normalized_ticker,
+                    next_earnings_date=next_date.isoformat(),
+                    days_until=days_until,
+                    warning=days_until <= 10,
+                )
+        except Exception as exc:
+            logger.info("Failed to fetch earnings calendar for %s: %s", normalized_ticker, exc)
+            result = EarningsProximityResponse(ticker=normalized_ticker)
+
+        _earnings_cache[normalized_ticker] = (today, result)
+        return result
 
     def create_order(self, request: CreateOrderRequest) -> dict:
         """Create a pending entry order in orders.json."""
@@ -802,6 +975,8 @@ class PortfolioService:
             trail_after_R=float(payload.get("trail_after_r", 2.0)),
             sma_buffer_pct=float(payload.get("sma_buffer_pct", 0.005)),
             max_holding_days=int(payload.get("max_holding_days", 20)),
+            time_stop_days=int(payload.get("time_stop_days", 15)),
+            time_stop_min_r=float(payload.get("time_stop_min_r", 0.5)),
         )
 
     def _suggest_position_stop_from_dict(

--- a/api/services/watchlist_service.py
+++ b/api/services/watchlist_service.py
@@ -1,0 +1,149 @@
+"""Watchlist enrichment service."""
+from __future__ import annotations
+
+import logging
+from dataclasses import replace
+from typing import Optional
+
+import pandas as pd
+
+from api.models.screener import PriceHistoryPoint
+from api.models.watchlist import WatchItem, WatchlistItemView
+from api.repositories.strategy_repo import StrategyRepository
+from api.repositories.watchlist_repo import WatchlistRepository
+from api.utils.files import get_today_str
+from swing_screener.data.providers import MarketDataProvider, get_default_provider
+from swing_screener.selection.entries import build_signal_board
+from swing_screener.strategy.config import build_entry_config
+from swing_screener.utils.dataframe_helpers import get_close_matrix
+from swing_screener.utils.date_helpers import get_default_history_start
+
+logger = logging.getLogger(__name__)
+
+WATCHLIST_SPARKLINE_BARS = 5
+
+
+def _to_iso(ts) -> Optional[str]:
+    if ts is None or pd.isna(ts):
+        return None
+    if isinstance(ts, pd.Timestamp):
+        ts = ts.to_pydatetime()
+    if hasattr(ts, "isoformat"):
+        return ts.isoformat()
+    return str(ts)
+
+
+def _last_close_map(ohlcv: pd.DataFrame) -> tuple[dict[str, float], dict[str, str]]:
+    prices: dict[str, float] = {}
+    bars: dict[str, str] = {}
+    if ohlcv is None or ohlcv.empty:
+        return prices, bars
+    close = get_close_matrix(ohlcv)
+    for ticker in close.columns:
+        series = close[ticker].dropna()
+        if series.empty:
+            continue
+        prices[str(ticker)] = float(series.iloc[-1])
+        iso = _to_iso(series.index[-1])
+        if iso:
+            bars[str(ticker)] = iso
+    return prices, bars
+
+
+def _sparkline_history_map(ohlcv: pd.DataFrame, tickers: list[str]) -> dict[str, list[PriceHistoryPoint]]:
+    out: dict[str, list[PriceHistoryPoint]] = {}
+    if ohlcv is None or ohlcv.empty:
+        return out
+    close = get_close_matrix(ohlcv)
+    for ticker in tickers:
+        if ticker not in close.columns:
+            out[ticker] = []
+            continue
+        series = close[ticker].dropna().tail(WATCHLIST_SPARKLINE_BARS)
+        out[ticker] = [
+            PriceHistoryPoint(date=str(idx.date().isoformat() if hasattr(idx, "date") else idx), close=float(value))
+            for idx, value in series.items()
+        ]
+    return out
+
+
+def _compute_distance_pct(current_price: Optional[float], trigger_price: Optional[float]) -> Optional[float]:
+    if (
+        current_price is None
+        or trigger_price is None
+        or not pd.notna(current_price)
+        or not pd.notna(trigger_price)
+        or float(trigger_price) <= 0
+    ):
+        return None
+    return ((float(current_price) - float(trigger_price)) / float(trigger_price)) * 100.0
+
+
+class WatchlistService:
+    def __init__(
+        self,
+        repo: WatchlistRepository,
+        strategy_repo: StrategyRepository,
+        provider: Optional[MarketDataProvider] = None,
+    ) -> None:
+        self._repo = repo
+        self._strategy_repo = strategy_repo
+        self._provider = provider or get_default_provider()
+
+    def list_items(self) -> list[WatchlistItemView]:
+        items = self._repo.list_items()
+        if not items:
+            return []
+
+        tickers = [item.ticker for item in items]
+        enriched = {item.ticker: WatchlistItemView(**item.model_dump()) for item in items}
+
+        try:
+            strategy = self._strategy_repo.get_active_strategy()
+            signals_cfg = build_entry_config(strategy)
+            # The watchlist view should still compute trigger distance for names that do
+            # not yet have a full long-history candidate profile.
+            signals_cfg = replace(signals_cfg, min_history=min(int(signals_cfg.min_history), 60))
+            ohlcv = self._provider.fetch_ohlcv(
+                tickers,
+                start_date=get_default_history_start(),
+                end_date=get_today_str(),
+            )
+            if ohlcv is None or ohlcv.empty:
+                return self._sorted_items(items, enriched)
+
+            board = build_signal_board(ohlcv, tickers, cfg=signals_cfg)
+            last_prices, last_bars = _last_close_map(ohlcv)
+            sparkline_history = _sparkline_history_map(ohlcv, tickers)
+
+            for ticker in tickers:
+                row = board.loc[ticker] if ticker in board.index else None
+                trigger_price = None
+                signal = None
+                if row is not None:
+                    raw_trigger = row.get("breakout_level")
+                    trigger_price = float(raw_trigger) if pd.notna(raw_trigger) else None
+                    raw_signal = row.get("signal")
+                    signal = str(raw_signal) if pd.notna(raw_signal) else None
+                payload = enriched[ticker].model_dump()
+                payload.update(
+                    current_price=last_prices.get(ticker),
+                    last_bar=last_bars.get(ticker),
+                    signal=signal,
+                    signal_trigger_price=trigger_price,
+                    distance_to_trigger_pct=_compute_distance_pct(last_prices.get(ticker), trigger_price),
+                    price_history=sparkline_history.get(ticker, []),
+                )
+                enriched[ticker] = WatchlistItemView(**payload)
+        except Exception:
+            logger.exception("Failed to enrich watchlist pipeline view")
+
+        return self._sorted_items(items, enriched)
+
+    @staticmethod
+    def _sorted_items(items: list[WatchItem], enriched: dict[str, WatchlistItemView]) -> list[WatchlistItemView]:
+        def sort_key(item: WatchlistItemView) -> tuple[bool, float, str]:
+            distance = item.distance_to_trigger_pct
+            return (distance is None, distance if distance is not None else float("inf"), item.ticker)
+
+        return sorted((enriched[item.ticker] for item in items), key=sort_key)

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -1,12 +1,14 @@
 app_config:
   risk:
     account_size: 50000
+    account_size_mode: equity
     risk_pct: 0.01
     max_position_pct: 0.6
     min_shares: 1
     k_atr: 2.0
     min_rr: 2.0
     max_fee_risk_pct: 0.2
+    max_concentration_pct: 60.0
   indicators:
     sma_fast: 20
     sma_mid: 50
@@ -24,6 +26,8 @@ app_config:
     trail_sma: 20
     sma_buffer_pct: 0.005
     max_holding_days: 20
+    time_stop_days: 15
+    time_stop_min_r: 0.5
   positions_file: data/positions.json
   orders_file: data/orders.json
 
@@ -64,6 +68,7 @@ strategy:
     min_history: 260
   risk:
     account_size: 50000.0
+    account_size_mode: equity
     risk_pct: 0.01
     max_position_pct: 0.6
     min_shares: 1
@@ -84,6 +89,8 @@ strategy:
     trail_sma: 20
     sma_buffer_pct: 0.005
     max_holding_days: 20
+    time_stop_days: 15
+    time_stop_min_r: 0.5
     benchmark: SPY
   market_intelligence:
     enabled: false

--- a/docs/superpowers/plans/2026-05-03-feature-1-trade-tagging.md
+++ b/docs/superpowers/plans/2026-05-03-feature-1-trade-tagging.md
@@ -11,6 +11,38 @@
 
 ---
 
+## Implementation status - 2026-05-03
+
+Status: implemented in draft PR https://github.com/matteolongo/swing_screener/pull/232.
+
+Branch stack:
+
+- Branch: `codex/trade-tagging`
+- Base: `main`
+- Head commit: `6128fd03`
+
+Implemented commits:
+
+- `763f68d8 feat: add tags field to Position model and close endpoint`
+- `f4637299 feat: add tags to frontend Position types`
+- `353e11c2 feat: add trade tag i18n strings`
+- `7f048d63 feat: add tag picker step to close position modal`
+- `6128fd03 feat: add tag column and filters to journal`
+
+What changed:
+
+- `Position` records now support a `tags` list.
+- Closing a position can persist selected tags.
+- Frontend position types transform tags at the API boundary.
+- The close-position modal includes a tag picker step.
+- The journal shows trade tags and supports client-side tag filtering.
+
+Review notes:
+
+- Compare PR #232 against `main`.
+- Confirm tag IDs are stable enough for analytics, because Feature 2 aggregates directly on stored tag strings.
+- Confirm UX copy and available tags match the desired trading workflow before merging downstream PRs.
+
 ## File map
 
 | File | Change |

--- a/docs/superpowers/plans/2026-05-03-feature-2-performance-breakdown.md
+++ b/docs/superpowers/plans/2026-05-03-feature-2-performance-breakdown.md
@@ -12,6 +12,34 @@
 
 ---
 
+## Implementation status - 2026-05-03
+
+Status: implemented in draft PR https://github.com/matteolongo/swing_screener/pull/233.
+
+Branch stack:
+
+- Branch: `codex/edge-breakdown`
+- Base: `codex/trade-tagging`
+- Head commit: `57fe1829`
+
+Implemented commits:
+
+- `980f192a feat: add edge breakdown i18n keys`
+- `7039f28a feat: add EdgeBreakdownTable component with tag aggregation`
+- `57fe1829 feat: mount EdgeBreakdownTable on Analytics page`
+
+What changed:
+
+- Added the `analyticsPage.edgeBreakdown.*` i18n keys.
+- Added `EdgeBreakdownTable` for client-side aggregation by trade tag.
+- Mounted the table on the Analytics page using closed positions from the existing portfolio positions hook.
+
+Review notes:
+
+- Compare PR #233 against `codex/trade-tagging`.
+- The component intentionally waits for at least 5 tagged closed trades before displaying stats.
+- The next planning upgrade should verify whether expectancy should remain the implemented R-based formula, and whether setup, exit reason, and market condition tags should be separated instead of aggregated together.
+
 ## File map
 
 | File | Change |

--- a/docs/superpowers/plans/2026-05-03-feature-3-account-equity-auto-update.md
+++ b/docs/superpowers/plans/2026-05-03-feature-3-account-equity-auto-update.md
@@ -11,6 +11,54 @@
 
 ---
 
+## Implementation status - 2026-05-03
+
+Status: backend and display UI implemented in draft PR https://github.com/matteolongo/swing_screener/pull/234.
+
+Branch stack:
+
+- Branch: `codex/account-equity`
+- Base: `codex/edge-breakdown`
+- Head commit: `afeb7773`
+
+Implemented commits:
+
+- `ebcf54b9 feat: add realized P&L and effective account size to portfolio summary`
+- `afeb7773 feat: show effective account equity in portfolio UI`
+
+What changed:
+
+- Backend `PortfolioSummary` now includes `realized_pnl` and `effective_account_size`.
+- Realized P&L is computed from closed positions.
+- `account_size_mode` config support was added for base vs equity mode.
+- Open risk percentage and available capital use effective equity when equity mode is active.
+- Frontend portfolio summary types now expose `realizedPnl` and `effectiveAccountSize`.
+- The top header risk summary shows effective `Equity` and `Realized P&L`.
+- Book -> Positions shows `Equity` and `Realized P&L` chips, and portfolio heat uses effective equity.
+- Local persistence mirrors the same fields so frontend tests and local mode stay consistent.
+
+How to inspect in the UI:
+
+- Run the backend and frontend.
+- Open `http://localhost:5173/book`.
+- On wide screens, inspect the top-right header risk summary for `Equity` and `Realized P&L`.
+- In `Book -> Positions`, inspect the risk strip for the `Equity` and `Realized P&L` chips.
+- If there are no closed trades with realized P&L, effective equity will equal the base account and realized P&L will be zero.
+
+Validation run:
+
+- `pytest tests/api/test_account_equity.py -v`
+- `pytest -q`
+- `cd web-ui && npm run typecheck`
+- `cd web-ui && npx vitest run`
+
+Review notes:
+
+- Compare PR #234 against `codex/edge-breakdown`.
+- The Settings UI toggle mentioned in the original architecture is not implemented yet.
+- The next plan upgrade should add a dedicated atomic task for the Settings toggle, including persistence rules, i18n, and tests.
+- Review whether realized P&L should include all known transaction costs. The implemented logic subtracts exit fees where available.
+
 ## File map
 
 | File | Change |

--- a/docs/superpowers/plans/2026-05-03-feature-4-earnings-warning.md
+++ b/docs/superpowers/plans/2026-05-03-feature-4-earnings-warning.md
@@ -11,6 +11,57 @@
 
 ---
 
+## Implementation status - 2026-05-04
+
+Status: implemented in draft PR https://github.com/matteolongo/swing_screener/pull/235.
+
+Branch stack:
+
+- Branch: `codex/earnings-warning`
+- Base: `codex/account-equity`
+- Head commit: `59bbb0e4`
+
+Implemented commits:
+
+- `1f071301 feat: add earnings proximity endpoint`
+- `85abbefc feat: add earnings warning banner`
+- `59bbb0e4 test: cover earnings proximity cache hit`
+
+What changed:
+
+- Added `GET /api/portfolio/earnings-proximity/{ticker}`.
+- Added `EarningsProximityResponse` and `PortfolioService.get_earnings_proximity()`.
+- Fetches the next earnings date from `yfinance.Ticker(...).calendar`.
+- Caches earnings proximity responses in memory by ticker for the current calendar day.
+- Returns `warning: false` without blocking the workflow when earnings data cannot be fetched.
+- Added frontend endpoint mapping, `fetchEarningsProximity()`, and `useEarningsProximity()`.
+- Added `EarningsWarningBanner` using the implemented `earningsWarning.message`, `earningsWarning.messageToday`, and `earningsWarning.messageSingular` i18n keys.
+- Mounted the banner in the shared order review experience, so it appears in both the trade plan panel and candidate order modal.
+- Added cache-hit test coverage proving `yfinance.Ticker` is called only once for the same ticker on the same day.
+
+How to inspect in the UI:
+
+- Run the backend and frontend.
+- Open `http://localhost:5173/today`.
+- Select a screener candidate and open the order/trade plan surface.
+- If the selected ticker has earnings within 10 calendar days, an amber banner appears above the order review.
+- If earnings are unknown, farther away, or the provider fails, nothing is shown.
+
+Validation run:
+
+- `pytest tests/api/test_earnings_proximity.py -v`
+- `pytest -q`
+- `cd web-ui && npm run typecheck`
+- `cd web-ui && npx vitest run src/components/domain/screener/EarningsWarningBanner.test.tsx`
+- `cd web-ui && npx vitest run src/components/domain/orders/CandidateOrderModal.test.tsx src/components/domain/workspace/ActionPanel.test.tsx src/components/domain/screener/EarningsWarningBanner.test.tsx`
+- `cd web-ui && npx vitest run`
+
+Review notes:
+
+- Compare PR #235 against `codex/account-equity`.
+- The warning is informational only; order creation remains allowed.
+- The backend currently depends on Yahoo/yfinance calendar availability and intentionally degrades silently to avoid noisy false blockers.
+
 ## File map
 
 | File | Change |

--- a/docs/superpowers/plans/2026-05-03-feature-5-concentration-warning.md
+++ b/docs/superpowers/plans/2026-05-03-feature-5-concentration-warning.md
@@ -5,9 +5,33 @@
 
 **Goal:** Show the user when their open risk is over-concentrated in a single country/exchange, so they don't stack correlated bets unknowingly.
 
-**Architecture:** Country is derived from ticker suffix (`.AS` = NL, `.PA` = FR, `.DE` = DE, `.MC` = ES, `.MI` = IT, `.ST` = SE, no suffix = US). Concentration is `sum(initial_risk for positions in group) / total_open_risk * 100`. Added as a new field on `PortfolioSummary`. Frontend shows a concentration row on the portfolio summary; order creation modal warns if new order would push a group over 60%.
+**Architecture:** Country is derived from ticker suffix (`.AS` = NL, `.PA` = FR, `.DE` = DE, `.MC` = ES, `.MI` = IT, `.ST` = SE, no suffix = US). Concentration is `sum(open risk for positions in group) / total_open_risk * 100`. Added as a new field on `PortfolioSummary` using `risk_amount`, `risk_pct`, `position_count`, and `warning`. Frontend shows a concentration row on the portfolio summary; order creation surfaces warn if a new order would push a group over 60%.
 
 **Tech Stack:** Python backend (pure calculation, no new data source), React 18/TypeScript frontend, config for threshold
+
+---
+
+## Implementation Status - 2026-05-04
+
+**Branch:** `codex/concentration-warning`  
+**Base:** `codex/earnings-warning`  
+**PR:** https://github.com/matteolongo/swing_screener/pull/236  
+**Status:** Draft PR opened, implemented.
+
+**Implemented:**
+- Backend `PortfolioSummary` now includes `concentration` groups sorted by open risk share.
+- Country/exchange grouping is derived from ticker suffixes and uses the configured `max_concentration_pct` threshold.
+- Book > Positions now shows a `ConcentrationBar` below the portfolio risk chips when open risk exists.
+- Shared order review surfaces now show a soft concentration warning when the proposed order pushes its country/exchange group above 60% of open risk.
+- Local persistence mode computes the same concentration summary shape as the API path.
+
+**Validation run:**
+- `pytest tests/api/test_concentration.py -v`
+- `cd web-ui && npx vitest run src/components/domain/portfolio/ConcentrationBar.test.tsx`
+- `cd web-ui && npx vitest run src/components/domain/orders/CandidateOrderModal.test.tsx src/components/domain/workspace/ActionPanel.test.tsx`
+- `cd web-ui && npm run typecheck`
+- `pytest -q`
+- `cd web-ui && npx vitest run`
 
 ---
 
@@ -22,6 +46,7 @@
 | `web-ui/src/features/portfolio/types.ts` | Add concentration types |
 | `web-ui/src/components/domain/portfolio/ConcentrationBar.tsx` | New — shows top concentration group |
 | `web-ui/src/components/domain/portfolio/ConcentrationBar.test.tsx` | Tests |
+| `web-ui/src/components/domain/orders/OrderReviewExperience.tsx` | Warn when projected order risk pushes concentration above threshold |
 | `web-ui/src/pages/Book.tsx` or portfolio summary area | Mount ConcentrationBar |
 
 ---
@@ -34,7 +59,7 @@
 - Modify: `config/defaults.yaml`
 - Test: `tests/api/test_concentration.py`
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 Create `tests/api/test_concentration.py`:
 
@@ -96,14 +121,14 @@ def test_concentration_warning_flag_when_above_threshold(client_with_positions):
     assert groups["NL"]["warning"] is True  # 75% > 60% threshold
 ```
 
-- [ ] **Step 2: Run to confirm failure**
+- [x] **Step 2: Run to confirm failure**
 
 ```bash
 pytest tests/api/test_concentration.py -v
 ```
 Expected: FAIL — `concentration` not in response
 
-- [ ] **Step 3: Add models to `api/models/portfolio.py`**
+- [x] **Step 3: Add models to `api/models/portfolio.py`**
 
 After `EarningsProximityResponse`, add:
 ```python
@@ -118,7 +143,7 @@ class ConcentrationGroup(BaseModel):
 concentration: list[ConcentrationGroup] = Field(default_factory=list)
 ```
 
-- [ ] **Step 4: Add country derivation helper and concentration computation**
+- [x] **Step 4: Add country derivation helper and concentration computation**
 
 In `api/services/portfolio_service.py`, add module-level function:
 ```python
@@ -166,21 +191,21 @@ Add `concentration=concentration_groups` to the `PortfolioSummary(...)` return.
 
 Import `ConcentrationGroup` at top of service file.
 
-- [ ] **Step 5: Add config to `config/defaults.yaml`**
+- [x] **Step 5: Add config to `config/defaults.yaml`**
 
 Under `risk:`, add:
 ```yaml
 max_concentration_pct: 60
 ```
 
-- [ ] **Step 6: Run tests**
+- [x] **Step 6: Run tests**
 
 ```bash
 pytest tests/api/test_concentration.py -v
 ```
 Expected: 3 PASSED
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```bash
 git add api/models/portfolio.py api/services/portfolio_service.py config/defaults.yaml tests/api/test_concentration.py
@@ -197,7 +222,7 @@ git commit -m "feat: add portfolio concentration by country to portfolio summary
 - Create: `web-ui/src/components/domain/portfolio/ConcentrationBar.tsx`
 - Create: `web-ui/src/components/domain/portfolio/ConcentrationBar.test.tsx`
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 Create `web-ui/src/components/domain/portfolio/ConcentrationBar.test.tsx`:
 
@@ -244,14 +269,14 @@ describe('ConcentrationBar', () => {
 });
 ```
 
-- [ ] **Step 2: Run to confirm failure**
+- [x] **Step 2: Run to confirm failure**
 
 ```bash
 cd web-ui && npx vitest run src/components/domain/portfolio/ConcentrationBar.test.tsx
 ```
 Expected: FAIL
 
-- [ ] **Step 3: Add i18n strings**
+- [x] **Step 3: Add i18n strings**
 
 ```typescript
 // In messages.en.ts:
@@ -261,7 +286,7 @@ concentrationBar: {
 },
 ```
 
-- [ ] **Step 4: Add types to frontend portfolio types**
+- [x] **Step 4: Add types to frontend portfolio types**
 
 In `web-ui/src/features/portfolio/types.ts` or wherever `PortfolioSummary` frontend type lives:
 ```typescript
@@ -287,7 +312,7 @@ concentration: (api.concentration ?? []).map(g => ({
 })),
 ```
 
-- [ ] **Step 5: Implement ConcentrationBar**
+- [x] **Step 5: Implement ConcentrationBar**
 
 Create `web-ui/src/components/domain/portfolio/ConcentrationBar.tsx`:
 
@@ -324,14 +349,14 @@ export default function ConcentrationBar({ groups }: Props) {
 }
 ```
 
-- [ ] **Step 6: Run tests**
+- [x] **Step 6: Run tests**
 
 ```bash
 cd web-ui && npx vitest run src/components/domain/portfolio/ConcentrationBar.test.tsx
 ```
 Expected: 4 PASSED
 
-- [ ] **Step 7: Mount on portfolio summary**
+- [x] **Step 7: Mount on portfolio summary**
 
 Find where `PortfolioSummary` data is displayed (grep for `portfolioSummary` or `usePortfolioSummary` in `web-ui/src/components/domain/portfolio/`). Add:
 ```tsx
@@ -340,13 +365,13 @@ import ConcentrationBar from './ConcentrationBar';
 <ConcentrationBar groups={summary.concentration} />
 ```
 
-- [ ] **Step 8: Run full suite**
+- [x] **Step 8: Run full suite**
 
 ```bash
 pytest -q && cd web-ui && npx vitest run
 ```
 
-- [ ] **Step 9: Commit**
+- [x] **Step 9: Commit**
 
 ```bash
 git add api/ config/ tests/ web-ui/src/

--- a/docs/superpowers/plans/2026-05-03-feature-6-time-stop-nudge.md
+++ b/docs/superpowers/plans/2026-05-03-feature-6-time-stop-nudge.md
@@ -1,0 +1,394 @@
+# Time Stop Nudge — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> Read `docs/superpowers/plans/handover-context.md` before starting.
+
+**Goal:** Show an ambient warning badge on position rows when a trade has been open too long without adequate profit, prompting the trader to make a deliberate exit/hold decision — without forcing an automatic close.
+
+**Architecture:** Add two config fields (`time_stop_days`, `time_stop_min_r`) to `ManageConfig` in `src/swing_screener/portfolio/state.py` and `config/defaults.yaml`. Add `days_open: int` and `time_stop_warning: bool` to `PositionWithMetrics` in the API layer. The backend computes both fields in `_build_position_with_metrics()`. The frontend `PositionWithMetrics` type gains these fields and the position row component shows a coloured badge when `timeStopWarning` is `true`.
+
+**Important distinction:** The hard `CLOSE_TIME_EXIT` action already exists in `ManageConfig` (fires in the daily review CLI workflow when `bars_since >= max_holding_days`). This feature is a **separate soft nudge** — a UI badge visible at all times in the Book page. It does NOT trigger any automatic close. It uses its own config fields (`time_stop_days` and `time_stop_min_r`) so thresholds can differ from `max_holding_days`.
+
+**Tech Stack:** Python/FastAPI backend, React 18/TypeScript frontend
+
+---
+
+## Implementation status - 2026-05-04
+
+Status: implemented on `codex/time-stop-nudge`.
+
+Branch stack:
+
+- Branch: `codex/time-stop-nudge`
+- Base: `codex/concentration-warning`
+- PR: pending
+
+What changed:
+
+- Added `time_stop_days` and `time_stop_min_r` manage settings with defaults of 15 days and 0.5R.
+- Added `days_open` and `time_stop_warning` to portfolio position metrics.
+- Daily review position rows now receive the same stale-trade warning payload.
+- Book position rows and Today action rows show a small amber stale-trade badge when the warning is active.
+- Strategy advanced manage settings expose the two soft time-stop thresholds.
+- Local persistence mode mirrors the same derived fields.
+
+Validation run:
+
+- `pytest tests/api/test_time_stop_nudge.py -v`
+- `cd web-ui && npx vitest run src/components/domain/workspace/PortfolioTable.test.tsx`
+- `cd web-ui && npm run typecheck`
+
+---
+
+## File map
+
+| File | Change |
+|---|---|
+| `src/swing_screener/portfolio/state.py` | Add `time_stop_days: int` and `time_stop_min_r: float` to `ManageConfig` |
+| `config/defaults.yaml` | Add `time_stop_days: 15` and `time_stop_min_r: 0.5` under `manage:` |
+| `api/models/portfolio.py` | Add `days_open: int` and `time_stop_warning: bool` to `PositionWithMetrics` |
+| `api/services/portfolio_service.py` | Compute `days_open` and `time_stop_warning` in `_build_position_with_metrics()` |
+| `web-ui/src/features/portfolio/api.ts` | Add `daysOpen`, `timeStopWarning` to `PositionWithMetricsApiResponse` and `PositionWithMetrics`; transform in `transformPositionWithMetrics()` |
+| `web-ui/src/i18n/messages.en.ts` | Add `book.positions.timeStopWarning` key |
+| `web-ui/src/components/domain/portfolio/PositionRow.tsx` (or wherever position rows render) | Render badge when `timeStopWarning` is true |
+| `tests/api/test_time_stop_nudge.py` | Backend tests |
+
+---
+
+### Task 1: Backend — config fields, model fields, and computed values
+
+**Files:**
+- Modify: `src/swing_screener/portfolio/state.py`
+- Modify: `config/defaults.yaml`
+- Modify: `api/models/portfolio.py`
+- Modify: `api/services/portfolio_service.py`
+- Test: `tests/api/test_time_stop_nudge.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/api/test_time_stop_nudge.py`:
+
+```python
+"""Tests for the time-stop nudge feature."""
+import json
+import pytest
+from datetime import date, timedelta
+from fastapi.testclient import TestClient
+from api.main import app
+import api.dependencies as deps
+
+def make_position(entry_date_str: str, r_now_approx: float = 0.0) -> dict:
+    """Build a minimal open position dict. exit_price=None => open."""
+    entry_price = 100.0
+    stop_price = 90.0  # 1R = 10
+    shares = 10
+    # Make current_price reproduce r_now_approx: current = entry + r_now * (entry - stop)
+    current_price = entry_price + r_now_approx * (entry_price - stop_price)
+    return {
+        "position_id": "POS-TST-001",
+        "ticker": "TEST",
+        "status": "open",
+        "entry_date": entry_date_str,
+        "entry_price": entry_price,
+        "stop_price": stop_price,
+        "shares": shares,
+        "initial_risk": 100.0,
+        "current_price": current_price,
+        "notes": "",
+        "tags": [],
+    }
+
+@pytest.fixture
+def client_with_old_flat_position(tmp_path, monkeypatch):
+    """Position open 20 days at 0R — should trigger warning with defaults."""
+    entry_date = (date.today() - timedelta(days=20)).isoformat()
+    pos = make_position(entry_date, r_now_approx=0.0)
+    positions_file = tmp_path / "positions.json"
+    orders_file = tmp_path / "orders.json"
+    positions_file.write_text(json.dumps({"asof": date.today().isoformat(), "positions": [pos]}))
+    orders_file.write_text(json.dumps({"asof": date.today().isoformat(), "orders": []}))
+    monkeypatch.setattr(deps, "_positions_path", positions_file)
+    monkeypatch.setattr(deps, "_orders_path", orders_file)
+    return TestClient(app)
+
+@pytest.fixture
+def client_with_new_profitable_position(tmp_path, monkeypatch):
+    """Position open 5 days at 2R — should NOT trigger warning."""
+    entry_date = (date.today() - timedelta(days=5)).isoformat()
+    pos = make_position(entry_date, r_now_approx=2.0)
+    positions_file = tmp_path / "positions.json"
+    orders_file = tmp_path / "orders.json"
+    positions_file.write_text(json.dumps({"asof": date.today().isoformat(), "positions": [pos]}))
+    orders_file.write_text(json.dumps({"asof": date.today().isoformat(), "orders": []}))
+    monkeypatch.setattr(deps, "_positions_path", positions_file)
+    monkeypatch.setattr(deps, "_orders_path", orders_file)
+    return TestClient(app)
+
+def test_position_includes_days_open(client_with_old_flat_position):
+    response = client_with_old_flat_position.get("/api/portfolio/positions")
+    assert response.status_code == 200
+    positions = response.json()["positions"]
+    assert len(positions) == 1
+    assert "days_open" in positions[0]
+    assert positions[0]["days_open"] >= 20
+
+def test_time_stop_warning_fires_for_old_flat_position(client_with_old_flat_position):
+    response = client_with_old_flat_position.get("/api/portfolio/positions")
+    positions = response.json()["positions"]
+    assert positions[0]["time_stop_warning"] is True
+
+def test_time_stop_warning_absent_for_new_profitable_position(client_with_new_profitable_position):
+    response = client_with_new_profitable_position.get("/api/portfolio/positions")
+    positions = response.json()["positions"]
+    assert positions[0]["time_stop_warning"] is False
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+```bash
+pytest tests/api/test_time_stop_nudge.py -v
+```
+Expected: FAIL — `days_open` not in response
+
+- [ ] **Step 3: Add config fields to ManageConfig**
+
+In `src/swing_screener/portfolio/state.py`, in class `ManageConfig` (around line 50):
+
+```python
+# Existing fields:
+max_holding_days: int = 20  # time exit (hard close in daily review workflow)
+
+# Add below:
+time_stop_days: int = 15   # soft nudge threshold (UI badge only — no automatic close)
+time_stop_min_r: float = 0.5  # minimum R to avoid nudge even after time_stop_days
+```
+
+- [ ] **Step 4: Add config defaults**
+
+In `config/defaults.yaml`, under the `manage:` section, add after `max_holding_days`:
+
+```yaml
+manage:
+  # ... existing keys ...
+  max_holding_days: 20
+  time_stop_days: 15       # days open before soft nudge appears
+  time_stop_min_r: 0.5     # nudge suppressed when r_now >= this value
+```
+
+- [ ] **Step 5: Add fields to PositionWithMetrics model**
+
+In `api/models/portfolio.py`, in class `PositionWithMetrics` (after `total_risk`):
+
+```python
+days_open: int = Field(default=0, description="Calendar days since entry_date")
+time_stop_warning: bool = Field(default=False, description="True when trade is stale and underperforming")
+```
+
+- [ ] **Step 6: Compute fields in _build_position_with_metrics**
+
+In `api/services/portfolio_service.py`, in `_build_position_with_metrics()`, after the `r_now` calculation and before the `return PositionWithMetrics(...)`:
+
+```python
+from datetime import date as _date
+
+# Compute days_open
+days_open = 0
+entry_date_str = str(position.get("entry_date") or "")
+if entry_date_str:
+    try:
+        entry_dt = _date.fromisoformat(entry_date_str)
+        days_open = (_date.today() - entry_dt).days
+    except ValueError:
+        pass
+
+# Read time-stop config (defaults from ManageConfig if not in strategy config)
+from swing_screener.portfolio.state import ManageConfig as _ManageConfig
+_manage_defaults = _ManageConfig()
+from swing_screener.settings import get_settings_manager as _get_sm
+_sm_manage = getattr(getattr(_get_sm().get(), "manage", None), "__dict__", {})
+time_stop_days = int(_sm_manage.get("time_stop_days", _manage_defaults.time_stop_days))
+time_stop_min_r = float(_sm_manage.get("time_stop_min_r", _manage_defaults.time_stop_min_r))
+r_now_val = calculate_r_now(state_position, current_price_for_metrics)
+time_stop_warning = (
+    state_position.status == "open"
+    and days_open >= time_stop_days
+    and r_now_val < time_stop_min_r
+)
+```
+
+Then in the `return PositionWithMetrics(...)` call, add:
+```python
+days_open=days_open,
+time_stop_warning=time_stop_warning,
+```
+
+Note: `r_now_val` is already computed above — remove the duplicate `r_now=calculate_r_now(...)` in the return and use `r_now=r_now_val`.
+
+- [ ] **Step 7: Run tests**
+
+```bash
+pytest tests/api/test_time_stop_nudge.py -v
+```
+Expected: 3 PASSED
+
+- [ ] **Step 8: Run full backend suite**
+
+```bash
+pytest -q
+```
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/swing_screener/portfolio/state.py config/defaults.yaml api/models/portfolio.py api/services/portfolio_service.py tests/api/test_time_stop_nudge.py
+git commit -m "feat: add days_open and time_stop_warning to position metrics"
+```
+
+---
+
+### Task 2: Frontend — display time stop warning badge
+
+**Files:**
+- Modify: `web-ui/src/features/portfolio/api.ts`
+- Modify: `web-ui/src/i18n/messages.en.ts`
+- Identify and modify the position row component (search `web-ui/src/` for where `rNow` or `ticker` is rendered in a list — likely `web-ui/src/components/domain/portfolio/`)
+
+- [ ] **Step 1: Find the position row component**
+
+```bash
+grep -rn "rNow\|time_stop\|timeStop" web-ui/src/components/domain/portfolio/ | head -20
+```
+
+Note which file renders individual position rows.
+
+- [ ] **Step 2: Add fields to frontend types**
+
+In `web-ui/src/features/portfolio/api.ts`:
+
+In `PositionWithMetricsApiResponse` interface (after `fees_eur`):
+```typescript
+days_open?: number;
+time_stop_warning?: boolean;
+```
+
+In `PositionWithMetrics` interface (after `feesEur`):
+```typescript
+daysOpen: number;
+timeStopWarning: boolean;
+```
+
+In `transformPositionWithMetrics()` (after `feesEur: data.fees_eur ?? 0`):
+```typescript
+daysOpen: data.days_open ?? 0,
+timeStopWarning: data.time_stop_warning ?? false,
+```
+
+- [ ] **Step 3: Add i18n string**
+
+In `web-ui/src/i18n/messages.en.ts`, locate the `book` section (search for `book:`) and add in the positions subsection:
+
+```typescript
+timeStopWarning: 'Stale trade — consider closing or setting a reason to hold',
+timeStopBadge: 'Stale',
+```
+
+- [ ] **Step 4: Write a failing test**
+
+Find the position row component filename from Step 1 (e.g. `PositionRow.tsx`). Create a test file next to it (e.g. `PositionRow.test.tsx`):
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '@/test/utils';
+import { t } from '@/i18n/t';
+// Adjust import path based on actual component found in Step 1:
+import PositionRow from './PositionRow';
+import type { PositionWithMetrics } from '@/features/portfolio/api';
+
+function makePosition(overrides: Partial<PositionWithMetrics> = {}): PositionWithMetrics {
+  return {
+    ticker: 'TEST',
+    status: 'open',
+    entryDate: '2026-01-01',
+    entryPrice: 100,
+    stopPrice: 90,
+    shares: 10,
+    pnl: 0,
+    pnlPercent: 0,
+    rNow: 0,
+    entryValue: 1000,
+    currentValue: 1000,
+    perShareRisk: 10,
+    totalRisk: 100,
+    feesEur: 0,
+    daysOpen: 0,
+    timeStopWarning: false,
+    notes: '',
+    tags: [],
+    ...overrides,
+  };
+}
+
+describe('PositionRow — time stop warning badge', () => {
+  it('does not show warning badge when timeStopWarning is false', () => {
+    renderWithProviders(<PositionRow position={makePosition({ timeStopWarning: false })} />);
+    expect(screen.queryByText(t('book.positions.timeStopBadge'))).not.toBeInTheDocument();
+  });
+
+  it('shows warning badge when timeStopWarning is true', () => {
+    renderWithProviders(<PositionRow position={makePosition({ timeStopWarning: true })} />);
+    expect(screen.getByText(t('book.positions.timeStopBadge'))).toBeInTheDocument();
+  });
+
+  it('badge has accessible title with full warning text', () => {
+    renderWithProviders(<PositionRow position={makePosition({ timeStopWarning: true })} />);
+    const badge = screen.getByTitle(t('book.positions.timeStopWarning'));
+    expect(badge).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 5: Run to confirm failure**
+
+```bash
+cd web-ui && npx vitest run src/components/domain/portfolio/PositionRow.test.tsx
+```
+Expected: FAIL — component renders without badge
+
+- [ ] **Step 6: Add the warning badge to the position row component**
+
+In the position row component found in Step 1, add the badge conditionally. The badge should be:
+- Small, amber/yellow coloured (indicates warning, not critical error)
+- Shown next to the ticker or position ID
+- Has `title` attribute for the full tooltip text
+
+```tsx
+{position.timeStopWarning && (
+  <span
+    className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300"
+    title={t('book.positions.timeStopWarning')}
+  >
+    {t('book.positions.timeStopBadge')}
+  </span>
+)}
+```
+
+- [ ] **Step 7: Run tests**
+
+```bash
+cd web-ui && npx vitest run src/components/domain/portfolio/PositionRow.test.tsx
+```
+Expected: 3 PASSED
+
+- [ ] **Step 8: Run full suite**
+
+```bash
+pytest -q && cd web-ui && npx vitest run
+```
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add web-ui/src/features/portfolio/api.ts web-ui/src/i18n/messages.en.ts web-ui/src/components/domain/portfolio/
+git commit -m "feat: show time stop warning badge on stale position rows"
+```

--- a/docs/superpowers/plans/2026-05-04-feature-7-watchlist-pipeline.md
+++ b/docs/superpowers/plans/2026-05-04-feature-7-watchlist-pipeline.md
@@ -1,0 +1,54 @@
+# Watchlist Pipeline View — Implementation Plan
+
+> Read `docs/superpowers/plans/handover-context.md` before starting.
+
+**Goal:** Turn the watchlist from a static symbol list into a ranked pipeline that shows which names are closest to triggering, with enough context to review them quickly from Research and Daily Review.
+
+**Architecture:** Keep persisted watchlist storage unchanged and add a dedicated enrichment layer in the API. `WatchlistService` reads raw watchlist items from `WatchlistRepository`, fetches recent OHLCV with the existing market-data provider, computes the breakout trigger using the existing selection signal board, derives `distance_to_trigger_pct`, and returns a richer `WatchlistItemView`. Daily Review consumes the same service and filters names within 3% of the trigger zone into a new `watchlist_near_trigger` section. The frontend adds a Watchlist tab in Research and a compact near-trigger section in Today.
+
+**Tech Stack:** Python/FastAPI backend, React 18/TypeScript frontend, existing OHLCV provider and screener signal logic
+
+---
+
+## Implementation status - 2026-05-04
+
+Status: implemented on `codex/watchlist-pipeline`.
+
+Branch stack:
+
+- Branch: `codex/watchlist-pipeline`
+- Base: `codex/time-stop-nudge`
+- PR: pending
+
+What changed:
+
+- Added `WatchlistService` to enrich watchlist rows with `current_price`, `signal_trigger_price`, `distance_to_trigger_pct`, `signal`, `last_bar`, and a 5-bar `price_history` sparkline payload.
+- Extended the watchlist API response shape with `WatchlistItemView` while keeping `watchlist.json` persistence untouched.
+- Added a Research > Watchlist tab with a pipeline table sorted by distance to trigger and a 5-day sparkline.
+- Added a Daily Review section `watchlist_near_trigger` surfaced above new candidates for names within 3% of the buy zone.
+- Added focused backend and frontend coverage for the enrichment path, Daily Review mapping, and the new UI panel.
+
+Validation run:
+
+- `pytest tests/api/test_watchlist_service.py tests/api/test_daily_review_service.py tests/api/test_watchlist_endpoints.py`
+- `cd web-ui && npm test -- --run src/components/domain/watchlist/WatchlistPipelinePanel.test.tsx src/features/dailyReview/types.test.ts src/pages/Today.test.tsx src/features/watchlist/hooks.test.tsx`
+- `cd web-ui && npm run typecheck`
+
+---
+
+## File map
+
+| File | Change |
+|---|---|
+| `api/models/watchlist.py` | Add `WatchlistItemView` with enriched trigger-distance fields |
+| `api/services/watchlist_service.py` | New enrichment service for pipeline ordering and sparkline history |
+| `api/routers/watchlist.py` | Serve enriched watchlist items via `WatchlistService` |
+| `api/models/daily_review.py` | Add `watchlist_near_trigger` to the Daily Review payload |
+| `api/services/daily_review_service.py` | Pull near-trigger watchlist names into Today |
+| `web-ui/src/components/domain/watchlist/WatchlistPipelinePanel.tsx` | New Research watchlist pipeline panel |
+| `web-ui/src/pages/Research.tsx` | Add Watchlist tab and ticker handoff into analysis |
+| `web-ui/src/pages/Today.tsx` | Render the near-trigger watchlist section above candidates |
+| `web-ui/src/features/watchlist/types.ts` | Extend watchlist client types with enrichment fields |
+| `web-ui/src/features/dailyReview/types.ts` | Map the new Daily Review watchlist section |
+| `tests/api/test_watchlist_service.py` | Backend enrichment and sorting coverage |
+| `web-ui/src/components/domain/watchlist/WatchlistPipelinePanel.test.tsx` | Frontend watchlist panel coverage |

--- a/docs/superpowers/plans/handover-context.md
+++ b/docs/superpowers/plans/handover-context.md
@@ -4,6 +4,39 @@ Read this before picking up any feature plan. It describes the codebase conventi
 
 ---
 
+## Current implementation status - 2026-05-04
+
+Tier 1 is complete locally and Tier 2 has started as sequential stacked PRs:
+
+| Feature | Branch | Base | PR | Status |
+|---|---|---|---|---|
+| Feature 1 - Trade tagging | `codex/trade-tagging` | `main` | https://github.com/matteolongo/swing_screener/pull/232 | Draft, fully implemented |
+| Feature 2 - Edge breakdown | `codex/edge-breakdown` | `codex/trade-tagging` | https://github.com/matteolongo/swing_screener/pull/233 | Draft, fully implemented |
+| Feature 3 - Account equity auto-update | `codex/account-equity` | `codex/edge-breakdown` | https://github.com/matteolongo/swing_screener/pull/234 | Draft, fully implemented (incl. Settings toggle) |
+| Feature 4 - Earnings proximity warning | `codex/earnings-warning` | `codex/account-equity` | https://github.com/matteolongo/swing_screener/pull/235 | Draft, fully implemented (incl. cache-hit test) |
+| Feature 5 - Concentration warning | `codex/concentration-warning` | `codex/earnings-warning` | https://github.com/matteolongo/swing_screener/pull/236 | Draft, fully implemented (incl. order modal warning) |
+| Feature 6 - Time stop nudge | `codex/time-stop-nudge` | `codex/concentration-warning` | pending | Implemented locally |
+| Feature 7 - Watchlist pipeline | `codex/watchlist-pipeline` | `codex/time-stop-nudge` | pending | Implemented locally |
+
+Review agents should review the PRs in order. Each branch intentionally builds on the previous one, so diffs should be compared against the listed base branch, not always against `main`.
+
+Known local dirty files that were not part of this work and should not be included unless explicitly requested:
+
+- `config/intelligence.yaml`
+- `config/strategies.yaml`
+- `config/user.yaml`
+- `data/screener_history.json`
+
+Validation already run during implementation:
+
+- Feature 1: backend trade tagging test, frontend typecheck, focused modal/journal tests, frontend suite during the feature work.
+- Feature 2: focused `EdgeBreakdownTable` test and frontend suite during the feature work.
+- Feature 3: `pytest tests/api/test_account_equity.py -v`, `pytest -q`, `cd web-ui && npm run typecheck`, `cd web-ui && npx vitest run src/components/domain/strategy/EnhancedRiskCard.test.tsx`, `cd web-ui && npx vitest run`.
+- Feature 4: `pytest tests/api/test_earnings_proximity.py -v` (includes cache-hit coverage), `pytest -q`, `cd web-ui && npm run typecheck`, `cd web-ui && npx vitest run`.
+- Feature 5: `pytest tests/api/test_concentration.py -v`, `cd web-ui && npx vitest run src/components/domain/portfolio/ConcentrationBar.test.tsx`, focused order review frontend tests, `pytest -q`, `cd web-ui && npm run typecheck`, `cd web-ui && npx vitest run`.
+- Feature 6: `pytest tests/api/test_time_stop_nudge.py -v`, `cd web-ui && npx vitest run src/components/domain/workspace/PortfolioTable.test.tsx`, `cd web-ui && npm run typecheck`.
+- Feature 7: `pytest tests/api/test_watchlist_service.py tests/api/test_daily_review_service.py tests/api/test_watchlist_endpoints.py`, `cd web-ui && npm test -- --run src/components/domain/watchlist/WatchlistPipelinePanel.test.tsx src/features/dailyReview/types.test.ts src/pages/Today.test.tsx src/features/watchlist/hooks.test.tsx`, `cd web-ui && npm run typecheck`.
+
 ## What this app is
 
 A deterministic, risk-first swing-trading framework. It screens stocks post-market-close, sizes positions using R-multiples (`1R = entry_price - stop_price`), and keeps all execution manual. No live trading, no auto-execution.
@@ -104,4 +137,6 @@ Use `locked_read_json` / `locked_write_json` from `api/utils/file_lock.py` — n
 
 ## Active branch
 
-Feature work currently lives on `feature/pending-orders-degiro-fill`. Start new features from `main` after that branch is merged, or from the current branch if building on top.
+Current stacked feature work is on `codex/watchlist-pipeline`. Tier 2 has started on top of the Tier 1 stack.
+
+Next work should continue Tier 2 from Feature 8 — Volume quality signal.

--- a/docs/superpowers/specs/2026-05-03-swing-trading-feature-roadmap.md
+++ b/docs/superpowers/specs/2026-05-03-swing-trading-feature-roadmap.md
@@ -16,6 +16,24 @@ Features are grouped into tiers. Ship all of Tier 1 before starting Tier 2.
 
 ---
 
+## Implementation status - 2026-05-04
+
+Tier 1 is implemented locally and Tier 2 has started as sequential stacked PRs:
+
+| # | Feature | Branch | Base | PR | Status |
+|---|---|---|---|---|---|
+| 1 | Trade tagging | `codex/trade-tagging` | `main` | https://github.com/matteolongo/swing_screener/pull/232 | Draft, implemented |
+| 2 | Performance breakdown | `codex/edge-breakdown` | `codex/trade-tagging` | https://github.com/matteolongo/swing_screener/pull/233 | Draft, implemented |
+| 3 | Account equity auto-update | `codex/account-equity` | `codex/edge-breakdown` | https://github.com/matteolongo/swing_screener/pull/234 | Draft, implemented |
+| 4 | Earnings warning | `codex/earnings-warning` | `codex/account-equity` | https://github.com/matteolongo/swing_screener/pull/235 | Draft, implemented |
+| 5 | Concentration warning | `codex/concentration-warning` | `codex/earnings-warning` | https://github.com/matteolongo/swing_screener/pull/236 | Draft, implemented |
+| 6 | Time stop nudge | `codex/time-stop-nudge` | `codex/concentration-warning` | pending | Implemented locally |
+| 7 | Watchlist pipeline view | `codex/watchlist-pipeline` | `codex/time-stop-nudge` | pending | Implemented locally |
+
+Review stacked PRs in order and compare each PR against its listed base branch.
+
+---
+
 ## Tier 1 — Core feedback loop and risk hygiene
 *These features have the highest ratio of trading value to build effort. They make the existing workflow meaningfully safer and smarter.*
 
@@ -299,19 +317,21 @@ The screener works on daily bars. A daily breakout that contradicts the weekly t
 
 ## Implementation order summary
 
-| # | Feature | Tier | Designer | UX | Dev | Value delivered |
-|---|---------|------|----------|----|-----|----------------|
-| 1 | Trade tagging | 1 | Tag taxonomy | Close flow | Model + filter | Queryable journal |
-| 2 | Performance by setup | 1 | Stats layout | Empty state | Client aggregation | See your edge |
-| 3 | Account equity auto-update | 1 | Settings UI | Mode toggle | P&L calc | Accurate sizing |
-| 4 | Earnings warning | 1 | Warning banner | Non-blocking | yfinance fetch | Avoid earnings traps |
-| 5 | Concentration warning | 1 | Portfolio section | Order warning | Country grouping | Prevent correlated bets |
-| 6 | Time stop nudge | 1 | Badge design | Nudge copy | Metrics flag | Kill dead capital |
-| 7 | Watchlist pipeline | 2 | Table column | Sort + sparkline | Distance calc | Spot setups early |
-| 8 | Volume quality | 2 | Signal indicator | Caution note | Volume ratio | Better entry timing |
-| 9 | Liquidity filter | 2 | Settings field | Warning copy | Pipeline filter | Avoid illiquid names |
-| 10 | Partial exits | 2 | Close modal | Share picker | Position events | Scale-out capability |
-| 11 | Regime performance | 3 | Stats section | — | Regime backfill | Size to conditions |
-| 12 | FX-adjusted R | 3 | Secondary display | Tooltip | FX rate fetch | True R visibility |
-| 13 | Trail customization | 3 | Method selector | Live preview | Branch logic | Setup-specific trails |
-| 14 | MTF trend filter | 3 | Filter toggle | Indicator chip | Weekly resample | Fewer false signals |
+Last updated: 2026-05-04
+
+| # | Feature | Tier | Status | Value delivered |
+|---|---------|------|--------|----------------|
+| 1 | Trade tagging | 1 | ✅ Done — `codex/trade-tagging` / PR #232 | Queryable journal |
+| 2 | Performance by setup | 1 | ✅ Done — `codex/edge-breakdown` / PR #233 | See your edge |
+| 3 | Account equity auto-update | 1 | ✅ Done — `codex/account-equity` / PR #234 | Accurate sizing |
+| 4 | Earnings warning | 1 | ✅ Done — `codex/earnings-warning` / PR #235 | Avoid earnings traps |
+| 5 | Concentration warning | 1 | ✅ Done — `codex/concentration-warning` / PR #236 | Prevent correlated bets |
+| 6 | Time stop nudge | 1 | ✅ Done — `codex/time-stop-nudge` / PR pending | Kill dead capital |
+| 7 | Watchlist pipeline | 2 | 🔲 No plan yet | Spot setups early |
+| 8 | Volume quality | 2 | 🔲 No plan yet | Better entry timing |
+| 9 | Liquidity filter | 2 | 🔲 No plan yet | Avoid illiquid names |
+| 10 | Partial exits | 2 | 🔲 No plan yet | Scale-out capability |
+| 11 | Regime performance | 3 | 🔲 No plan yet | Size to conditions |
+| 12 | FX-adjusted R | 3 | 🔲 No plan yet | True R visibility |
+| 13 | Trail customization | 3 | 🔲 No plan yet | Setup-specific trails |
+| 14 | MTF trend filter | 3 | 🔲 No plan yet | Fewer false signals |

--- a/src/swing_screener/portfolio/state.py
+++ b/src/swing_screener/portfolio/state.py
@@ -48,6 +48,8 @@ class ManageConfig:
     trail_after_R: float = 2.0
     sma_buffer_pct: float = 0.005  # buffer under SMA (0.5%)
     max_holding_days: int = 20  # time exit
+    time_stop_days: int = 15  # soft stale-trade nudge threshold
+    time_stop_min_r: float = 0.5  # suppress nudge once trade has made this much progress
     benchmark: str = "SPY"
 
 

--- a/src/swing_screener/strategy/config.py
+++ b/src/swing_screener/strategy/config.py
@@ -42,6 +42,8 @@ def build_manage_config(strategy: dict) -> ManageConfig:
         trail_sma=raw.get("trail_sma", 20),
         sma_buffer_pct=raw.get("sma_buffer_pct", 0.005),
         max_holding_days=raw.get("max_holding_days", 20),
+        time_stop_days=raw.get("time_stop_days", 15),
+        time_stop_min_r=raw.get("time_stop_min_r", 0.5),
         benchmark=raw.get("benchmark", "SPY"),
     )
 

--- a/src/swing_screener/strategy/storage.py
+++ b/src/swing_screener/strategy/storage.py
@@ -135,6 +135,17 @@ def _normalize_document(doc: dict[str, Any]) -> tuple[dict[str, Any], bool]:
                 filt["currencies"] = ["USD", "EUR"]
                 dirty = True
 
+        manage = strategy.get("manage")
+        default_manage = defaults.get("manage", {})
+        if not isinstance(manage, dict):
+            strategy["manage"] = deepcopy(default_manage if isinstance(default_manage, dict) else {})
+            dirty = True
+        elif isinstance(default_manage, dict):
+            for key, value in default_manage.items():
+                if manage.get(key) is None:
+                    manage[key] = deepcopy(value)
+                    dirty = True
+
         market_intelligence = strategy.get("market_intelligence")
         if not isinstance(market_intelligence, dict):
             strategy["market_intelligence"] = deepcopy(market_intelligence_default)

--- a/tests/api/test_account_equity.py
+++ b/tests/api/test_account_equity.py
@@ -1,0 +1,69 @@
+"""Tests for account equity auto-update feature."""
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+import api.dependencies as deps
+from api.main import app
+
+
+POSITIONS = [
+    {
+        "position_id": "POS-001",
+        "ticker": "AAPL",
+        "status": "closed",
+        "entry_date": "2026-01-01",
+        "entry_price": 100.0,
+        "stop_price": 95.0,
+        "shares": 10,
+        "initial_risk": 50.0,
+        "exit_price": 120.0,
+        "exit_date": "2026-01-15",
+        "notes": "",
+        "tags": [],
+    },
+    {
+        "position_id": "POS-002",
+        "ticker": "MSFT",
+        "status": "closed",
+        "entry_date": "2026-01-05",
+        "entry_price": 200.0,
+        "stop_price": 190.0,
+        "shares": 5,
+        "initial_risk": 50.0,
+        "exit_price": 185.0,
+        "exit_date": "2026-01-20",
+        "notes": "",
+        "tags": [],
+    },
+]
+
+
+@pytest.fixture
+def client_with_closed_positions(tmp_path, monkeypatch):
+    positions_file = tmp_path / "positions.json"
+    orders_file = tmp_path / "orders.json"
+    positions_file.write_text(json.dumps({"asof": "2026-01-20", "positions": POSITIONS}))
+    orders_file.write_text(json.dumps({"asof": "2026-01-20", "orders": []}))
+    monkeypatch.setattr(deps, "_positions_path", positions_file)
+    monkeypatch.setattr(deps, "_orders_path", orders_file)
+    return TestClient(app)
+
+
+def test_portfolio_summary_includes_realized_pnl(client_with_closed_positions):
+    response = client_with_closed_positions.get("/api/portfolio/summary")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "realized_pnl" in data
+    assert abs(data["realized_pnl"] - 125.0) < 0.01
+
+
+def test_portfolio_summary_includes_effective_account_size(client_with_closed_positions):
+    response = client_with_closed_positions.get("/api/portfolio/summary")
+
+    data = response.json()
+    assert "effective_account_size" in data
+    assert data["effective_account_size"] > data["account_size"]
+    assert abs(data["effective_account_size"] - (data["account_size"] + 125.0)) < 0.01

--- a/tests/api/test_concentration.py
+++ b/tests/api/test_concentration.py
@@ -1,0 +1,87 @@
+"""Tests for portfolio concentration warnings."""
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+import api.dependencies as deps
+from api.main import app
+
+
+POSITIONS = [
+    {
+        "position_id": "POS-SBMO",
+        "ticker": "SBMO.AS",
+        "status": "open",
+        "entry_date": "2026-01-01",
+        "entry_price": 34.0,
+        "stop_price": 33.0,
+        "shares": 10,
+        "initial_risk": 1.0,
+        "notes": "",
+        "tags": [],
+    },
+    {
+        "position_id": "POS-ALLF",
+        "ticker": "ALLF.AS",
+        "status": "open",
+        "entry_date": "2026-01-01",
+        "entry_price": 10.0,
+        "stop_price": 9.0,
+        "shares": 5,
+        "initial_risk": 1.0,
+        "notes": "",
+        "tags": [],
+    },
+    {
+        "position_id": "POS-AAPL",
+        "ticker": "AAPL",
+        "status": "open",
+        "entry_date": "2026-01-01",
+        "entry_price": 100.0,
+        "stop_price": 95.0,
+        "shares": 1,
+        "initial_risk": 5.0,
+        "notes": "",
+        "tags": [],
+    },
+]
+
+
+@pytest.fixture
+def client_with_positions(tmp_path, monkeypatch):
+    positions_file = tmp_path / "positions.json"
+    orders_file = tmp_path / "orders.json"
+    positions_file.write_text(json.dumps({"asof": "2026-01-01", "positions": POSITIONS}))
+    orders_file.write_text(json.dumps({"asof": "2026-01-01", "orders": []}))
+    monkeypatch.setattr(deps, "_positions_path", positions_file)
+    monkeypatch.setattr(deps, "_orders_path", orders_file)
+    return TestClient(app)
+
+
+def test_concentration_included_in_summary(client_with_positions):
+    response = client_with_positions.get("/api/portfolio/summary")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "concentration" in data
+    assert len(data["concentration"]) > 0
+
+
+def test_concentration_correct_pct(client_with_positions):
+    response = client_with_positions.get("/api/portfolio/summary")
+
+    data = response.json()
+    groups = {group["country"]: group for group in data["concentration"]}
+    assert "NL" in groups
+    assert abs(groups["NL"]["risk_pct"] - 75.0) < 1.0
+
+
+def test_concentration_warning_flag_when_above_threshold(client_with_positions):
+    response = client_with_positions.get("/api/portfolio/summary")
+
+    data = response.json()
+    groups = {group["country"]: group for group in data["concentration"]}
+    assert groups["NL"]["warning"] is True

--- a/tests/api/test_daily_review_service.py
+++ b/tests/api/test_daily_review_service.py
@@ -430,6 +430,50 @@ def test_generate_daily_review_no_candidates(mock_portfolio_service, tmp_path):
     assert review.summary.total_positions == 3
 
 
+def test_generate_daily_review_includes_watchlist_near_trigger(
+    mock_screener_service,
+    mock_portfolio_service,
+    tmp_path,
+):
+    watchlist_service = Mock()
+    watchlist_service.list_items.return_value = [
+        {
+            "ticker": "ASML",
+            "watched_at": "2026-05-01T10:00:00Z",
+            "watch_price": 660.0,
+            "currency": "EUR",
+            "source": "screener",
+            "current_price": 671.0,
+            "signal_trigger_price": 680.0,
+            "distance_to_trigger_pct": -1.32,
+            "price_history": [],
+        },
+        {
+            "ticker": "SAP",
+            "watched_at": "2026-05-01T10:00:00Z",
+            "watch_price": 250.0,
+            "currency": "EUR",
+            "source": "screener",
+            "current_price": 260.0,
+            "signal_trigger_price": 270.0,
+            "distance_to_trigger_pct": -3.7,
+            "price_history": [],
+        },
+    ]
+
+    service = DailyReviewService(
+        mock_screener_service,
+        mock_portfolio_service,
+        watchlist_service=watchlist_service,
+        data_dir=tmp_path,
+    )
+
+    review = service.generate_daily_review(top_n=10)
+
+    assert [item.ticker for item in review.watchlist_near_trigger] == ["ASML"]
+    assert review.summary.watchlist_near_trigger == 1
+
+
 def test_generate_daily_review_survives_stop_suggestion_error(
     mock_screener_service,
     mock_portfolio_service,

--- a/tests/api/test_earnings_proximity.py
+++ b/tests/api/test_earnings_proximity.py
@@ -1,0 +1,77 @@
+"""Tests for earnings proximity endpoint."""
+from __future__ import annotations
+
+from datetime import date, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.main import app
+from api.services import portfolio_service
+
+
+@pytest.fixture(autouse=True)
+def clear_earnings_cache():
+    portfolio_service._earnings_cache.clear()
+    yield
+    portfolio_service._earnings_cache.clear()
+
+
+client = TestClient(app)
+
+
+def test_earnings_within_10_days_returns_warning():
+    near_date = (date.today() + timedelta(days=5)).isoformat()
+    mock_ticker = MagicMock()
+    mock_ticker.calendar = {"Earnings Date": [near_date]}
+
+    with patch("yfinance.Ticker", return_value=mock_ticker):
+        response = client.get("/api/portfolio/earnings-proximity/AAPL")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ticker"] == "AAPL"
+    assert data["warning"] is True
+    assert data["days_until"] == 5
+    assert data["next_earnings_date"] == near_date
+
+
+def test_earnings_beyond_10_days_returns_no_warning():
+    far_date = (date.today() + timedelta(days=30)).isoformat()
+    mock_ticker = MagicMock()
+    mock_ticker.calendar = {"Earnings Date": [far_date]}
+
+    with patch("yfinance.Ticker", return_value=mock_ticker):
+        response = client.get("/api/portfolio/earnings-proximity/AAPL")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["warning"] is False
+    assert data["days_until"] == 30
+
+
+def test_yfinance_failure_returns_no_warning():
+    with patch("yfinance.Ticker", side_effect=Exception("network error")):
+        response = client.get("/api/portfolio/earnings-proximity/AAPL")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["warning"] is False
+    assert data["next_earnings_date"] is None
+    assert data["days_until"] is None
+
+
+def test_earnings_result_cached_per_ticker_for_today():
+    near_date = (date.today() + timedelta(days=5)).isoformat()
+    mock_ticker = MagicMock()
+    mock_ticker.calendar = {"Earnings Date": [near_date]}
+
+    with patch("yfinance.Ticker", return_value=mock_ticker) as ticker_cls:
+        first_response = client.get("/api/portfolio/earnings-proximity/AAPL")
+        second_response = client.get("/api/portfolio/earnings-proximity/AAPL")
+
+    assert first_response.status_code == 200
+    assert second_response.status_code == 200
+    assert first_response.json() == second_response.json()
+    ticker_cls.assert_called_once_with("AAPL")

--- a/tests/api/test_time_stop_nudge.py
+++ b/tests/api/test_time_stop_nudge.py
@@ -1,0 +1,84 @@
+"""Tests for stale-position time-stop nudges."""
+from __future__ import annotations
+
+import json
+from datetime import date, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+
+import api.dependencies as deps
+from api.main import app
+
+
+class FakeStrategyRepo:
+    def get_active_strategy(self) -> dict:
+        return {"manage": {"time_stop_days": 15, "time_stop_min_r": 0.5}}
+
+
+def make_position(entry_date: str, r_now: float) -> dict:
+    entry_price = 100.0
+    stop_price = 90.0
+    return {
+        "position_id": "POS-TIME-001",
+        "ticker": "TEST",
+        "status": "open",
+        "entry_date": entry_date,
+        "entry_price": entry_price,
+        "stop_price": stop_price,
+        "shares": 10,
+        "initial_risk": None,
+        "current_price": entry_price + r_now * (entry_price - stop_price),
+        "notes": "",
+        "tags": [],
+    }
+
+
+@pytest.fixture
+def client_with_positions(tmp_path, monkeypatch):
+    positions_file = tmp_path / "positions.json"
+    orders_file = tmp_path / "orders.json"
+
+    def write_positions(positions: list[dict]) -> None:
+        positions_file.write_text(
+            json.dumps({"asof": date.today().isoformat(), "positions": positions}),
+            encoding="utf-8",
+        )
+        orders_file.write_text(json.dumps({"asof": date.today().isoformat(), "orders": []}), encoding="utf-8")
+
+    monkeypatch.setattr(deps, "_positions_path", positions_file)
+    monkeypatch.setattr(deps, "_orders_path", orders_file)
+    app.dependency_overrides[deps.get_strategy_repo] = lambda: FakeStrategyRepo()
+    yield TestClient(app), write_positions
+    app.dependency_overrides.pop(deps.get_strategy_repo, None)
+
+
+def test_position_includes_days_open(client_with_positions):
+    client, write_positions = client_with_positions
+    write_positions([make_position((date.today() - timedelta(days=20)).isoformat(), r_now=0.0)])
+
+    response = client.get("/api/portfolio/positions")
+
+    assert response.status_code == 200
+    position = response.json()["positions"][0]
+    assert position["days_open"] >= 20
+
+
+def test_time_stop_warning_fires_for_old_flat_position(client_with_positions):
+    client, write_positions = client_with_positions
+    write_positions([make_position((date.today() - timedelta(days=20)).isoformat(), r_now=0.0)])
+
+    response = client.get("/api/portfolio/positions")
+
+    assert response.status_code == 200
+    assert response.json()["positions"][0]["time_stop_warning"] is True
+
+
+def test_time_stop_warning_absent_for_new_profitable_position(client_with_positions):
+    client, write_positions = client_with_positions
+    write_positions([make_position((date.today() - timedelta(days=5)).isoformat(), r_now=2.0)])
+
+    response = client.get("/api/portfolio/positions")
+
+    assert response.status_code == 200
+    assert response.json()["positions"][0]["time_stop_warning"] is False

--- a/tests/api/test_watchlist_service.py
+++ b/tests/api/test_watchlist_service.py
@@ -1,0 +1,43 @@
+from unittest.mock import Mock
+
+import pytest
+import pandas as pd
+
+from api.models.watchlist import WatchItemUpsertRequest
+from api.repositories.watchlist_repo import WatchlistRepository
+from api.services.watchlist_service import WatchlistService
+from swing_screener.strategy.storage import _default_strategy_payload
+
+
+class _FakeProvider:
+    def fetch_ohlcv(self, tickers, start_date: str, end_date: str):  # noqa: ANN001
+        index = pd.date_range("2026-02-20", periods=70, freq="D")
+        columns = pd.MultiIndex.from_product([["Close"], tickers])
+        data = [[95.0 + idx * 0.1, 49.0 + idx * 0.05] for idx in range(len(index))]
+        data[-2] = [101.0, 52.0]
+        data[-1] = [102.0, 52.5]
+        return pd.DataFrame(data, index=index, columns=columns)
+
+
+def test_watchlist_service_enriches_and_sorts_items(tmp_path):
+    repo = WatchlistRepository(tmp_path / "watchlist.json")
+    repo.upsert_item("AAPL", WatchItemUpsertRequest(watch_price=90.0, currency="USD", source="screener"))
+    repo.upsert_item("MSFT", WatchItemUpsertRequest(watch_price=45.0, currency="USD", source="screener"))
+
+    strategy_repo = Mock()
+    strategy_repo.get_active_strategy.return_value = _default_strategy_payload()  # noqa: SLF001
+
+    service = WatchlistService(repo=repo, strategy_repo=strategy_repo, provider=_FakeProvider())
+    items = service.list_items()
+
+    assert [item.ticker for item in items] == ["MSFT", "AAPL"]
+    msft, aapl = items
+    assert aapl.current_price == 102.0
+    assert aapl.signal_trigger_price is not None
+    assert aapl.signal_trigger_price < aapl.current_price
+    assert aapl.distance_to_trigger_pct == pytest.approx(
+        100.0 * (aapl.current_price - aapl.signal_trigger_price) / aapl.signal_trigger_price
+    )
+    assert len(aapl.price_history) == 5
+    assert aapl.price_history[-1].close == 102.0
+    assert msft.distance_to_trigger_pct <= aapl.distance_to_trigger_pct

--- a/web-ui/src/components/domain/onboarding/OnboardingStrategySetupStep.test.tsx
+++ b/web-ui/src/components/domain/onboarding/OnboardingStrategySetupStep.test.tsx
@@ -63,6 +63,8 @@ function buildStrategy(): any {
       trailSma: 20,
       smaBufferPct: 1,
       maxHoldingDays: 20,
+      timeStopDays: 15,
+      timeStopMinR: 0.5,
       benchmark: 'SPY',
     },
     marketIntelligence: {

--- a/web-ui/src/components/domain/orders/CandidateOrderModal.test.tsx
+++ b/web-ui/src/components/domain/orders/CandidateOrderModal.test.tsx
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '@/test/utils';
 import userEvent from '@testing-library/user-event';
 import CandidateOrderModal from '@/components/domain/orders/CandidateOrderModal';
+import { t } from '@/i18n/t';
 
 const { createOrderMock } = vi.hoisted(() => ({
   createOrderMock: vi.fn(),
@@ -9,6 +11,34 @@ const { createOrderMock } = vi.hoisted(() => ({
 
 vi.mock('@/features/portfolio/api', () => ({
   createOrder: createOrderMock,
+  fetchPortfolioSummary: () =>
+    Promise.resolve({
+      totalPositions: 2,
+      totalValue: 0,
+      totalCostBasis: 0,
+      totalPnl: 0,
+      totalPnlPercent: 0,
+      openRisk: 50,
+      openRiskPercent: 0.1,
+      accountSize: 50000,
+      availableCapital: 50000,
+      largestPositionValue: 0,
+      largestPositionTicker: '',
+      bestPerformerTicker: '',
+      bestPerformerPnlPct: 0,
+      worstPerformerTicker: '',
+      worstPerformerPnlPct: 0,
+      avgRNow: 0,
+      positionsProfitable: 0,
+      positionsLosing: 0,
+      winRate: 0,
+      concentration: [
+        { country: 'NL', riskAmount: 25, riskPct: 50, positionCount: 1, warning: false },
+        { country: 'US', riskAmount: 25, riskPct: 50, positionCount: 1, warning: false },
+      ],
+      realizedPnl: 0,
+      effectiveAccountSize: 50000,
+    }),
 }));
 
 const risk = {
@@ -57,7 +87,7 @@ describe('CandidateOrderModal', () => {
   });
 
   it('disables create action for not recommended candidate', () => {
-    render(
+    renderWithProviders(
       <CandidateOrderModal
         candidate={{
           ticker: 'VALE',
@@ -107,7 +137,7 @@ describe('CandidateOrderModal', () => {
   });
 
   it('defaults to BUY_STOP when backend guidance suggests breakout stop entry', () => {
-    render(
+    renderWithProviders(
       <CandidateOrderModal
         candidate={{
           ticker: 'AAPL',
@@ -136,7 +166,7 @@ describe('CandidateOrderModal', () => {
   });
 
   it('shows pullback execution guidance when breakout signal is already passed and backend suggests BUY_LIMIT', () => {
-    render(
+    renderWithProviders(
       <CandidateOrderModal
         candidate={{
           ticker: 'AAPL',
@@ -165,7 +195,7 @@ describe('CandidateOrderModal', () => {
 
   it('requires override confirmation before submitting mismatch order type', async () => {
     const user = userEvent.setup();
-    render(
+    renderWithProviders(
       <CandidateOrderModal
         candidate={{
           ticker: 'AAPL',
@@ -197,7 +227,7 @@ describe('CandidateOrderModal', () => {
   });
 
   it('blocks BUY_STOP when trigger is not above current price', () => {
-    render(
+    renderWithProviders(
       <CandidateOrderModal
         candidate={{
           ticker: 'AAPL',
@@ -222,7 +252,7 @@ describe('CandidateOrderModal', () => {
   });
 
   it('renders fallback guidance when signal is missing', () => {
-    render(
+    renderWithProviders(
       <CandidateOrderModal
         candidate={{
           ticker: 'AAPL',
@@ -243,7 +273,7 @@ describe('CandidateOrderModal', () => {
 
   it('preserves entered values while moving between review sections', async () => {
     const user = userEvent.setup();
-    render(
+    renderWithProviders(
       <CandidateOrderModal
         candidate={{
           ticker: 'AAPL',
@@ -270,5 +300,35 @@ describe('CandidateOrderModal', () => {
 
     await user.click(screen.getByRole('tab', { name: 'Decision' }));
     expect((screen.getByLabelText('Notes') as HTMLTextAreaElement).value).toBe('Adjusted note');
+  });
+
+  it('shows a soft concentration warning when an order pushes country risk over threshold', async () => {
+    renderWithProviders(
+      <CandidateOrderModal
+        candidate={{
+          ticker: 'SBMO.AS',
+          entry: 10,
+          stop: 9,
+          shares: 30,
+          recommendation: {
+            ...recommendedRecommendation,
+            risk: {
+              ...recommendedRecommendation.risk,
+              entry: 10,
+              stop: 9,
+              shares: 30,
+            },
+          },
+        }}
+        risk={risk}
+        defaultNotes="From daily review"
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    expect(
+      await screen.findByText(t('concentrationWarning.orderMessage', { country: 'NL', currentPct: '50', projectedPct: '69' })),
+    ).toBeInTheDocument();
   });
 });

--- a/web-ui/src/components/domain/orders/OrderReviewExperience.tsx
+++ b/web-ui/src/components/domain/orders/OrderReviewExperience.tsx
@@ -1,14 +1,17 @@
 import { useEffect, useMemo, useState } from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
+import { AlertTriangle } from 'lucide-react';
 import Button from '@/components/common/Button';
 import RecommendationBadge from '@/components/domain/recommendation/RecommendationBadge';
+import EarningsWarningBanner from '@/components/domain/screener/EarningsWarningBanner';
 import SetupExecutionGuide from '@/components/domain/orders/SetupExecutionGuide';
 import DegiroOrderConfigGuide from '@/components/domain/orders/DegiroOrderConfigGuide';
 import { useOrderRiskMetrics } from '@/components/domain/orders/useOrderRiskMetrics';
 import { candidateOrderSchema, type CandidateOrderFormValues } from '@/components/domain/orders/schemas';
 import { getSetupExecutionGuidance, normalizeSetupSignal } from '@/features/orders/setupGuidance';
 import { normalizeSuggestedOrderType, resolveDefaultOrderType } from '@/features/orders/executionDefaults';
+import { usePortfolioSummary } from '@/features/portfolio/hooks';
 import type { CreateOrderRequest } from '@/features/portfolio/types';
 import type { SameSymbolCandidateContext } from '@/features/screener/types';
 import type { RiskConfig } from '@/types/config';
@@ -57,6 +60,22 @@ const REVIEW_SECTIONS: Array<{ id: ReviewSectionId; titleKey: string }> = [
   { id: 'risk', titleKey: 'order.review.sections.risk' },
 ];
 
+const CONCENTRATION_WARNING_THRESHOLD = 60;
+const COUNTRY_SUFFIXES: Record<string, string> = {
+  '.AS': 'NL',
+  '.PA': 'FR',
+  '.DE': 'DE',
+  '.MC': 'ES',
+  '.MI': 'IT',
+  '.ST': 'SE',
+  '.L': 'UK',
+  '.BR': 'BE',
+  '.LS': 'PT',
+  '.HE': 'FI',
+  '.CO': 'DK',
+  '.OL': 'NO',
+};
+
 function MetricTile({
   label,
   value,
@@ -95,6 +114,14 @@ function classifyInvalidationRule(condition: string) {
     return 'hard';
   }
   return 'soft';
+}
+
+function countryFromTicker(ticker: string): string {
+  const normalized = ticker.trim().toUpperCase();
+  for (const [suffix, country] of Object.entries(COUNTRY_SUFFIXES)) {
+    if (normalized.endsWith(suffix)) return country;
+  }
+  return 'US';
 }
 
 export default function OrderReviewExperience({
@@ -162,6 +189,7 @@ export default function OrderReviewExperience({
   const [submitSucceeded, setSubmitSucceeded] = useState(false);
   const [activeSection, setActiveSection] = useState<ReviewSectionId>('decision');
   const [tradeThesis, setTradeThesis] = useState('');
+  const portfolioSummaryQuery = usePortfolioSummary();
 
   useEffect(() => {
     form.reset({
@@ -195,6 +223,23 @@ export default function OrderReviewExperience({
     quantity,
     accountSize: risk.accountSize,
   });
+
+  const projectedConcentration = useMemo(() => {
+    const summary = portfolioSummaryQuery.data;
+    if (!summary || riskAmount <= 0) return null;
+    const country = countryFromTicker(normalizedTicker);
+    const currentGroup = summary.concentration.find((group) => group.country === country);
+    const currentRisk = currentGroup?.riskAmount ?? 0;
+    const projectedOpenRisk = summary.openRisk + riskAmount;
+    if (projectedOpenRisk <= 0) return null;
+    const projectedRiskPct = ((currentRisk + riskAmount) / projectedOpenRisk) * 100;
+    if (projectedRiskPct < CONCENTRATION_WARNING_THRESHOLD) return null;
+    return {
+      country,
+      currentRiskPct: currentGroup?.riskPct ?? 0,
+      projectedRiskPct,
+    };
+  }, [normalizedTicker, portfolioSummaryQuery.data, riskAmount]);
 
   const warnings = useMemo(() => {
     const nextWarnings: string[] = [];
@@ -277,6 +322,20 @@ export default function OrderReviewExperience({
 
   return (
     <div className="space-y-4">
+      <EarningsWarningBanner ticker={normalizedTicker} />
+      {projectedConcentration ? (
+        <div className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-900/20 dark:text-amber-100">
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-300" aria-hidden="true" />
+          <span>
+            {t('concentrationWarning.orderMessage', {
+              country: projectedConcentration.country,
+              currentPct: formatNumber(projectedConcentration.currentRiskPct, 0),
+              projectedPct: formatNumber(projectedConcentration.projectedRiskPct, 0),
+            })}
+          </span>
+        </div>
+      ) : null}
+
       <section
         className="rounded-lg border border-gray-200 bg-slate-50/70 p-3 dark:border-gray-700 dark:bg-gray-900/50"
         aria-label={t('order.review.carouselLabel')}

--- a/web-ui/src/components/domain/portfolio/ConcentrationBar.test.tsx
+++ b/web-ui/src/components/domain/portfolio/ConcentrationBar.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { renderWithProviders, screen } from '@/test/utils';
+import { t } from '@/i18n/t';
+import type { ConcentrationGroup } from '@/features/portfolio/api';
+import ConcentrationBar from './ConcentrationBar';
+
+const highConcentration: ConcentrationGroup[] = [
+  { country: 'NL', riskAmount: 150, riskPct: 75, positionCount: 2, warning: true },
+  { country: 'US', riskAmount: 50, riskPct: 25, positionCount: 1, warning: false },
+];
+
+const lowConcentration: ConcentrationGroup[] = [
+  { country: 'US', riskAmount: 50, riskPct: 40, positionCount: 1, warning: false },
+  { country: 'NL', riskAmount: 45, riskPct: 36, positionCount: 2, warning: false },
+];
+
+describe('ConcentrationBar', () => {
+  it('renders nothing without concentration groups', () => {
+    const { container } = renderWithProviders(<ConcentrationBar groups={[]} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows the top concentration group', () => {
+    renderWithProviders(<ConcentrationBar groups={highConcentration} />);
+
+    expect(screen.getByText(t('concentrationBar.title'))).toBeInTheDocument();
+    expect(screen.getByText(t('concentrationBar.warningLabel', { country: 'NL', pct: '75' }))).toBeInTheDocument();
+  });
+
+  it('marks warning concentrations', () => {
+    const { container } = renderWithProviders(<ConcentrationBar groups={highConcentration} />);
+
+    expect(container.querySelector('[data-warning="true"]')).toBeInTheDocument();
+  });
+
+  it('keeps normal concentrations non-warning', () => {
+    const { container } = renderWithProviders(<ConcentrationBar groups={lowConcentration} />);
+
+    expect(screen.getByText(t('concentrationBar.normalLabel', { country: 'US', pct: '40' }))).toBeInTheDocument();
+    expect(container.querySelector('[data-warning="false"]')).toBeInTheDocument();
+  });
+});

--- a/web-ui/src/components/domain/portfolio/ConcentrationBar.tsx
+++ b/web-ui/src/components/domain/portfolio/ConcentrationBar.tsx
@@ -1,0 +1,63 @@
+import { AlertTriangle } from 'lucide-react';
+import type { ConcentrationGroup } from '@/features/portfolio/api';
+import { t } from '@/i18n/t';
+import { cn } from '@/utils/cn';
+import { formatCurrency, formatNumber } from '@/utils/formatters';
+
+interface ConcentrationBarProps {
+  groups: ConcentrationGroup[];
+}
+
+export default function ConcentrationBar({ groups }: ConcentrationBarProps) {
+  if (groups.length === 0) {
+    return null;
+  }
+
+  const topGroup = groups[0];
+  const pct = formatNumber(topGroup.riskPct, 0);
+  const fillWidth = `${Math.min(Math.max(topGroup.riskPct, 0), 100)}%`;
+  const labelKey = topGroup.warning ? 'concentrationBar.warningLabel' : 'concentrationBar.normalLabel';
+
+  return (
+    <section
+      data-warning={topGroup.warning ? 'true' : 'false'}
+      className={cn(
+        'rounded-lg border bg-white px-4 py-3 dark:bg-gray-900',
+        topGroup.warning
+          ? 'border-amber-300 dark:border-amber-700'
+          : 'border-gray-200 dark:border-gray-700',
+      )}
+    >
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-2">
+          {topGroup.warning ? (
+            <AlertTriangle className="h-4 w-4 shrink-0 text-amber-600 dark:text-amber-300" aria-hidden="true" />
+          ) : null}
+          <div className="min-w-0">
+            <p className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+              {t('concentrationBar.title')}
+            </p>
+            <p className="truncate text-sm font-semibold text-gray-900 dark:text-gray-100">
+              {t(labelKey, { country: topGroup.country, pct })}
+            </p>
+          </div>
+        </div>
+        <p className="shrink-0 text-xs font-medium text-gray-500 dark:text-gray-400">
+          {t('concentrationBar.detail', {
+            count: topGroup.positionCount,
+            amount: formatCurrency(topGroup.riskAmount, 'EUR'),
+          })}
+        </p>
+      </div>
+      <div className="mt-3 h-2 overflow-hidden rounded-full bg-gray-100 dark:bg-gray-800">
+        <div
+          className={cn(
+            'h-full rounded-full',
+            topGroup.warning ? 'bg-amber-500 dark:bg-amber-400' : 'bg-blue-500 dark:bg-blue-400',
+          )}
+          style={{ width: fillWidth }}
+        />
+      </div>
+    </section>
+  );
+}

--- a/web-ui/src/components/domain/portfolio/EdgeBreakdownTable.test.tsx
+++ b/web-ui/src/components/domain/portfolio/EdgeBreakdownTable.test.tsx
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '@/test/utils';
+import EdgeBreakdownTable from './EdgeBreakdownTable';
+import type { Position } from '@/types/position';
+import { t } from '@/i18n/t';
+
+function makePosition(overrides: Partial<Position>): Position {
+  return {
+    ticker: 'TEST',
+    status: 'closed',
+    entryDate: '2026-01-01',
+    entryPrice: 100,
+    stopPrice: 95,
+    shares: 10,
+    initialRisk: 50,
+    exitPrice: 110,
+    exitDate: '2026-01-15',
+    notes: '',
+    tags: [],
+    ...overrides,
+  };
+}
+
+describe('EdgeBreakdownTable', () => {
+  it('shows empty state when fewer than 5 tagged trades', () => {
+    const positions = [
+      makePosition({ tags: ['breakout'], exitPrice: 110 }),
+      makePosition({ tags: ['breakout'], exitPrice: 90 }),
+    ];
+
+    renderWithProviders(<EdgeBreakdownTable positions={positions} />);
+
+    expect(screen.getByText(t('analyticsPage.edgeBreakdown.emptyState'))).toBeInTheDocument();
+  });
+
+  it('shows breakdown when 5+ tagged trades exist', () => {
+    const positions = Array.from({ length: 6 }, (_, i) =>
+      makePosition({ tags: ['breakout'], exitPrice: i % 2 === 0 ? 110 : 90 }),
+    );
+
+    renderWithProviders(<EdgeBreakdownTable positions={positions} />);
+
+    expect(screen.getByText(t('tradeTags.breakout'))).toBeInTheDocument();
+    expect(screen.getByText('6')).toBeInTheDocument();
+  });
+
+  it('computes win rate correctly', () => {
+    const positions = [
+      makePosition({ tags: ['breakout'], exitPrice: 110, entryPrice: 100, initialRisk: 10 }),
+      makePosition({ tags: ['breakout'], exitPrice: 110, entryPrice: 100, initialRisk: 10 }),
+      makePosition({ tags: ['breakout'], exitPrice: 110, entryPrice: 100, initialRisk: 10 }),
+      makePosition({ tags: ['breakout'], exitPrice: 90, entryPrice: 100, initialRisk: 10 }),
+      makePosition({ tags: ['breakout'], exitPrice: 110, entryPrice: 100, initialRisk: 10 }),
+    ];
+
+    renderWithProviders(<EdgeBreakdownTable positions={positions} />);
+
+    expect(screen.getByText('80%')).toBeInTheDocument();
+  });
+});

--- a/web-ui/src/components/domain/portfolio/EdgeBreakdownTable.tsx
+++ b/web-ui/src/components/domain/portfolio/EdgeBreakdownTable.tsx
@@ -1,0 +1,141 @@
+import { useMemo } from 'react';
+import type { Position } from '@/types/position';
+import { t } from '@/i18n/t';
+import { formatNumber } from '@/utils/formatters';
+import { cn } from '@/utils/cn';
+
+interface TagStats {
+  tag: string;
+  count: number;
+  winRate: number;
+  avgR: number;
+  expectancy: number;
+}
+
+const MIN_TRADES_FOR_DISPLAY = 5;
+
+function finalR(position: Position): number | null {
+  if (!position.initialRisk || position.initialRisk <= 0 || position.exitPrice == null) return null;
+  return (position.exitPrice - position.entryPrice) / position.initialRisk;
+}
+
+function tagLabel(tag: string): string {
+  const labels: Record<string, string> = {
+    breakout: t('tradeTags.breakout'),
+    pullback: t('tradeTags.pullback'),
+    add_on: t('tradeTags.addOn'),
+    stop_hit: t('tradeTags.stopHit'),
+    target_reached: t('tradeTags.targetReached'),
+    time_stop: t('tradeTags.timeStop'),
+    manual_exit: t('tradeTags.manualExit'),
+    trending: t('tradeTags.trending'),
+    choppy: t('tradeTags.choppy'),
+    news_driven: t('tradeTags.newsDriven'),
+  };
+  return labels[tag] ?? tag;
+}
+
+function computeTagStats(positions: Position[]): TagStats[] {
+  const byTag = new Map<string, Position[]>();
+  for (const position of positions) {
+    for (const tag of position.tags ?? []) {
+      const tagged = byTag.get(tag) ?? [];
+      tagged.push(position);
+      byTag.set(tag, tagged);
+    }
+  }
+
+  const stats: TagStats[] = [];
+  for (const [tag, taggedPositions] of byTag.entries()) {
+    const rValues = taggedPositions.map(finalR).filter((r): r is number => r !== null);
+    if (rValues.length === 0) continue;
+
+    const wins = rValues.filter((r) => r > 0);
+    const losses = rValues.filter((r) => r <= 0);
+    const winRate = (wins.length / rValues.length) * 100;
+    const avgWinR = wins.length > 0 ? wins.reduce((sum, r) => sum + r, 0) / wins.length : 0;
+    const avgLossR = losses.length > 0 ? Math.abs(losses.reduce((sum, r) => sum + r, 0) / losses.length) : 0;
+
+    stats.push({
+      tag,
+      count: rValues.length,
+      winRate,
+      avgR: rValues.reduce((sum, r) => sum + r, 0) / rValues.length,
+      expectancy: avgWinR * (winRate / 100) - avgLossR * (1 - winRate / 100),
+    });
+  }
+
+  return stats.sort((a, b) => b.expectancy - a.expectancy);
+}
+
+interface EdgeBreakdownTableProps {
+  positions: Position[];
+}
+
+export default function EdgeBreakdownTable({ positions }: EdgeBreakdownTableProps) {
+  const taggedClosed = useMemo(
+    () => positions.filter((position) => position.status === 'closed' && (position.tags ?? []).length > 0),
+    [positions],
+  );
+  const stats = useMemo(() => computeTagStats(taggedClosed), [taggedClosed]);
+
+  if (taggedClosed.length < MIN_TRADES_FOR_DISPLAY) {
+    return (
+      <p className="py-4 text-sm text-gray-500 dark:text-gray-400">
+        {t('analyticsPage.edgeBreakdown.emptyState')}
+      </p>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-800">
+            <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+              {t('analyticsPage.edgeBreakdown.colTag')}
+            </th>
+            <th className="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+              {t('analyticsPage.edgeBreakdown.colTrades')}
+            </th>
+            <th className="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+              {t('analyticsPage.edgeBreakdown.colWinRate')}
+            </th>
+            <th className="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+              {t('analyticsPage.edgeBreakdown.colAvgR')}
+            </th>
+            <th
+              className="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400"
+              title={t('analyticsPage.edgeBreakdown.expectancyHint')}
+            >
+              {t('analyticsPage.edgeBreakdown.colExpectancy')}
+            </th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+          {stats.map((stat) => (
+            <tr key={stat.tag} className="hover:bg-gray-50 dark:hover:bg-gray-800/50">
+              <td className="px-4 py-3 font-semibold text-gray-900 dark:text-gray-100">
+                {tagLabel(stat.tag)}
+              </td>
+              <td className="px-4 py-3 text-right tabular-nums">{stat.count}</td>
+              <td className="px-4 py-3 text-right tabular-nums">{Math.round(stat.winRate)}%</td>
+              <td className={cn(
+                'px-4 py-3 text-right tabular-nums font-semibold',
+                stat.avgR >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400',
+              )}>
+                {stat.avgR >= 0 ? '+' : ''}{formatNumber(stat.avgR, 2)}R
+              </td>
+              <td className={cn(
+                'px-4 py-3 text-right tabular-nums font-semibold',
+                stat.expectancy >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400',
+              )}>
+                {stat.expectancy >= 0 ? '+' : ''}{formatNumber(stat.expectancy, 2)}R
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/web-ui/src/components/domain/portfolio/EdgeBreakdownTable.tsx
+++ b/web-ui/src/components/domain/portfolio/EdgeBreakdownTable.tsx
@@ -16,7 +16,7 @@ const MIN_TRADES_FOR_DISPLAY = 5;
 
 function finalR(position: Position): number | null {
   if (!position.initialRisk || position.initialRisk <= 0 || position.exitPrice == null) return null;
-  return (position.exitPrice - position.entryPrice) / position.initialRisk;
+  return (position.exitPrice - position.entryPrice) * position.shares / position.initialRisk;
 }
 
 function tagLabel(tag: string): string {

--- a/web-ui/src/components/domain/portfolio/PortfolioRiskSummary.tsx
+++ b/web-ui/src/components/domain/portfolio/PortfolioRiskSummary.tsx
@@ -6,9 +6,10 @@ import { formatCurrency, formatNumber } from '@/utils/formatters';
 interface PortfolioRiskSummaryProps {
   openPositions: Position[];
   accountSize?: number;
+  realizedPnl?: number;
 }
 
-export default function PortfolioRiskSummary({ openPositions, accountSize }: PortfolioRiskSummaryProps) {
+export default function PortfolioRiskSummary({ openPositions, accountSize, realizedPnl }: PortfolioRiskSummaryProps) {
   const totalOpenRisk = openPositions.reduce((sum, p) => sum + (p.initialRisk ?? 0), 0);
 
   const portfolioHeat =
@@ -53,6 +54,30 @@ export default function PortfolioRiskSummary({ openPositions, accountSize }: Por
         </span>
         <span className="font-bold text-gray-900 dark:text-gray-100">{openPositionCount}</span>
       </span>
+
+      {/* Effective equity */}
+      <span className={cn(chipBase, 'border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-300')}>
+        <span className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+          {t('portfolioRisk.effectiveEquity')}
+        </span>
+        <span className="font-bold text-gray-900 dark:text-gray-100">
+          {accountSize != null ? formatCurrency(accountSize, 'EUR') : '—'}
+        </span>
+      </span>
+
+      {realizedPnl != null ? (
+        <span className={cn(chipBase, 'border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-300')}>
+          <span className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+            {t('portfolioRisk.realizedPnl')}
+          </span>
+          <span className={cn(
+            'font-bold',
+            realizedPnl >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400',
+          )}>
+            {realizedPnl >= 0 ? '+' : ''}{formatCurrency(realizedPnl, 'EUR')}
+          </span>
+        </span>
+      ) : null}
 
       {/* Total risk */}
       <span className={cn(chipBase, 'border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-300')}>

--- a/web-ui/src/components/domain/screener/EarningsWarningBanner.test.tsx
+++ b/web-ui/src/components/domain/screener/EarningsWarningBanner.test.tsx
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import EarningsWarningBanner from './EarningsWarningBanner';
+import { server } from '@/test/mocks/server';
+import { renderWithProviders, screen } from '@/test/utils';
+
+describe('EarningsWarningBanner', () => {
+  it('shows warning when earnings are within 10 days', async () => {
+    server.use(
+      http.get('*/api/portfolio/earnings-proximity/AAPL', () =>
+        HttpResponse.json({
+          ticker: 'AAPL',
+          next_earnings_date: '2026-05-08',
+          days_until: 5,
+          warning: true,
+        }),
+      ),
+    );
+
+    renderWithProviders(<EarningsWarningBanner ticker="AAPL" />);
+
+    expect(await screen.findByText(/5 days/i)).toBeInTheDocument();
+  });
+
+  it('renders nothing when no warning is returned', async () => {
+    server.use(
+      http.get('*/api/portfolio/earnings-proximity/AAPL', () =>
+        HttpResponse.json({
+          ticker: 'AAPL',
+          next_earnings_date: null,
+          days_until: null,
+          warning: false,
+        }),
+      ),
+    );
+
+    const { container } = renderWithProviders(<EarningsWarningBanner ticker="AAPL" />);
+
+    await waitFor(() => {
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  it('renders nothing when ticker is undefined', () => {
+    const { container } = renderWithProviders(<EarningsWarningBanner ticker={undefined} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/web-ui/src/components/domain/screener/EarningsWarningBanner.tsx
+++ b/web-ui/src/components/domain/screener/EarningsWarningBanner.tsx
@@ -1,0 +1,28 @@
+import { AlertTriangle } from 'lucide-react';
+import { useEarningsProximity } from '@/features/portfolio/hooks';
+import { t } from '@/i18n/t';
+
+interface EarningsWarningBannerProps {
+  ticker?: string;
+}
+
+function warningMessage(daysUntil: number) {
+  if (daysUntil === 0) return t('earningsWarning.messageToday');
+  if (daysUntil === 1) return t('earningsWarning.messageSingular');
+  return t('earningsWarning.message', { days: daysUntil });
+}
+
+export default function EarningsWarningBanner({ ticker }: EarningsWarningBannerProps) {
+  const { data } = useEarningsProximity(ticker);
+
+  if (!data?.warning || data.daysUntil == null) {
+    return null;
+  }
+
+  return (
+    <div className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-900/20 dark:text-amber-100">
+      <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-300" aria-hidden="true" />
+      <span>{warningMessage(data.daysUntil)}</span>
+    </div>
+  );
+}

--- a/web-ui/src/components/domain/strategy/EnhancedRiskCard.test.tsx
+++ b/web-ui/src/components/domain/strategy/EnhancedRiskCard.test.tsx
@@ -1,0 +1,127 @@
+import { describe, expect, it, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders } from '@/test/utils';
+import { t } from '@/i18n/t';
+import type { Strategy } from '@/features/strategy/types';
+import EnhancedRiskCard from './EnhancedRiskCard';
+
+function makeStrategy(riskOverrides: Partial<Strategy['risk']> = {}): Strategy {
+  return {
+    id: 'test',
+    name: 'Test',
+    module: 'momentum',
+    universe: {
+      trend: { smaFast: 50, smaMid: 100, smaLong: 200 },
+      vol: { atrWindow: 14 },
+      mom: { lookback6m: 125, lookback12m: 252, benchmark: 'SPY' },
+      filt: {
+        minPrice: 5,
+        maxPrice: 1000,
+        maxAtrPct: 0.1,
+        requireTrendOk: true,
+        requireRsPositive: true,
+        currencies: ['USD'],
+      },
+    },
+    ranking: { wMom6m: 0.5, wMom12m: 0.3, wRs6m: 0.2, topN: 10 },
+    signals: { breakoutLookback: 20, pullbackMa: 10, minHistory: 50 },
+    risk: {
+      accountSize: 50000,
+      riskPct: 0.02,
+      maxPositionPct: 0.2,
+      minShares: 1,
+      kAtr: 1.5,
+      minRr: 2.0,
+      rrTarget: 2.0,
+      commissionPct: 0,
+      maxFeeRiskPct: 0.2,
+      accountSizeMode: 'equity',
+      regimeEnabled: false,
+      regimeTrendSma: 200,
+      regimeTrendMultiplier: 0.5,
+      regimeVolAtrWindow: 14,
+      regimeVolAtrPctThreshold: 6.0,
+      regimeVolMultiplier: 0.5,
+      ...riskOverrides,
+    },
+    manage: {
+      breakevenAtR: 1.0,
+      trailAfterR: 2.0,
+      trailSma: 20,
+      smaBufferPct: 0.005,
+      maxHoldingDays: 20,
+      timeStopDays: 15,
+      timeStopMinR: 0.5,
+      benchmark: 'SPY',
+    },
+    marketIntelligence: {
+      enabled: false,
+      providers: [],
+      universeScope: 'screener_universe',
+      marketContextSymbols: [],
+      llm: {
+        enabled: false,
+        provider: 'openai',
+        model: '',
+        baseUrl: '',
+        enableCache: false,
+        enableAudit: false,
+        cachePath: '',
+        auditPath: '',
+        maxConcurrency: 1,
+      },
+      catalyst: {
+        lookbackHours: 72,
+        recencyHalfLifeHours: 36,
+        falseCatalystReturnZ: 1.5,
+        minPriceReactionAtr: 0.8,
+        requirePriceConfirmation: true,
+      },
+      theme: {
+        enabled: false,
+        minClusterSize: 3,
+        minPeerConfirmation: 2,
+        curatedPeerMapPath: '',
+      },
+      opportunity: {
+        technicalWeight: 0.55,
+        catalystWeight: 0.45,
+        maxDailyOpportunities: 8,
+        minOpportunityScore: 0.55,
+      },
+    },
+    isDefault: false,
+    createdAt: '',
+    updatedAt: '',
+  };
+}
+
+describe('EnhancedRiskCard account size mode', () => {
+  it('shows the account size mode selector', () => {
+    renderWithProviders(<EnhancedRiskCard draft={makeStrategy()} setDraft={vi.fn()} warnings={[]} />);
+
+    expect(screen.getByText(t('strategyPage.core.fields.accountSizeMode'))).toBeInTheDocument();
+    expect(screen.getByRole('combobox')).toHaveValue('equity');
+  });
+
+  it('updates the strategy draft when the mode changes', async () => {
+    const user = userEvent.setup();
+    const setDraft = vi.fn();
+    renderWithProviders(
+      <EnhancedRiskCard
+        draft={makeStrategy({ accountSizeMode: 'equity' })}
+        setDraft={setDraft}
+        warnings={[]}
+      />,
+    );
+
+    await user.selectOptions(screen.getByRole('combobox'), 'base');
+
+    expect(setDraft).toHaveBeenCalledWith(
+      expect.objectContaining({
+        risk: expect.objectContaining({ accountSizeMode: 'base' }),
+      }),
+    );
+  });
+});

--- a/web-ui/src/components/domain/strategy/EnhancedRiskCard.tsx
+++ b/web-ui/src/components/domain/strategy/EnhancedRiskCard.tsx
@@ -5,7 +5,9 @@
 import Card, { CardContent, CardHeader, CardTitle } from '@/components/common/Card';
 import { Strategy } from '@/features/strategy/types';
 import { EducationalNumberInput } from './EducationalFieldControls';
+import { SelectInput } from './StrategyFieldControls';
 import type { ValidationWarning } from '@/features/strategy/api';
+import { t } from '@/i18n/t';
 
 interface EnhancedRiskCardProps {
   draft: Strategy;
@@ -39,6 +41,26 @@ export default function EnhancedRiskCard({ draft, setDraft, warnings }: Enhanced
             }
             step={1000}
             min={0}
+          />
+
+          <SelectInput
+            label={t('strategyPage.core.fields.accountSizeMode')}
+            value={draft.risk.accountSizeMode ?? 'equity'}
+            onChange={(value) =>
+              setDraft({
+                ...draft,
+                risk: { ...draft.risk, accountSizeMode: value as Strategy['risk']['accountSizeMode'] },
+              })
+            }
+            options={[
+              { value: 'equity', label: t('strategyPage.core.fields.accountSizeModeEquity') },
+              { value: 'base', label: t('strategyPage.core.fields.accountSizeModeBase') },
+            ]}
+            help={{
+              title: t('strategyPage.core.fields.accountSizeMode'),
+              short: t('strategyPage.core.fields.accountSizeModeHint'),
+              content: <p>{t('strategyPage.core.fields.accountSizeModeHint')}</p>,
+            }}
           />
 
           {/* Risk Per Trade - CRITICAL */}

--- a/web-ui/src/components/domain/strategy/StrategyAdvancedSettingsCard.tsx
+++ b/web-ui/src/components/domain/strategy/StrategyAdvancedSettingsCard.tsx
@@ -501,6 +501,30 @@ export default function StrategyAdvancedSettingsCard({
                   step={1}
                   min={1}
                 />
+                <NumberInput
+                  label={t('strategyPage.advanced.fields.timeStopDays')}
+                  value={draft.manage.timeStopDays}
+                  onChange={(value) =>
+                    setDraft({
+                      ...draft,
+                      manage: { ...draft.manage, timeStopDays: value },
+                    })
+                  }
+                  step={1}
+                  min={1}
+                />
+                <NumberInput
+                  label={t('strategyPage.advanced.fields.timeStopMinR')}
+                  value={draft.manage.timeStopMinR}
+                  onChange={(value) =>
+                    setDraft({
+                      ...draft,
+                      manage: { ...draft.manage, timeStopMinR: value },
+                    })
+                  }
+                  step={0.1}
+                  min={0}
+                />
                 <TextInput
                   label={t('strategyPage.advanced.fields.benchmark')}
                   value={draft.manage.benchmark}

--- a/web-ui/src/components/domain/strategy/StrategyCapitalRiskSummary.test.tsx
+++ b/web-ui/src/components/domain/strategy/StrategyCapitalRiskSummary.test.tsx
@@ -33,6 +33,7 @@ const strategy: Strategy = {
     rrTarget: 2,
     commissionPct: 0,
     maxFeeRiskPct: 0.2,
+    accountSizeMode: 'equity',
     regimeEnabled: false,
     regimeTrendSma: 200,
     regimeTrendMultiplier: 0.5,
@@ -46,6 +47,8 @@ const strategy: Strategy = {
     trailSma: 20,
     smaBufferPct: 0.005,
     maxHoldingDays: 20,
+    timeStopDays: 15,
+    timeStopMinR: 0.5,
     benchmark: 'SPY',
   },
   marketIntelligence: {
@@ -105,5 +108,19 @@ describe('StrategyCapitalRiskSummary', () => {
     expect(screen.getByText('Balanced')).toBeInTheDocument();
     expect(screen.getByText(/Account \$800.00/)).toBeInTheDocument();
     expect(screen.getByText(/Risk \/ trade \$20.00/)).toBeInTheDocument();
+  });
+
+  it('uses effective equity when a portfolio equity snapshot is provided', () => {
+    render(
+      <StrategyCapitalRiskSummary
+        strategy={strategy}
+        equitySnapshot={{ effectiveAccountSize: 925, realizedPnl: 125 }}
+        variant="compact"
+      />,
+    );
+
+    expect(screen.getByText(/Equity \$925.00/)).toBeInTheDocument();
+    expect(screen.getByText(/Realized P&L \+\$125.00/)).toBeInTheDocument();
+    expect(screen.getByText(/Risk \/ trade \$23.13/)).toBeInTheDocument();
   });
 });

--- a/web-ui/src/components/domain/strategy/StrategyCapitalRiskSummary.tsx
+++ b/web-ui/src/components/domain/strategy/StrategyCapitalRiskSummary.tsx
@@ -2,9 +2,16 @@ import Card, { CardContent, CardHeader, CardTitle } from '@/components/common/Ca
 import type { Strategy } from '@/features/strategy/types';
 import { cn } from '@/utils/cn';
 import { formatCurrency, formatRatioAsPercent } from '@/utils/formatters';
+import { t } from '@/i18n/t';
+
+interface EquitySnapshot {
+  effectiveAccountSize: number;
+  realizedPnl: number;
+}
 
 interface StrategyCapitalRiskSummaryProps {
   strategy?: Strategy | null;
+  equitySnapshot?: EquitySnapshot;
   variant?: 'card' | 'compact';
   className?: string;
 }
@@ -16,9 +23,10 @@ function formatOrDash(value: number | null | undefined, formatter: (value: numbe
   return formatter(value);
 }
 
-function buildRiskSnapshot(strategy?: Strategy | null) {
+function buildRiskSnapshot(strategy?: Strategy | null, equitySnapshot?: EquitySnapshot) {
   const risk = strategy?.risk;
-  const accountSize = risk?.accountSize ?? null;
+  const baseAccountSize = risk?.accountSize ?? null;
+  const accountSize = equitySnapshot?.effectiveAccountSize ?? baseAccountSize;
   const riskPct = risk?.riskPct ?? null;
   const maxPositionPct = risk?.maxPositionPct ?? null;
   const capitalAtRisk = accountSize != null && riskPct != null ? accountSize * riskPct : null;
@@ -27,6 +35,9 @@ function buildRiskSnapshot(strategy?: Strategy | null) {
   return {
     strategyName: strategy?.name ?? 'Strategy',
     accountSize,
+    baseAccountSize,
+    realizedPnl: equitySnapshot?.realizedPnl ?? null,
+    isEquityMode: equitySnapshot != null,
     riskPct,
     maxPositionPct,
     capitalAtRisk,
@@ -36,11 +47,14 @@ function buildRiskSnapshot(strategy?: Strategy | null) {
 
 export default function StrategyCapitalRiskSummary({
   strategy,
+  equitySnapshot,
   variant = 'card',
   className,
 }: StrategyCapitalRiskSummaryProps) {
-  const snapshot = buildRiskSnapshot(strategy);
+  const snapshot = buildRiskSnapshot(strategy, equitySnapshot);
   const accountSizeLabel = formatOrDash(snapshot.accountSize, (value) => formatCurrency(value));
+  const baseAccountLabel = formatOrDash(snapshot.baseAccountSize, (value) => formatCurrency(value));
+  const realizedPnlLabel = formatOrDash(snapshot.realizedPnl, (value) => `${value >= 0 ? '+' : ''}${formatCurrency(value)}`);
   const riskPctLabel = formatOrDash(snapshot.riskPct, (value) => formatRatioAsPercent(value));
   const capitalAtRiskLabel = formatOrDash(snapshot.capitalAtRisk, (value) => formatCurrency(value));
   const maxPositionLabel = formatOrDash(snapshot.maxPositionValue, (value) => formatCurrency(value));
@@ -57,7 +71,12 @@ export default function StrategyCapitalRiskSummary({
           <span className="text-slate-500 dark:text-slate-400">Risk</span>
           <span>{snapshot.strategyName}</span>
         </span>
-        <span>Account {accountSizeLabel}</span>
+        <span title={snapshot.isEquityMode ? t('portfolioHeader.equityModeHint') : undefined}>
+          {snapshot.isEquityMode ? t('portfolioHeader.effectiveEquity') : 'Account'} {accountSizeLabel}
+        </span>
+        {snapshot.isEquityMode ? (
+          <span>{t('portfolioHeader.realizedPnl')} {realizedPnlLabel}</span>
+        ) : null}
         <span>Risk / trade {capitalAtRiskLabel} ({riskPctLabel})</span>
         <span>Max position {maxPositionLabel}</span>
       </div>
@@ -89,11 +108,16 @@ export default function StrategyCapitalRiskSummary({
         <div className="grid gap-3 md:grid-cols-3">
           <div className="rounded-lg border border-slate-200 bg-white/80 p-3 dark:border-slate-700 dark:bg-slate-900/60">
             <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-              Account Size
+              {snapshot.isEquityMode ? t('portfolioHeader.effectiveEquity') : 'Account Size'}
             </div>
             <div className="mt-1 text-lg font-semibold text-slate-900 dark:text-slate-50">
               {accountSizeLabel}
             </div>
+            {snapshot.isEquityMode ? (
+              <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                {t('portfolioHeader.baseAccount')} {baseAccountLabel} · {t('portfolioHeader.realizedPnl')} {realizedPnlLabel}
+              </div>
+            ) : null}
           </div>
           <div className="rounded-lg border border-slate-200 bg-white/80 p-3 dark:border-slate-700 dark:bg-slate-900/60">
             <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">

--- a/web-ui/src/components/domain/strategy/StrategyPresets.test.ts
+++ b/web-ui/src/components/domain/strategy/StrategyPresets.test.ts
@@ -52,6 +52,7 @@ function buildStrategy(): Strategy {
       rrTarget: 2.0,
       commissionPct: 0,
       maxFeeRiskPct: 0.2,
+      accountSizeMode: 'equity',
       regimeEnabled: false,
       regimeTrendSma: 200,
       regimeTrendMultiplier: 0.5,
@@ -65,6 +66,8 @@ function buildStrategy(): Strategy {
       trailSma: 20,
       smaBufferPct: 0.005,
       maxHoldingDays: 20,
+      timeStopDays: 15,
+      timeStopMinR: 0.5,
       benchmark: 'SPY',
     },
     marketIntelligence: {

--- a/web-ui/src/components/domain/watchlist/WatchlistPipelinePanel.test.tsx
+++ b/web-ui/src/components/domain/watchlist/WatchlistPipelinePanel.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '@/test/utils';
+import WatchlistPipelinePanel from '@/components/domain/watchlist/WatchlistPipelinePanel';
+
+vi.mock('@/features/watchlist/hooks', () => ({
+  useWatchlist: () => ({
+    data: [
+      {
+        ticker: 'ASML',
+        watchedAt: '2026-05-01T10:00:00Z',
+        watchPrice: 660,
+        currentPrice: 671,
+        currency: 'EUR',
+        source: 'screener',
+        signal: 'breakout',
+        signalTriggerPrice: 680,
+        distanceToTriggerPct: -1.3,
+        priceHistory: [
+          { date: '2026-04-28', close: 650 },
+          { date: '2026-04-29', close: 655 },
+          { date: '2026-04-30', close: 662 },
+          { date: '2026-05-01', close: 668 },
+          { date: '2026-05-02', close: 671 },
+        ],
+      },
+    ],
+    isLoading: false,
+    isError: false,
+  }),
+}));
+
+describe('WatchlistPipelinePanel', () => {
+  it('renders distance-to-trigger copy and sparkline row', () => {
+    renderWithProviders(<WatchlistPipelinePanel />);
+
+    expect(screen.getByText('Watchlist Pipeline')).toBeInTheDocument();
+    expect(screen.getByText('ASML')).toBeInTheDocument();
+    expect(screen.getByText('-1.3% to buy zone')).toBeInTheDocument();
+    expect(screen.getByText('Trigger €680.00')).toBeInTheDocument();
+    expect(screen.getByText('BREAKOUT')).toBeInTheDocument();
+  });
+});

--- a/web-ui/src/components/domain/watchlist/WatchlistPipelinePanel.tsx
+++ b/web-ui/src/components/domain/watchlist/WatchlistPipelinePanel.tsx
@@ -1,0 +1,175 @@
+import { useMemo } from 'react';
+import { ArrowUpRight, TrendingUp } from 'lucide-react';
+import WatchMetaInline from '@/components/domain/watchlist/WatchMetaInline';
+import { useWatchlist } from '@/features/watchlist/hooks';
+import type { WatchItem } from '@/features/watchlist/types';
+import { t } from '@/i18n/t';
+import { cn } from '@/utils/cn';
+import { formatCurrency, formatPercent } from '@/utils/formatters';
+
+interface WatchlistPipelinePanelProps {
+  onTickerSelect?: (ticker: string) => void;
+}
+
+function DistanceCell({ item }: { item: WatchItem }) {
+  if (item.distanceToTriggerPct == null) {
+    return <span className="text-sm text-gray-400 dark:text-gray-500">—</span>;
+  }
+  const distance = item.distanceToTriggerPct;
+  const isBelow = distance <= 0;
+  return (
+    <div className="flex flex-col items-end">
+      <span
+        className={cn(
+          'text-sm font-semibold tabular-nums',
+          isBelow ? 'text-amber-700 dark:text-amber-300' : 'text-emerald-700 dark:text-emerald-300',
+        )}
+      >
+        {isBelow
+          ? t('watchlist.pipeline.distanceToBuyZone', { value: formatPercent(distance) })
+          : t('watchlist.pipeline.aboveBuyZone', { value: formatPercent(distance) })}
+      </span>
+      {item.signalTriggerPrice != null ? (
+        <span className="text-[11px] text-gray-500 dark:text-gray-400">
+          {t('watchlist.pipeline.triggerPrice', {
+            value: formatCurrency(item.signalTriggerPrice, item.currency ?? 'USD'),
+          })}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+function Sparkline({ item }: { item: WatchItem }) {
+  const points = item.priceHistory ?? [];
+  const polyline = useMemo(() => {
+    if (points.length < 2) {
+      return '';
+    }
+    const values = points.map((point) => point.close);
+    const min = Math.min(...values);
+    const max = Math.max(...values);
+    const range = max - min || 1;
+    return values
+      .map((value, index) => {
+        const x = (index / (values.length - 1)) * 56;
+        const y = 20 - ((value - min) / range) * 16;
+        return `${x.toFixed(1)},${y.toFixed(1)}`;
+      })
+      .join(' ');
+  }, [points]);
+
+  if (!polyline) {
+    return <span className="text-xs text-gray-400 dark:text-gray-500">—</span>;
+  }
+
+  const first = points[0]?.close ?? 0;
+  const last = points[points.length - 1]?.close ?? 0;
+  const positive = last >= first;
+
+  return (
+    <svg viewBox="0 0 56 20" className="h-6 w-16 overflow-visible" aria-hidden="true">
+      <polyline
+        fill="none"
+        stroke={positive ? 'currentColor' : 'currentColor'}
+        strokeWidth="1.75"
+        points={polyline}
+        className={positive ? 'text-emerald-600 dark:text-emerald-400' : 'text-rose-600 dark:text-rose-400'}
+      />
+    </svg>
+  );
+}
+
+export default function WatchlistPipelinePanel({ onTickerSelect }: WatchlistPipelinePanelProps) {
+  const watchlistQuery = useWatchlist();
+  const items = watchlistQuery.data ?? [];
+
+  if (watchlistQuery.isLoading) {
+    return <div className="py-10 text-sm text-gray-500 dark:text-gray-400">{t('watchlist.pipeline.loading')}</div>;
+  }
+
+  if (watchlistQuery.isError) {
+    return (
+      <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900/50 dark:bg-red-950/30 dark:text-red-300">
+        {t('watchlist.pipeline.error')}
+      </div>
+    );
+  }
+
+  if (items.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed border-gray-300 px-4 py-10 text-center text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400">
+        {t('watchlist.pipeline.empty')}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">{t('watchlist.pipeline.title')}</h2>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">{t('watchlist.pipeline.subtitle')}</p>
+        </div>
+        <div className="inline-flex items-center gap-2 rounded-full bg-amber-50 px-3 py-1 text-xs font-medium text-amber-700 dark:bg-amber-950/40 dark:text-amber-300">
+          <TrendingUp className="h-3.5 w-3.5" />
+          {t('watchlist.pipeline.sortedByDistance')}
+        </div>
+      </div>
+
+      <div className="overflow-hidden rounded-lg border border-border">
+        <table className="min-w-full divide-y divide-border text-sm">
+          <thead className="bg-gray-50 dark:bg-gray-900/50">
+            <tr className="text-left text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+              <th className="px-4 py-3 font-semibold">{t('watchlist.pipeline.columns.symbol')}</th>
+              <th className="px-4 py-3 font-semibold">{t('watchlist.pipeline.columns.current')}</th>
+              <th className="px-4 py-3 font-semibold">{t('watchlist.pipeline.columns.distance')}</th>
+              <th className="px-4 py-3 font-semibold">{t('watchlist.pipeline.columns.sparkline')}</th>
+              <th className="px-4 py-3 font-semibold">{t('watchlist.pipeline.columns.status')}</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border bg-white dark:bg-gray-950/20">
+            {items.map((item) => (
+              <tr
+                key={item.ticker}
+                className={cn(
+                  'align-top transition-colors',
+                  onTickerSelect ? 'cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-900/30' : '',
+                )}
+                onClick={() => onTickerSelect?.(item.ticker)}
+              >
+                <td className="px-4 py-3">
+                  <div className="flex items-center gap-2">
+                    <span className="font-semibold text-gray-900 dark:text-gray-100">{item.ticker}</span>
+                    {onTickerSelect ? <ArrowUpRight className="h-3.5 w-3.5 text-gray-400" /> : null}
+                  </div>
+                  <WatchMetaInline
+                    watchedAt={item.watchedAt}
+                    watchPrice={item.watchPrice}
+                    currentPrice={item.currentPrice}
+                    currency={item.currency}
+                    className="mt-1 flex flex-wrap items-center gap-2 text-[11px]"
+                  />
+                </td>
+                <td className="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">
+                  {item.currentPrice != null ? formatCurrency(item.currentPrice, item.currency ?? 'USD') : '—'}
+                </td>
+                <td className="px-4 py-3">
+                  <DistanceCell item={item} />
+                </td>
+                <td className="px-4 py-3">
+                  <Sparkline item={item} />
+                </td>
+                <td className="px-4 py-3">
+                  <span className="inline-flex rounded-full bg-gray-100 px-2 py-1 text-[11px] font-medium text-gray-700 dark:bg-gray-800 dark:text-gray-300">
+                    {(item.signal ?? 'none').toUpperCase()}
+                  </span>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/web-ui/src/components/domain/workspace/ActionPanel.test.tsx
+++ b/web-ui/src/components/domain/workspace/ActionPanel.test.tsx
@@ -33,8 +33,17 @@ vi.mock('@/features/portfolio/hooks', () => ({
   useCreateOrderMutation: () => ({
     mutateAsync: mutateMock,
   }),
+  useEarningsProximity: () => ({
+    data: undefined,
+  }),
   useOpenPositions: () => ({
     data: openPositionsMock(),
+  }),
+  usePortfolioSummary: () => ({
+    data: {
+      openRisk: 0,
+      concentration: [],
+    },
   }),
 }));
 

--- a/web-ui/src/components/domain/workspace/PortfolioTable.test.tsx
+++ b/web-ui/src/components/domain/workspace/PortfolioTable.test.tsx
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+
+import PortfolioTable from '@/components/domain/workspace/PortfolioTable';
+import { t } from '@/i18n/t';
+import { renderWithProviders } from '@/test/utils';
+import type { PositionWithMetrics } from '@/features/portfolio/api';
+
+const { positionsMock } = vi.hoisted(() => ({
+  positionsMock: vi.fn(),
+}));
+
+vi.mock('@/features/portfolio/hooks', () => ({
+  usePositions: () => ({
+    data: positionsMock(),
+    isLoading: false,
+    isFetched: true,
+    isError: false,
+  }),
+  useOrders: () => ({
+    data: [],
+    isLoading: false,
+    isFetched: true,
+    isError: false,
+  }),
+  useUpdateStopMutation: () => ({ mutate: vi.fn(), isPending: false, error: null }),
+  useClosePositionMutation: () => ({ mutate: vi.fn(), isPending: false, error: null }),
+  useFillOrderMutation: () => ({ mutate: vi.fn(), isPending: false, error: null }),
+  useCancelOrderMutation: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+function makePosition(overrides: Partial<PositionWithMetrics> = {}): PositionWithMetrics {
+  return {
+    ticker: 'TEST',
+    status: 'open',
+    entryDate: '2026-01-01',
+    entryPrice: 100,
+    stopPrice: 90,
+    shares: 10,
+    positionId: 'POS-TEST',
+    pnl: 0,
+    pnlPercent: 0,
+    rNow: 0,
+    entryValue: 1000,
+    currentValue: 1000,
+    perShareRisk: 10,
+    totalRisk: 100,
+    feesEur: 0,
+    daysOpen: 0,
+    timeStopWarning: false,
+    notes: '',
+    tags: [],
+    ...overrides,
+  };
+}
+
+describe('PortfolioTable time stop nudge', () => {
+  it('shows stale-trade badge for positions with time stop warning', () => {
+    positionsMock.mockReturnValue([
+      makePosition({ daysOpen: 16, rNow: 0.3, timeStopWarning: true }),
+    ]);
+
+    renderWithProviders(<PortfolioTable />);
+
+    expect(screen.getByText(t('bookPage.positions.timeStopBadge', { days: '16', r: '+0.30' }))).toBeInTheDocument();
+    expect(screen.getByTitle(t('bookPage.positions.timeStopWarning'))).toBeInTheDocument();
+  });
+
+  it('hides stale-trade badge when warning is false', () => {
+    positionsMock.mockReturnValue([
+      makePosition({ daysOpen: 16, rNow: 1.1, timeStopWarning: false }),
+    ]);
+
+    renderWithProviders(<PortfolioTable />);
+
+    expect(screen.queryByTitle(t('bookPage.positions.timeStopWarning'))).not.toBeInTheDocument();
+  });
+});

--- a/web-ui/src/components/domain/workspace/PortfolioTable.tsx
+++ b/web-ui/src/components/domain/workspace/PortfolioTable.tsx
@@ -44,6 +44,22 @@ function formatOptionalCurrency(value: number | null): string {
   return value == null ? t('common.placeholders.dash') : formatCurrency(value);
 }
 
+function TimeStopBadge({ position }: { position: PositionWithMetrics | null }) {
+  if (!position?.timeStopWarning) return null;
+  const label = t('bookPage.positions.timeStopBadge', {
+    days: String(position.daysOpen),
+    r: `${position.rNow >= 0 ? '+' : ''}${position.rNow.toFixed(2)}`,
+  });
+  return (
+    <span
+      className="inline-flex items-center rounded bg-amber-100 px-1.5 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-900/40 dark:text-amber-300"
+      title={t('bookPage.positions.timeStopWarning')}
+    >
+      {label}
+    </span>
+  );
+}
+
 /** Compact actions dropdown using native <details> */
 function ActionsDropdown({ children }: { children: React.ReactNode }) {
   return (
@@ -242,6 +258,7 @@ export default function PortfolioTable() {
         <div className="flex items-center gap-1.5">
           <span className="font-semibold text-sm">{row.ticker}</span>
           <Badge variant={row.status === 'open' ? 'success' : 'warning'} >{row.status}</Badge>
+          <TimeStopBadge position={row.position} />
         </div>
       ),
     },

--- a/web-ui/src/components/layout/Header.tsx
+++ b/web-ui/src/components/layout/Header.tsx
@@ -2,6 +2,7 @@ import { TrendingUp, PanelLeft, PanelLeftClose } from 'lucide-react';
 import { useI18n } from '@/i18n/I18nProvider';
 import Button from '@/components/common/Button';
 import StrategyCapitalRiskSummary from '@/components/domain/strategy/StrategyCapitalRiskSummary';
+import { usePortfolioSummary } from '@/features/portfolio/hooks';
 import {
   useActiveStrategyQuery,
   useSetActiveStrategyMutation,
@@ -19,6 +20,7 @@ export default function Header({ isSidebarCollapsed = false, onToggleSidebar }: 
 
   const strategiesQuery = useStrategiesQuery();
   const activeStrategyQuery = useActiveStrategyQuery();
+  const portfolioSummaryQuery = usePortfolioSummary();
   const setActiveMutation = useSetActiveStrategyMutation();
   const strategies = strategiesQuery.data ?? [];
   const activeId = activeStrategyQuery.data?.id ?? '';
@@ -77,7 +79,15 @@ export default function Header({ isSidebarCollapsed = false, onToggleSidebar }: 
 
       <div className="flex items-center gap-3 text-xs text-gray-500 dark:text-gray-400 shrink-0">
         <div className="hidden xl:block">
-          <StrategyCapitalRiskSummary strategy={activeStrategyQuery.data} variant="compact" className="max-w-[38rem]" />
+          <StrategyCapitalRiskSummary
+            strategy={activeStrategyQuery.data}
+            equitySnapshot={portfolioSummaryQuery.data ? {
+              effectiveAccountSize: portfolioSummaryQuery.data.effectiveAccountSize,
+              realizedPnl: portfolioSummaryQuery.data.realizedPnl,
+            } : undefined}
+            variant="compact"
+            className="max-w-[42rem]"
+          />
         </div>
         <span className="hidden md:block">{dateStr}</span>
         <span className="font-mono">{timeStr}</span>

--- a/web-ui/src/features/dailyReview/types.test.ts
+++ b/web-ui/src/features/dailyReview/types.test.ts
@@ -4,6 +4,19 @@ import { transformDailyReview, type DailyReviewAPI } from '@/features/dailyRevie
 describe('transformDailyReview', () => {
   it('maps candidate close and execution guidance fields', () => {
     const apiPayload: DailyReviewAPI = {
+      watchlist_near_trigger: [
+        {
+          ticker: 'ASML',
+          watched_at: '2026-05-01T10:00:00Z',
+          watch_price: 660,
+          currency: 'EUR',
+          source: 'screener',
+          current_price: 671,
+          signal_trigger_price: 680,
+          distance_to_trigger_pct: -1.3,
+          price_history: [],
+        },
+      ],
       new_candidates: [
         {
           ticker: 'AAPL',
@@ -67,11 +80,14 @@ describe('transformDailyReview', () => {
         close_positions: 0,
         new_candidates: 1,
         add_on_candidates: 0,
+        watchlist_near_trigger: 1,
         review_date: '2026-03-02',
       },
     };
 
     const result = transformDailyReview(apiPayload);
+    expect(result.watchlistNearTrigger[0].ticker).toBe('ASML');
+    expect(result.summary.watchlistNearTrigger).toBe(1);
     expect(result.newCandidates[0].close).toBe(100);
     expect(result.newCandidates[0].currency).toBe('USD');
     expect(result.newCandidates[0].score).toBe(83.2);

--- a/web-ui/src/features/dailyReview/types.ts
+++ b/web-ui/src/features/dailyReview/types.ts
@@ -8,6 +8,7 @@ import {
   type DecisionSummaryAPI,
   type SameSymbolCandidateContext,
 } from '@/features/screener/types';
+import { type WatchItem, type WatchItemAPI, transformWatchItem } from '@/features/watchlist/types';
 
 // API response types (snake_case from backend)
 export interface DailyReviewCandidateAPI {
@@ -58,6 +59,8 @@ export interface DailyReviewPositionHoldAPI {
   stop_price: number;
   current_price: number;
   r_now: number;
+  days_open?: number;
+  time_stop_warning?: boolean;
   reason: string;
 }
 
@@ -69,6 +72,8 @@ export interface DailyReviewPositionUpdateAPI {
   stop_suggested: number;
   current_price: number;
   r_now: number;
+  days_open?: number;
+  time_stop_warning?: boolean;
   reason: string;
 }
 
@@ -79,6 +84,8 @@ export interface DailyReviewPositionCloseAPI {
   stop_price: number;
   current_price: number;
   r_now: number;
+  days_open?: number;
+  time_stop_warning?: boolean;
   reason: string;
 }
 
@@ -89,10 +96,12 @@ export interface DailyReviewSummaryAPI {
   close_positions: number;
   new_candidates: number;
   add_on_candidates: number;
+  watchlist_near_trigger?: number;
   review_date: string;
 }
 
 export interface DailyReviewAPI {
+  watchlist_near_trigger?: WatchItemAPI[];
   new_candidates: DailyReviewCandidateAPI[];
   positions_add_on_candidates: DailyReviewCandidateAPI[];
   positions_hold: DailyReviewPositionHoldAPI[];
@@ -139,6 +148,8 @@ export interface DailyReviewPositionHold {
   stopPrice: number;
   currentPrice: number;
   rNow: number;
+  daysOpen: number;
+  timeStopWarning: boolean;
   reason: string;
 }
 
@@ -150,6 +161,8 @@ export interface DailyReviewPositionUpdate {
   stopSuggested: number;
   currentPrice: number;
   rNow: number;
+  daysOpen: number;
+  timeStopWarning: boolean;
   reason: string;
 }
 
@@ -160,6 +173,8 @@ export interface DailyReviewPositionClose {
   stopPrice: number;
   currentPrice: number;
   rNow: number;
+  daysOpen: number;
+  timeStopWarning: boolean;
   reason: string;
 }
 
@@ -170,10 +185,12 @@ export interface DailyReviewSummary {
   closePositions: number;
   newCandidates: number;
   addOnCandidates: number;
+  watchlistNearTrigger: number;
   reviewDate: string;
 }
 
 export interface DailyReview {
+  watchlistNearTrigger: WatchItem[];
   newCandidates: DailyReviewCandidate[];
   positionsAddOnCandidates: DailyReviewCandidate[];
   positionsHold: DailyReviewPositionHold[];
@@ -273,6 +290,8 @@ export function transformPositionHold(api: DailyReviewPositionHoldAPI): DailyRev
     stopPrice: api.stop_price,
     currentPrice: api.current_price,
     rNow: api.r_now,
+    daysOpen: api.days_open ?? 0,
+    timeStopWarning: api.time_stop_warning ?? false,
     reason: api.reason,
   };
 }
@@ -286,6 +305,8 @@ export function transformPositionUpdate(api: DailyReviewPositionUpdateAPI): Dail
     stopSuggested: api.stop_suggested,
     currentPrice: api.current_price,
     rNow: api.r_now,
+    daysOpen: api.days_open ?? 0,
+    timeStopWarning: api.time_stop_warning ?? false,
     reason: api.reason,
   };
 }
@@ -298,6 +319,8 @@ export function transformPositionClose(api: DailyReviewPositionCloseAPI): DailyR
     stopPrice: api.stop_price,
     currentPrice: api.current_price,
     rNow: api.r_now,
+    daysOpen: api.days_open ?? 0,
+    timeStopWarning: api.time_stop_warning ?? false,
     reason: api.reason,
   };
 }
@@ -310,12 +333,14 @@ export function transformSummary(api: DailyReviewSummaryAPI): DailyReviewSummary
     closePositions: api.close_positions,
     newCandidates: api.new_candidates,
     addOnCandidates: api.add_on_candidates,
+    watchlistNearTrigger: api.watchlist_near_trigger ?? 0,
     reviewDate: api.review_date,
   };
 }
 
 export function transformDailyReview(api: DailyReviewAPI): DailyReview {
   return {
+    watchlistNearTrigger: (api.watchlist_near_trigger ?? []).map(transformWatchItem),
     newCandidates: api.new_candidates.map(transformCandidate),
     positionsAddOnCandidates: (api.positions_add_on_candidates ?? []).map(transformCandidate),
     positionsHold: api.positions_hold.map(transformPositionHold),

--- a/web-ui/src/features/persistence/defaultStrategyFixture.json
+++ b/web-ui/src/features/persistence/defaultStrategyFixture.json
@@ -60,6 +60,8 @@
     "trail_sma": 20,
     "sma_buffer_pct": 0.005,
     "max_holding_days": 20,
+    "time_stop_days": 15,
+    "time_stop_min_r": 0.5,
     "benchmark": "SPY"
   },
   "market_intelligence": {

--- a/web-ui/src/features/persistence/portfolioService.test.ts
+++ b/web-ui/src/features/persistence/portfolioService.test.ts
@@ -81,6 +81,8 @@ describe('portfolio local persistence service', () => {
 
     const summary = portfolioSummaryLocal();
     expect(summary.totalPositions).toBe(0);
+    expect(summary.realizedPnl).toBe(40.1);
+    expect(summary.effectiveAccountSize).toBe(summary.accountSize + 40.1);
   });
 
   it('auto-merges repeated entry fills into the existing open position', () => {

--- a/web-ui/src/features/persistence/portfolioService.ts
+++ b/web-ui/src/features/persistence/portfolioService.ts
@@ -36,6 +36,16 @@ export interface LocalPositionWithMetrics extends Position {
   perShareRisk: number;
   totalRisk: number;
   feesEur: number;
+  daysOpen: number;
+  timeStopWarning: boolean;
+}
+
+export interface LocalConcentrationGroup {
+  country: string;
+  riskAmount: number;
+  riskPct: number;
+  positionCount: number;
+  warning: boolean;
 }
 
 export interface LocalPortfolioSummary {
@@ -58,6 +68,9 @@ export interface LocalPortfolioSummary {
   positionsProfitable: number;
   positionsLosing: number;
   winRate: number;
+  concentration: LocalConcentrationGroup[];
+  realizedPnl: number;
+  effectiveAccountSize: number;
 }
 
 export type LocalOrderFilterStatus = OrderStatus | 'all';
@@ -73,12 +86,58 @@ function normalizeTicker(value: string): string {
   return value.trim().toUpperCase();
 }
 
+function countryFromTicker(ticker: string): string {
+  const suffixMap: Record<string, string> = {
+    '.AS': 'NL',
+    '.PA': 'FR',
+    '.DE': 'DE',
+    '.MC': 'ES',
+    '.MI': 'IT',
+    '.ST': 'SE',
+    '.L': 'UK',
+    '.BR': 'BE',
+    '.LS': 'PT',
+    '.HE': 'FI',
+    '.CO': 'DK',
+    '.OL': 'NO',
+  };
+  const normalized = normalizeTicker(ticker);
+  for (const [suffix, country] of Object.entries(suffixMap)) {
+    if (normalized.endsWith(suffix)) return country;
+  }
+  return 'US';
+}
+
 function roundToCents(value: number): number {
   return Math.round((value + Number.EPSILON) * 100) / 100;
 }
 
 function roundToFourDecimals(value: number): number {
   return Math.round((value + Number.EPSILON) * 10000) / 10000;
+}
+
+function concentrationGroups(positions: LocalPositionWithMetrics[], openRisk: number): LocalConcentrationGroup[] {
+  const countryRisk = new Map<string, number>();
+  const countryCount = new Map<string, number>();
+  for (const position of positions) {
+    if (position.totalRisk <= 0) continue;
+    const country = countryFromTicker(position.ticker);
+    countryRisk.set(country, (countryRisk.get(country) ?? 0) + position.totalRisk);
+    countryCount.set(country, (countryCount.get(country) ?? 0) + 1);
+  }
+
+  return Array.from(countryRisk.entries())
+    .sort((a, b) => b[1] - a[1])
+    .map(([country, riskAmount]) => {
+      const riskPct = openRisk > 0 ? (riskAmount / openRisk) * 100 : 0;
+      return {
+        country,
+        riskAmount,
+        riskPct,
+        positionCount: countryCount.get(country) ?? 0,
+        warning: riskPct >= 60,
+      };
+    });
 }
 
 function inferOrderKind(order: Pick<Order, 'orderKind' | 'orderType'>): LocalOrderKind | null {
@@ -126,6 +185,13 @@ function perShareRisk(position: Position): number {
   return computed > 0 ? computed : 0;
 }
 
+function daysBetween(startIso: string, endIso: string): number {
+  const start = new Date(`${startIso}T00:00:00`);
+  const end = new Date(`${endIso}T00:00:00`);
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) return 0;
+  return Math.max(Math.floor((end.getTime() - start.getTime()) / 86_400_000), 0);
+}
+
 function toPositionWithMetrics(position: Position, feesByPosition: Map<string, number>): LocalPositionWithMetrics {
   const currentPrice = currentPriceForPosition(position);
   const entryValue = position.entryPrice * position.shares;
@@ -134,18 +200,26 @@ function toPositionWithMetrics(position: Position, feesByPosition: Map<string, n
   const pnl = (currentPrice - position.entryPrice) * position.shares - fee;
   const riskPerShare = perShareRisk(position);
   const totalRisk = riskPerShare * position.shares;
+  const store = readTradingStore();
+  const active = store.strategies.find((strategy) => strategy.id === store.activeStrategyId);
+  const daysOpen = daysBetween(position.entryDate, currentDateIso());
+  const rNow = totalRisk > 0 ? pnl / totalRisk : 0;
+  const timeStopDays = active?.manage.timeStopDays ?? 15;
+  const timeStopMinR = active?.manage.timeStopMinR ?? 0.5;
 
   return {
     ...cloneValue(position),
     currentPrice: position.status === 'open' ? currentPrice : position.currentPrice,
     pnl,
     pnlPercent: entryValue > 0 ? (pnl / entryValue) * 100 : 0,
-    rNow: totalRisk > 0 ? pnl / totalRisk : 0,
+    rNow,
     entryValue,
     currentValue,
     perShareRisk: riskPerShare,
     totalRisk,
     feesEur: fee,
+    daysOpen,
+    timeStopWarning: position.status === 'open' && daysOpen >= timeStopDays && rNow < timeStopMinR,
   };
 }
 
@@ -475,6 +549,12 @@ export function positionMetricsLocal(positionId: string): LocalPositionMetrics {
 
 export function portfolioSummaryLocal(): LocalPortfolioSummary {
   const accountSize = activeAccountSize();
+  const closedPositions = listPositionsLocal('closed');
+  const realizedPnl = closedPositions.reduce(
+    (sum, position) => sum + ((position.exitPrice ?? position.entryPrice) - position.entryPrice) * position.shares - (position.exitFeeEur ?? 0),
+    0,
+  );
+  const effectiveAccountSize = accountSize + realizedPnl;
   const positions = listPositionsLocal('open');
   if (positions.length === 0) {
     return {
@@ -497,6 +577,9 @@ export function portfolioSummaryLocal(): LocalPortfolioSummary {
       positionsProfitable: 0,
       positionsLosing: 0,
       winRate: 0,
+      concentration: [],
+      realizedPnl,
+      effectiveAccountSize,
     };
   }
 
@@ -555,9 +638,9 @@ export function portfolioSummaryLocal(): LocalPortfolioSummary {
     totalPnl,
     totalPnlPercent: totalCostBasis > 0 ? (totalPnl / totalCostBasis) * 100 : 0,
     openRisk,
-    openRiskPercent: accountSize > 0 ? (openRisk / accountSize) * 100 : 0,
+    openRiskPercent: effectiveAccountSize > 0 ? (openRisk / effectiveAccountSize) * 100 : 0,
     accountSize,
-    availableCapital: accountSize - totalValue,
+    availableCapital: effectiveAccountSize - totalValue,
     largestPositionValue,
     largestPositionTicker,
     bestPerformerTicker,
@@ -568,6 +651,9 @@ export function portfolioSummaryLocal(): LocalPortfolioSummary {
     positionsProfitable,
     positionsLosing,
     winRate: positions.length > 0 ? (positionsProfitable / positions.length) * 100 : 0,
+    concentration: concentrationGroups(positions, openRisk),
+    realizedPnl,
+    effectiveAccountSize,
   };
 }
 

--- a/web-ui/src/features/portfolio/api.ts
+++ b/web-ui/src/features/portfolio/api.ts
@@ -53,6 +53,8 @@ interface PositionWithMetricsApiResponse extends PositionApiResponse {
   per_share_risk: number;
   total_risk: number;
   fees_eur: number;
+  days_open?: number;
+  time_stop_warning?: boolean;
 }
 
 interface PortfolioSummaryApiResponse {
@@ -75,6 +77,17 @@ interface PortfolioSummaryApiResponse {
   positions_profitable: number;
   positions_losing: number;
   win_rate: number;
+  concentration?: ConcentrationGroupApiResponse[];
+  realized_pnl?: number;
+  effective_account_size?: number;
+}
+
+interface ConcentrationGroupApiResponse {
+  country: string;
+  risk_amount: number;
+  risk_pct: number;
+  position_count: number;
+  warning: boolean;
 }
 
 export interface PositionMetrics {
@@ -97,6 +110,8 @@ export interface PositionWithMetrics extends Position {
   perShareRisk: number;
   totalRisk: number;
   feesEur: number;
+  daysOpen: number;
+  timeStopWarning: boolean;
 }
 
 export interface PortfolioSummary {
@@ -119,6 +134,31 @@ export interface PortfolioSummary {
   positionsProfitable: number;
   positionsLosing: number;
   winRate: number;
+  concentration: ConcentrationGroup[];
+  realizedPnl: number;
+  effectiveAccountSize: number;
+}
+
+export interface ConcentrationGroup {
+  country: string;
+  riskAmount: number;
+  riskPct: number;
+  positionCount: number;
+  warning: boolean;
+}
+
+interface EarningsProximityApiResponse {
+  ticker: string;
+  next_earnings_date?: string | null;
+  days_until?: number | null;
+  warning: boolean;
+}
+
+export interface EarningsProximity {
+  ticker: string;
+  nextEarningsDate: string | null;
+  daysUntil: number | null;
+  warning: boolean;
 }
 
 export interface DegiroStatusApiResponse {
@@ -302,6 +342,26 @@ export async function fetchPortfolioSummary(): Promise<PortfolioSummary> {
   return transformPortfolioSummary(data);
 }
 
+export async function fetchEarningsProximity(ticker: string): Promise<EarningsProximity> {
+  const normalizedTicker = ticker.trim().toUpperCase();
+  if (!normalizedTicker || isLocalPersistenceMode()) {
+    return { ticker: normalizedTicker, nextEarningsDate: null, daysUntil: null, warning: false };
+  }
+
+  const response = await fetch(apiUrl(API_ENDPOINTS.earningsProximity(normalizedTicker)));
+  if (!response.ok) {
+    return { ticker: normalizedTicker, nextEarningsDate: null, daysUntil: null, warning: false };
+  }
+
+  const data: EarningsProximityApiResponse = await response.json();
+  return {
+    ticker: data.ticker,
+    nextEarningsDate: data.next_earnings_date ?? null,
+    daysUntil: data.days_until ?? null,
+    warning: data.warning,
+  };
+}
+
 export async function updatePositionStop(
   positionId: string,
   request: UpdateStopRequest,
@@ -358,6 +418,8 @@ export async function fetchPositionStopSuggestion(positionId: string): Promise<P
           trail_sma: strategy.manage.trailSma,
           sma_buffer_pct: strategy.manage.smaBufferPct,
           max_holding_days: strategy.manage.maxHoldingDays,
+          time_stop_days: strategy.manage.timeStopDays,
+          time_stop_min_r: strategy.manage.timeStopMinR,
         },
       }),
     });
@@ -476,6 +538,8 @@ function transformPositionWithMetrics(data: PositionWithMetricsApiResponse): Pos
     perShareRisk: data.per_share_risk,
     totalRisk: data.total_risk,
     feesEur: data.fees_eur ?? 0,
+    daysOpen: data.days_open ?? 0,
+    timeStopWarning: data.time_stop_warning ?? false,
   };
 }
 
@@ -500,5 +564,14 @@ function transformPortfolioSummary(data: PortfolioSummaryApiResponse): Portfolio
     positionsProfitable: data.positions_profitable,
     positionsLosing: data.positions_losing,
     winRate: data.win_rate,
+    concentration: (data.concentration ?? []).map((group) => ({
+      country: group.country,
+      riskAmount: group.risk_amount,
+      riskPct: group.risk_pct,
+      positionCount: group.position_count,
+      warning: group.warning,
+    })),
+    realizedPnl: data.realized_pnl ?? 0,
+    effectiveAccountSize: data.effective_account_size ?? data.account_size,
   };
 }

--- a/web-ui/src/features/portfolio/hooks.ts
+++ b/web-ui/src/features/portfolio/hooks.ts
@@ -10,6 +10,7 @@ import {
   fetchPositionStopSuggestion,
   fetchDegiroStatus,
   fetchDegiroOrderHistory,
+  fetchEarningsProximity,
   fillOrder,
   fillOrderFromDegiro,
   syncDegiroOrders,
@@ -119,6 +120,17 @@ export function usePortfolioSummary() {
     queryKey: queryKeys.portfolioSummary(),
     queryFn: fetchPortfolioSummary,
     staleTime: 30_000,
+  });
+}
+
+export function useEarningsProximity(ticker?: string) {
+  const normalizedTicker = ticker?.trim().toUpperCase();
+  return useQuery({
+    queryKey: ['earnings-proximity', normalizedTicker] as const,
+    queryFn: () => fetchEarningsProximity(normalizedTicker as string),
+    enabled: Boolean(normalizedTicker),
+    staleTime: 8 * 60 * 60 * 1000,
+    retry: false,
   });
 }
 

--- a/web-ui/src/features/strategy/types.ts
+++ b/web-ui/src/features/strategy/types.ts
@@ -55,6 +55,7 @@ export interface StrategyRisk {
   rrTarget: number;
   commissionPct: number;
   maxFeeRiskPct: number;
+  accountSizeMode: 'base' | 'equity';
   regimeEnabled: boolean;
   regimeTrendSma: number;
   regimeTrendMultiplier: number;
@@ -69,6 +70,8 @@ export interface StrategyManage {
   trailSma: number;
   smaBufferPct: number;
   maxHoldingDays: number;
+  timeStopDays: number;
+  timeStopMinR: number;
   benchmark: string;
 }
 
@@ -188,6 +191,7 @@ export interface StrategyRiskAPI {
   rr_target?: number;
   commission_pct?: number;
   max_fee_risk_pct?: number;
+  account_size_mode?: 'base' | 'equity';
   regime_enabled?: boolean;
   regime_trend_sma?: number;
   regime_trend_multiplier?: number;
@@ -202,6 +206,8 @@ export interface StrategyManageAPI {
   trail_sma: number;
   sma_buffer_pct: number;
   max_holding_days: number;
+  time_stop_days?: number;
+  time_stop_min_r?: number;
   benchmark: string;
 }
 
@@ -348,6 +354,7 @@ export function transformStrategy(api: StrategyAPI): Strategy {
       rrTarget: api.risk.rr_target ?? 2.0,
       commissionPct: api.risk.commission_pct ?? 0.0,
       maxFeeRiskPct: api.risk.max_fee_risk_pct ?? 0.2,
+      accountSizeMode: api.risk.account_size_mode ?? 'equity',
       regimeEnabled: api.risk.regime_enabled ?? false,
       regimeTrendSma: api.risk.regime_trend_sma ?? 200,
       regimeTrendMultiplier: api.risk.regime_trend_multiplier ?? 0.5,
@@ -361,6 +368,8 @@ export function transformStrategy(api: StrategyAPI): Strategy {
       trailSma: api.manage.trail_sma,
       smaBufferPct: api.manage.sma_buffer_pct,
       maxHoldingDays: api.manage.max_holding_days,
+      timeStopDays: api.manage.time_stop_days ?? 15,
+      timeStopMinR: api.manage.time_stop_min_r ?? 0.5,
       benchmark: api.manage.benchmark,
     },
     marketIntelligence: {
@@ -461,6 +470,7 @@ export function toStrategyUpdateRequest(strategy: Strategy): StrategyUpdateReque
       rr_target: strategy.risk.rrTarget,
       commission_pct: strategy.risk.commissionPct,
       max_fee_risk_pct: strategy.risk.maxFeeRiskPct,
+      account_size_mode: strategy.risk.accountSizeMode,
       regime_enabled: strategy.risk.regimeEnabled,
       regime_trend_sma: strategy.risk.regimeTrendSma,
       regime_trend_multiplier: strategy.risk.regimeTrendMultiplier,
@@ -474,6 +484,8 @@ export function toStrategyUpdateRequest(strategy: Strategy): StrategyUpdateReque
       trail_sma: strategy.manage.trailSma,
       sma_buffer_pct: strategy.manage.smaBufferPct,
       max_holding_days: strategy.manage.maxHoldingDays,
+      time_stop_days: strategy.manage.timeStopDays,
+      time_stop_min_r: strategy.manage.timeStopMinR,
       benchmark: strategy.manage.benchmark,
     },
     market_intelligence: {

--- a/web-ui/src/features/strategy/useStrategyReadiness.test.ts
+++ b/web-ui/src/features/strategy/useStrategyReadiness.test.ts
@@ -47,6 +47,7 @@ const createMockStrategy = (overrides?: Partial<Strategy>): Strategy => ({
     rrTarget: 2.0,
     commissionPct: 0.001,
     maxFeeRiskPct: 0.2,
+    accountSizeMode: 'equity',
     regimeEnabled: false,
     regimeTrendSma: 200,
     regimeTrendMultiplier: 0.5,
@@ -60,6 +61,8 @@ const createMockStrategy = (overrides?: Partial<Strategy>): Strategy => ({
     trailSma: 10,
     smaBufferPct: 0.5,
     maxHoldingDays: 90,
+    timeStopDays: 15,
+    timeStopMinR: 0.5,
     benchmark: 'SPY',
   },
   marketIntelligence: {

--- a/web-ui/src/features/watchlist/api.ts
+++ b/web-ui/src/features/watchlist/api.ts
@@ -21,6 +21,7 @@ export async function fetchWatchlist(): Promise<WatchItem[]> {
       watchPrice: item.watchPrice ?? undefined,
       currency: item.currency ?? undefined,
       source: item.source,
+      priceHistory: [],
     }));
   }
 
@@ -51,6 +52,7 @@ export async function watchSymbol(request: WatchSymbolRequest): Promise<WatchIte
       watchPrice: saved.watchPrice ?? undefined,
       currency: saved.currency ?? undefined,
       source: saved.source,
+      priceHistory: [],
     };
   }
 
@@ -109,4 +111,3 @@ export async function unwatchSymbol(ticker: string): Promise<void> {
     throw new Error(message);
   }
 }
-

--- a/web-ui/src/features/watchlist/hooks.test.tsx
+++ b/web-ui/src/features/watchlist/hooks.test.tsx
@@ -46,6 +46,7 @@ describe('watchlist hooks', () => {
         watchPrice: 180,
         currency: 'USD',
         source: 'screener',
+        priceHistory: [],
       },
     ]);
 
@@ -70,6 +71,7 @@ describe('watchlist hooks', () => {
       watchPrice: 180,
       currency: 'USD',
       source: 'screener',
+      priceHistory: [],
     });
 
     const { result } = renderHook(() => useWatchSymbolMutation(), {
@@ -111,4 +113,3 @@ describe('watchlist hooks', () => {
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.watchlist() });
   });
 });
-

--- a/web-ui/src/features/watchlist/types.ts
+++ b/web-ui/src/features/watchlist/types.ts
@@ -1,9 +1,17 @@
+import type { PriceHistoryPoint } from '@/features/screener/types';
+
 export interface WatchItemAPI {
   ticker: string;
   watched_at: string;
   watch_price?: number | null;
   currency?: string | null;
   source: string;
+  current_price?: number | null;
+  last_bar?: string | null;
+  signal?: string | null;
+  signal_trigger_price?: number | null;
+  distance_to_trigger_pct?: number | null;
+  price_history?: PriceHistoryPoint[] | null;
 }
 
 export interface WatchlistResponseAPI {
@@ -16,6 +24,12 @@ export interface WatchItem {
   watchPrice?: number;
   currency?: string;
   source: string;
+  currentPrice?: number;
+  lastBar?: string;
+  signal?: string;
+  signalTriggerPrice?: number;
+  distanceToTriggerPct?: number;
+  priceHistory: PriceHistoryPoint[];
 }
 
 export interface WatchSymbolRequest {
@@ -32,6 +46,11 @@ export function transformWatchItem(api: WatchItemAPI): WatchItem {
     watchPrice: api.watch_price ?? undefined,
     currency: api.currency?.trim().toUpperCase() || undefined,
     source: api.source,
+    currentPrice: api.current_price ?? undefined,
+    lastBar: api.last_bar ?? undefined,
+    signal: api.signal ?? undefined,
+    signalTriggerPrice: api.signal_trigger_price ?? undefined,
+    distanceToTriggerPct: api.distance_to_trigger_pct ?? undefined,
+    priceHistory: api.price_history ?? [],
   };
 }
-

--- a/web-ui/src/i18n/messages.en.ts
+++ b/web-ui/src/i18n/messages.en.ts
@@ -1972,6 +1972,17 @@ export const messagesEn = {
       maxR: 'Max R',
       holdDays: 'Hold Days',
     },
+    edgeBreakdown: {
+      title: 'Edge by setup type',
+      emptyState: 'Close and tag 5 or more trades to see your edge breakdown.',
+      colTag: 'Tag',
+      colTrades: 'Trades',
+      colWinRate: 'Win rate',
+      colAvgR: 'Avg R',
+      colExpectancy: 'Expectancy',
+      expectancyHint: 'Average R per tagged trade',
+      byConditionTitle: 'By market condition',
+    },
   },
   portfolioRisk: {
     openPositions: 'Open Positions',

--- a/web-ui/src/i18n/messages.en.ts
+++ b/web-ui/src/i18n/messages.en.ts
@@ -53,6 +53,26 @@ export const messagesEn = {
       unavailable: '—',
       value: '{{abs}} ({{pct}})',
     },
+    pipeline: {
+      title: 'Watchlist Pipeline',
+      subtitle: 'Track which names are closest to their trigger zone.',
+      sortedByDistance: 'Closest first',
+      loading: 'Loading watchlist pipeline...',
+      error: 'Unable to load the watchlist pipeline.',
+      empty: 'No watchlist symbols yet.',
+      distanceToBuyZone: '{{value}} to buy zone',
+      aboveBuyZone: '{{value}} above buy zone',
+      triggerPrice: 'Trigger {{value}}',
+      columns: {
+        symbol: 'Symbol',
+        current: 'Current',
+        distance: 'Distance to Trigger',
+        sparkline: '5D',
+        status: 'Signal',
+      },
+      dailyReviewTitle: 'Watchlist nearing trigger',
+      dailyReviewSubtitle: '{{count}} names within 3% of the buy zone.',
+    },
   },
   modal: {
     closeAria: 'Close modal',
@@ -1646,6 +1666,10 @@ export const messagesEn = {
         strategyModule: 'Strategy Module',
         idValue: 'ID: {{id}}',
         accountSize: 'Account Size',
+        accountSizeMode: 'Account Size Mode',
+        accountSizeModeBase: 'Base - use configured account size',
+        accountSizeModeEquity: 'Equity - base + realized P&L from closed trades',
+        accountSizeModeHint: 'Controls how position size is calculated. Equity mode grows or shrinks your risk budget as you realize profits or losses.',
         riskPerTrade: 'Risk Per Trade',
         maxPositionSize: 'Max Position Size',
         atrMultiplier: 'ATR Multiplier',
@@ -1707,6 +1731,8 @@ export const messagesEn = {
         trailSma: 'Trail SMA',
         smaBuffer: 'SMA Buffer',
         maxHoldingDays: 'Max Holding Days',
+        timeStopDays: 'Time Stop Days',
+        timeStopMinR: 'Time Stop Min R',
         takeProfitR: 'Take Profit (R)',
         commission: 'Commission',
         minHistory: 'Min History',
@@ -1986,9 +2012,31 @@ export const messagesEn = {
   },
   portfolioRisk: {
     openPositions: 'Open Positions',
+    effectiveEquity: 'Equity',
+    realizedPnl: 'Realized P&L',
     totalRisk: 'Total Risk',
     portfolioHeat: 'Portfolio Heat',
     avgRNow: 'Avg R Now',
+  },
+  concentrationBar: {
+    title: 'Concentration',
+    warningLabel: '{{country}} is {{pct}}% of open risk',
+    normalLabel: '{{country}} is {{pct}}% of open risk',
+    detail: '{{count}} positions - {{amount}} risk',
+  },
+  concentrationWarning: {
+    orderMessage: 'This order would move {{country}} concentration from {{currentPct}}% to {{projectedPct}}% of open risk.',
+  },
+  portfolioHeader: {
+    effectiveEquity: 'Equity',
+    baseAccount: 'Base',
+    realizedPnl: 'Realized P&L',
+    equityModeHint: 'Account size + realized P&L from closed trades',
+  },
+  earningsWarning: {
+    message: 'Earnings in {{days}} days - gap risk is elevated',
+    messageToday: 'Earnings today - gap risk is elevated',
+    messageSingular: 'Earnings tomorrow - gap risk is elevated',
   },
   dailyReviewBanner: {
     newCandidates: '{{n}} new candidates',
@@ -2006,6 +2054,10 @@ export const messagesEn = {
       journal: 'Journal',
       performance: 'Performance',
       review: 'Weekly Review',
+    },
+    positions: {
+      timeStopBadge: '{{days}}d / {{r}}R',
+      timeStopWarning: 'Stale trade: consider closing or documenting a reason to hold.',
     },
   },
   pendingOrdersTab: {
@@ -2042,6 +2094,7 @@ export const messagesEn = {
     tabs: {
       intelligence: 'Intelligence',
       fundamentals: 'Fundamentals',
+      watchlist: 'Watchlist',
       calendar: 'Calendar',
     },
     symbolSearch: {
@@ -2055,6 +2108,7 @@ export const messagesEn = {
       screener: 'Screener',
     },
     actionList: {
+      watchlistNearTrigger: 'Watchlist Near Trigger',
       requiresAction: 'Requires Action',
       opportunities: 'New Opportunities',
       holding: 'Holding',
@@ -2065,6 +2119,8 @@ export const messagesEn = {
       loading: "Loading today's review...",
       closeAction: 'Close →',
       updateAction: 'Update →',
+      timeStopBadge: '{{days}}d / {{r}}R',
+      timeStopWarning: 'Stale trade: consider closing or documenting a reason to hold.',
     },
     keyboard: {
       hint: 'j/k navigate · Enter select',

--- a/web-ui/src/lib/api.ts
+++ b/web-ui/src/lib/api.ts
@@ -33,6 +33,7 @@ export const API_ENDPOINTS = {
   positionStopSuggestionCompute: '/api/portfolio/stop-suggestion/compute',
   positionClose: (id: string) => `/api/portfolio/positions/${id}/close`,
   portfolioSummary: '/api/portfolio/summary',
+  earningsProximity: (ticker: string) => `/api/portfolio/earnings-proximity/${encodeURIComponent(ticker)}`,
   degiroStatus: '/api/portfolio/degiro/status',
   
   // Portfolio - Orders

--- a/web-ui/src/pages/Analytics.tsx
+++ b/web-ui/src/pages/Analytics.tsx
@@ -4,6 +4,7 @@ import type { Position } from '@/types/position';
 import { t } from '@/i18n/t';
 import { cn } from '@/utils/cn';
 import { formatNumber, formatCurrency } from '@/utils/formatters';
+import EdgeBreakdownTable from '@/components/domain/portfolio/EdgeBreakdownTable';
 
 // ─── helpers ────────────────────────────────────────────────────────────────
 
@@ -458,6 +459,14 @@ export default function Analytics() {
 
           {/* How to read */}
           <HowToReadBox />
+
+          {/* Edge by setup type */}
+          <section>
+            <h2 className="mb-3 text-sm font-semibold text-gray-700 dark:text-gray-300">
+              {t('analyticsPage.edgeBreakdown.title')}
+            </h2>
+            <EdgeBreakdownTable positions={stats.sorted} />
+          </section>
 
           {/* Trade list table */}
           <div className="rounded-lg border border-gray-200 dark:border-gray-700 overflow-x-auto">

--- a/web-ui/src/pages/Book.tsx
+++ b/web-ui/src/pages/Book.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect } from 'react';
+import ConcentrationBar from '@/components/domain/portfolio/ConcentrationBar';
 import PortfolioRiskSummary from '@/components/domain/portfolio/PortfolioRiskSummary';
 import PortfolioPanel from '@/components/domain/workspace/PortfolioPanel';
-import { usePositions } from '@/features/portfolio/hooks';
+import { usePortfolioSummary, usePositions } from '@/features/portfolio/hooks';
 import { useActiveStrategyQuery } from '@/features/strategy/hooks';
 import { useWeeklyReviews } from '@/features/weeklyReview/hooks';
 import { cn } from '@/utils/cn';
@@ -18,12 +19,15 @@ type BookTab = 'positions' | 'orders' | 'journal' | 'performance' | 'review';
 function PositionsTab() {
   const openPositionsQuery = usePositions('open');
   const activeStrategyQuery = useActiveStrategyQuery();
+  const portfolioSummaryQuery = usePortfolioSummary();
   const openPositions = openPositionsQuery.data ?? [];
-  const accountSize = activeStrategyQuery.data?.risk?.accountSize;
+  const accountSize = portfolioSummaryQuery.data?.effectiveAccountSize ?? activeStrategyQuery.data?.risk?.accountSize;
+  const realizedPnl = portfolioSummaryQuery.data?.realizedPnl;
 
   return (
     <div className="space-y-4">
-      <PortfolioRiskSummary openPositions={openPositions} accountSize={accountSize} />
+      <PortfolioRiskSummary openPositions={openPositions} accountSize={accountSize} realizedPnl={realizedPnl} />
+      <ConcentrationBar groups={portfolioSummaryQuery.data?.concentration ?? []} />
       <PortfolioPanel />
     </div>
   );

--- a/web-ui/src/pages/Research.tsx
+++ b/web-ui/src/pages/Research.tsx
@@ -4,20 +4,23 @@ import { t } from '@/i18n/t';
 import IntelligencePage from './Intelligence';
 import FundamentalsPage from './Fundamentals';
 import EventsCalendar from '@/components/domain/calendar/EventsCalendar';
+import WatchlistPipelinePanel from '@/components/domain/watchlist/WatchlistPipelinePanel';
 import { usePositions } from '@/features/portfolio/hooks';
 import { useWatchlist } from '@/features/watchlist/hooks';
+import { useWorkspaceStore } from '@/stores/workspaceStore';
 
 const STORAGE_KEY = 'research.activeTab';
-type ResearchTab = 'intelligence' | 'fundamentals' | 'calendar';
+type ResearchTab = 'intelligence' | 'fundamentals' | 'watchlist' | 'calendar';
 
 export default function Research() {
   const [activeTab, setActiveTab] = useState<ResearchTab>(() => {
     const stored = localStorage.getItem(STORAGE_KEY);
-    if (stored === 'intelligence' || stored === 'fundamentals' || stored === 'calendar') {
+    if (stored === 'intelligence' || stored === 'fundamentals' || stored === 'watchlist' || stored === 'calendar') {
       return stored;
     }
     return 'intelligence';
   });
+  const setSelectedTicker = useWorkspaceStore((state) => state.setSelectedTicker);
 
   const openPositionsQuery = usePositions('open');
   const watchlistQuery = useWatchlist();
@@ -39,6 +42,7 @@ export default function Research() {
   const tabs: { key: ResearchTab; label: string }[] = [
     { key: 'intelligence', label: t('researchPage.tabs.intelligence') },
     { key: 'fundamentals', label: t('researchPage.tabs.fundamentals') },
+    { key: 'watchlist', label: t('researchPage.tabs.watchlist') },
     { key: 'calendar', label: t('researchPage.tabs.calendar') },
   ];
 
@@ -105,6 +109,16 @@ export default function Research() {
       <div>
         {activeTab === 'intelligence' && <IntelligencePage initialSymbol={committedSymbol} />}
         {activeTab === 'fundamentals' && <FundamentalsPage initialSymbol={committedSymbol} />}
+        {activeTab === 'watchlist' && (
+          <WatchlistPipelinePanel
+            onTickerSelect={(ticker) => {
+              setSharedSymbol(ticker);
+              setCommittedSymbol(ticker);
+              setSelectedTicker(ticker, 'screener');
+              setActiveTab('intelligence');
+            }}
+          />
+        )}
         {activeTab === 'calendar' && (
           <EventsCalendar symbols={calendarSymbols} daysAhead={30} />
         )}

--- a/web-ui/src/pages/Today.test.tsx
+++ b/web-ui/src/pages/Today.test.tsx
@@ -52,4 +52,48 @@ describe('Today page — pending orders badge', () => {
       screen.queryByText(t('todayPage.pendingBadge.singular', { count: '1' }))
     ).not.toBeInTheDocument();
   });
+
+  it('shows watchlist near-trigger section when daily review returns matches', async () => {
+    server.use(
+      http.get('*/api/portfolio/orders/local', () =>
+        HttpResponse.json({ orders: [], asof: '2026-04-28' })
+      ),
+      http.get('*/api/daily-review', () =>
+        HttpResponse.json({
+          watchlist_near_trigger: [
+            {
+              ticker: 'ASML',
+              watched_at: '2026-05-01T10:00:00Z',
+              watch_price: 660,
+              currency: 'EUR',
+              source: 'screener',
+              current_price: 671,
+              signal_trigger_price: 680,
+              distance_to_trigger_pct: -1.3,
+              price_history: [],
+            },
+          ],
+          new_candidates: [],
+          positions_add_on_candidates: [],
+          positions_hold: [],
+          positions_update_stop: [],
+          positions_close: [],
+          summary: {
+            total_positions: 0,
+            no_action: 0,
+            update_stop: 0,
+            close_positions: 0,
+            new_candidates: 0,
+            add_on_candidates: 0,
+            watchlist_near_trigger: 1,
+            review_date: '2026-05-04',
+          },
+        })
+      )
+    );
+
+    renderWithProviders(<Today />);
+    expect(await screen.findByText(new RegExp(t('watchlist.pipeline.dailyReviewTitle'), 'i'))).toBeInTheDocument();
+    expect(screen.getByText('ASML')).toBeInTheDocument();
+  });
 });

--- a/web-ui/src/pages/Today.tsx
+++ b/web-ui/src/pages/Today.tsx
@@ -5,6 +5,7 @@ import FloatingChatWidget from '@/components/domain/workspace/FloatingChatWidget
 import ScreenerInboxPanel from '@/components/domain/workspace/ScreenerInboxPanel';
 import ClosePositionModalForm from '@/components/domain/positions/ClosePositionModalForm';
 import UpdateStopModalForm from '@/components/domain/positions/UpdateStopModalForm';
+import WatchMetaInline from '@/components/domain/watchlist/WatchMetaInline';
 import { useSymbolIntelligenceRunner } from '@/features/intelligence/useSymbolIntelligenceRunner';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
 import { useDailyReview } from '@/features/dailyReview/api';
@@ -26,8 +27,30 @@ import type {
   DailyReviewPositionHold,
   DailyReviewPositionUpdate,
 } from '@/features/dailyReview/types';
+import type { WatchItem } from '@/features/watchlist/types';
 
 // ─── Action item row components ─────────────────────────────────────────────
+
+interface TimeStopBadgeProps {
+  daysOpen: number;
+  rNow: number;
+  show: boolean;
+}
+
+function TimeStopBadge({ daysOpen, rNow, show }: TimeStopBadgeProps) {
+  if (!show) return null;
+  return (
+    <span
+      className="text-xs font-medium px-1.5 py-0.5 rounded bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400"
+      title={t('todayPage.actionList.timeStopWarning')}
+    >
+      {t('todayPage.actionList.timeStopBadge', {
+        days: String(daysOpen),
+        r: `${rNow >= 0 ? '+' : ''}${formatNumber(rNow, 2)}`,
+      })}
+    </span>
+  );
+}
 
 interface CloseItemProps {
   item: DailyReviewPositionClose;
@@ -57,6 +80,7 @@ function CloseItem({ item, onClick, onAction, isDone, isFocused }: CloseItemProp
       <span className={cn('text-xs font-semibold tabular-nums', item.rNow >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400')}>
         {item.rNow >= 0 ? '+' : ''}{formatNumber(item.rNow, 2)}R
       </span>
+      <TimeStopBadge daysOpen={item.daysOpen} rNow={item.rNow} show={item.timeStopWarning} />
       <span className="text-xs text-gray-500 dark:text-gray-400 truncate flex-1">{item.reason}</span>
       {isDone ? (
         <CheckCircle2 className="w-4 h-4 text-green-500 shrink-0" />
@@ -103,6 +127,7 @@ function UpdateStopItem({ item, onClick, onAction, isDone, isFocused }: UpdateSt
       <span className={cn('text-xs font-semibold tabular-nums', item.rNow >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400')}>
         {item.rNow >= 0 ? '+' : ''}{formatNumber(item.rNow, 2)}R
       </span>
+      <TimeStopBadge daysOpen={item.daysOpen} rNow={item.rNow} show={item.timeStopWarning} />
       <span className="text-xs text-gray-500 dark:text-gray-400 truncate flex-1">{item.reason}</span>
       {isDone ? (
         <CheckCircle2 className="w-4 h-4 text-green-500 shrink-0" />
@@ -185,7 +210,43 @@ function HoldItem({ item, onClick, isFocused }: HoldItemProps) {
       <span className={cn('text-xs font-semibold tabular-nums', item.rNow >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400')}>
         {item.rNow >= 0 ? '+' : ''}{formatNumber(item.rNow, 2)}R
       </span>
+      <TimeStopBadge daysOpen={item.daysOpen} rNow={item.rNow} show={item.timeStopWarning} />
       <span className="text-xs text-gray-400 dark:text-gray-500 truncate flex-1">{item.reason}</span>
+    </button>
+  );
+}
+
+function WatchlistNearTriggerItem({ item, onClick, isFocused }: { item: WatchItem; onClick: (ticker: string) => void; isFocused?: boolean }) {
+  const distance = item.distanceToTriggerPct;
+  return (
+    <button
+      type="button"
+      onClick={() => onClick(item.ticker)}
+      className={cn(
+        'w-full text-left flex items-start gap-3 px-3 py-2 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors border-l-2 border-amber-400',
+        isFocused && 'ring-1 ring-primary',
+      )}
+    >
+      <span className="text-sm font-semibold text-gray-900 dark:text-gray-100 min-w-[60px]">
+        {item.ticker}
+      </span>
+      <span className="text-xs font-medium px-1.5 py-0.5 rounded bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">
+        {t('todayPage.actionList.watchlistNearTrigger')}
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="text-xs font-semibold tabular-nums text-amber-700 dark:text-amber-300">
+          {distance != null
+            ? t('watchlist.pipeline.distanceToBuyZone', { value: `${distance >= 0 ? '+' : ''}${formatNumber(distance, 1)}%` })
+            : '—'}
+        </div>
+        <WatchMetaInline
+          watchedAt={item.watchedAt}
+          watchPrice={item.watchPrice}
+          currentPrice={item.currentPrice}
+          currency={item.currency}
+          className="mt-0.5 flex flex-wrap items-center gap-2 text-[11px]"
+        />
+      </div>
     </button>
   );
 }
@@ -329,6 +390,7 @@ function TodayActionList({ onTickerSelect }: TodayActionListProps) {
   // Flat ordered list for keyboard navigation
   const flatItems = useMemo(
     () => [
+      ...(review?.watchlistNearTrigger.map((i) => ({ ticker: i.ticker, id: `watch-${i.ticker}` })) ?? []),
       ...(review?.positionsClose.map((i) => ({ ticker: i.ticker, id: i.positionId })) ?? []),
       ...(review?.positionsUpdateStop.map((i) => ({ ticker: i.ticker, id: i.positionId })) ?? []),
       ...filteredCandidates.map((i) => ({ ticker: i.ticker, id: i.ticker })),
@@ -363,6 +425,7 @@ function TodayActionList({ onTickerSelect }: TodayActionListProps) {
 
   const requiresActionCount =
     (review?.positionsClose.length ?? 0) + (review?.positionsUpdateStop.length ?? 0);
+  const watchlistNearTriggerCount = review?.watchlistNearTrigger.length ?? 0;
   const opportunitiesCount = filteredCandidates.length + filteredAddOns.length;
   const holdCount = review?.positionsHold.length ?? 0;
 
@@ -382,7 +445,7 @@ function TodayActionList({ onTickerSelect }: TodayActionListProps) {
     );
   }
 
-  const isEmpty = requiresActionCount === 0 && opportunitiesCount === 0 && holdCount === 0;
+  const isEmpty = requiresActionCount === 0 && watchlistNearTriggerCount === 0 && opportunitiesCount === 0 && holdCount === 0;
 
   return (
     <div className="flex flex-col h-full overflow-hidden">
@@ -455,6 +518,31 @@ function TodayActionList({ onTickerSelect }: TodayActionListProps) {
           <p className="text-sm text-gray-500 dark:text-gray-400 px-2 py-4 text-center">
             {t('todayPage.actionList.empty')}
           </p>
+        )}
+
+        {/* Requires Action section */}
+        {watchlistNearTriggerCount > 0 && (
+          <div className="space-y-1">
+            <div className="px-3 py-1 text-xs font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-300 bg-amber-50 dark:bg-amber-900/20 rounded">
+              {t('watchlist.pipeline.dailyReviewTitle')} · {watchlistNearTriggerCount}
+            </div>
+            <p className="px-3 text-[11px] text-gray-500 dark:text-gray-400">
+              {t('watchlist.pipeline.dailyReviewSubtitle', { count: String(watchlistNearTriggerCount) })}
+            </p>
+            <div className="space-y-0.5">
+              {review?.watchlistNearTrigger.map((item) => {
+                const idx = flatItems.findIndex((fi) => fi.id === `watch-${item.ticker}`);
+                return (
+                  <WatchlistNearTriggerItem
+                    key={item.ticker}
+                    item={item}
+                    onClick={onTickerSelect}
+                    isFocused={focusedIndex === idx}
+                  />
+                );
+              })}
+            </div>
+          </div>
         )}
 
         {/* Requires Action section */}

--- a/web-ui/src/test/mocks/handlers.ts
+++ b/web-ui/src/test/mocks/handlers.ts
@@ -445,6 +445,8 @@ export const mockPortfolioSummary = {
   positions_profitable: 1,
   positions_losing: 0,
   win_rate: 100,
+  realized_pnl: 125,
+  effective_account_size: 625,
 }
 
 export const mockPositionMetrics = {
@@ -600,6 +602,12 @@ type WatchlistItemPayload = {
   watch_price: number | null
   currency: string | null
   source: string
+  current_price?: number | null
+  last_bar?: string | null
+  signal?: string | null
+  signal_trigger_price?: number | null
+  distance_to_trigger_pct?: number | null
+  price_history?: Array<{ date: string; close: number }>
 }
 let watchlistItems: WatchlistItemPayload[] = []
 
@@ -980,6 +988,55 @@ export const handlers = [
       return HttpResponse.json({ detail: `Watch item not found: ${ticker}` }, { status: 404 })
     }
     return HttpResponse.json({ deleted: true })
+  }),
+
+  // Daily review endpoints
+  http.get(`${API_BASE_URL}/api/daily-review`, () => {
+    return HttpResponse.json({
+      watchlist_near_trigger: watchlistItems.filter((item) => {
+        const distance = item.distance_to_trigger_pct
+        return typeof distance === 'number' && distance >= -3 && distance <= 0
+      }),
+      new_candidates: [],
+      positions_add_on_candidates: [],
+      positions_hold: [],
+      positions_update_stop: [],
+      positions_close: [],
+      summary: {
+        total_positions: 0,
+        no_action: 0,
+        update_stop: 0,
+        close_positions: 0,
+        new_candidates: 0,
+        add_on_candidates: 0,
+        watchlist_near_trigger: watchlistItems.filter((item) => {
+          const distance = item.distance_to_trigger_pct
+          return typeof distance === 'number' && distance >= -3 && distance <= 0
+        }).length,
+        review_date: '2026-05-04',
+      },
+    })
+  }),
+
+  http.post(`${API_BASE_URL}/api/daily-review/compute`, () => {
+    return HttpResponse.json({
+      watchlist_near_trigger: [],
+      new_candidates: [],
+      positions_add_on_candidates: [],
+      positions_hold: [],
+      positions_update_stop: [],
+      positions_close: [],
+      summary: {
+        total_positions: 0,
+        no_action: 0,
+        update_stop: 0,
+        close_positions: 0,
+        new_candidates: 0,
+        add_on_candidates: 0,
+        watchlist_near_trigger: 0,
+        review_date: '2026-05-04',
+      },
+    })
   }),
 
   // Screener endpoints

--- a/web-ui/src/types/config.ts
+++ b/web-ui/src/types/config.ts
@@ -27,6 +27,8 @@ export interface ManageConfig {
   trailSma: number;
   smaBufferPct: number;
   maxHoldingDays: number;
+  timeStopDays: number;
+  timeStopMinR: number;
 }
 
 export interface AppConfig {
@@ -66,6 +68,8 @@ export interface ManageConfigAPI {
   trail_sma: number;
   sma_buffer_pct: number;
   max_holding_days: number;
+  time_stop_days?: number;
+  time_stop_min_r?: number;
 }
 
 export interface AppConfigAPI {
@@ -105,6 +109,8 @@ export function transformAppConfig(api: AppConfigAPI): AppConfig {
       trailSma: api.manage.trail_sma,
       smaBufferPct: api.manage.sma_buffer_pct,
       maxHoldingDays: api.manage.max_holding_days,
+      timeStopDays: api.manage.time_stop_days ?? 15,
+      timeStopMinR: api.manage.time_stop_min_r ?? 0.5,
     },
     positionsFile: api.positions_file,
     ordersFile: api.orders_file,
@@ -140,6 +146,8 @@ export function toAppConfigAPI(config: AppConfig): AppConfigAPI {
       trail_sma: config.manage.trailSma,
       sma_buffer_pct: config.manage.smaBufferPct,
       max_holding_days: config.manage.maxHoldingDays,
+      time_stop_days: config.manage.timeStopDays,
+      time_stop_min_r: config.manage.timeStopMinR,
     },
     positions_file: config.positionsFile,
     orders_file: config.ordersFile,


### PR DESCRIPTION
## Summary

Adds an Analytics section that aggregates closed tagged trades by tag so setup/exit/context labels can be evaluated as performance groups.

## Changes

- Adds `analyticsPage.edgeBreakdown.*` i18n keys.
- Adds `EdgeBreakdownTable` with client-side tag aggregation.
- Shows empty guidance until at least 5 tagged closed trades exist.
- Mounts the breakdown on the Analytics page above the detailed trade list.

## Impact

Once trades are tagged through the close-position flow from the base PR, Analytics can surface win rate, average R, and expectancy by tag without adding new backend endpoints.

## Validation

- `cd web-ui && npm run typecheck`
- `cd web-ui && npx vitest run`
