### PR TITLE
[codex] Add time stop nudge

### DIFF
--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -22,6 +22,7 @@ from api.services.intelligence_service import IntelligenceService
 from api.services.portfolio_service import PortfolioService
 from api.services.screener_service import ScreenerService
 from api.services.strategy_service import StrategyService
+from api.services.watchlist_service import WatchlistService
 from api.services.workspace_context_service import WorkspaceContextService
 from api.utils.files import read_json_file, write_json_file, get_today_str
 from swing_screener.settings import data_dir, get_settings_manager, project_root
@@ -77,6 +78,13 @@ def get_watchlist_repo() -> WatchlistRepository:
 
 def get_strategy_repo() -> StrategyRepository:
     return StrategyRepository()
+
+
+def get_watchlist_service(
+    watchlist_repo: WatchlistRepository = Depends(get_watchlist_repo),
+    strategy_repo: StrategyRepository = Depends(get_strategy_repo),
+) -> WatchlistService:
+    return WatchlistService(repo=watchlist_repo, strategy_repo=strategy_repo)
 
 
 def get_intelligence_config_repo() -> IntelligenceConfigRepository:

--- a/api/models/config.py
+++ b/api/models/config.py
@@ -45,6 +45,8 @@ class ManageConfig(BaseModel):
     trail_sma: int = Field(gt=0, description="SMA to trail under")
     sma_buffer_pct: float = Field(ge=0, description="Buffer below SMA (e.g., 0.005 = 0.5%)")
     max_holding_days: int = Field(gt=0, description="Max days to hold position")
+    time_stop_days: int = Field(default=15, gt=0, description="Days open before stale-trade nudge appears")
+    time_stop_min_r: float = Field(default=0.5, ge=0, description="Minimum R that suppresses stale-trade nudge")
 
 
 class AppConfig(BaseModel):

--- a/api/models/daily_review.py
+++ b/api/models/daily_review.py
@@ -6,6 +6,7 @@ from api.models.recommendation import Recommendation
 from api.models.portfolio import Position
 from api.models.screener import SameSymbolCandidateContext
 from api.models.strategy import Strategy
+from api.models.watchlist import WatchlistItemView
 from swing_screener.recommendation.models import DecisionSummary
 
 
@@ -88,11 +89,13 @@ class DailyReviewSummary(BaseModel):
     close_positions: int
     new_candidates: int
     add_on_candidates: int = 0
+    watchlist_near_trigger: int = 0
     review_date: date
 
 
 class DailyReview(BaseModel):
     """Complete daily review with action items."""
+    watchlist_near_trigger: list[WatchlistItemView] = Field(default_factory=list)
     new_candidates: list[DailyReviewCandidate]
     positions_add_on_candidates: list[DailyReviewCandidate] = Field(default_factory=list)
     positions_hold: list[DailyReviewPositionHold]

--- a/api/models/daily_review.py
+++ b/api/models/daily_review.py
@@ -48,6 +48,8 @@ class DailyReviewPositionHold(BaseModel):
     stop_price: float
     current_price: float
     r_now: float
+    days_open: int = 0
+    time_stop_warning: bool = False
     reason: str = Field(..., description="Why no action is needed")
 
 
@@ -60,6 +62,8 @@ class DailyReviewPositionUpdate(BaseModel):
     stop_suggested: float
     current_price: float
     r_now: float
+    days_open: int = 0
+    time_stop_warning: bool = False
     reason: str = Field(..., description="Why stop should be updated")
 
 
@@ -71,6 +75,8 @@ class DailyReviewPositionClose(BaseModel):
     stop_price: float
     current_price: float
     r_now: float
+    days_open: int = 0
+    time_stop_warning: bool = False
     reason: str = Field(..., description="Why position should be closed")
 
 

--- a/api/models/portfolio.py
+++ b/api/models/portfolio.py
@@ -109,6 +109,8 @@ class StopSuggestionManageConfig(BaseModel):
     trail_sma: int = Field(default=20, gt=0)
     sma_buffer_pct: float = Field(default=0.005, ge=0)
     max_holding_days: int = Field(default=20, gt=0)
+    time_stop_days: int = Field(default=15, gt=0)
+    time_stop_min_r: float = Field(default=0.5, ge=0)
 
 
 class StopSuggestionComputeRequest(BaseModel):
@@ -282,6 +284,11 @@ class PositionWithMetrics(Position):
     current_value: float = Field(..., description="Current market value (shares × current_price)")
     per_share_risk: float = Field(..., description="Risk per share in dollars")
     total_risk: float = Field(..., description="Total position risk (per_share_risk × shares)")
+    days_open: int = Field(default=0, description="Calendar days since entry date")
+    time_stop_warning: bool = Field(
+        default=False,
+        description="True when an open trade is stale and below the configured R threshold",
+    )
 
 
 class PositionsWithMetricsResponse(BaseModel):

--- a/api/models/strategy.py
+++ b/api/models/strategy.py
@@ -78,12 +78,14 @@ class StrategyRisk(BaseModel):
 
 
 class StrategyManage(BaseModel):
-    breakeven_at_r: float = Field(ge=0)
-    trail_after_r: float = Field(ge=0)
-    trail_sma: int = Field(gt=0)
-    sma_buffer_pct: float = Field(ge=0)
-    max_holding_days: int = Field(gt=0)
-    benchmark: str
+    breakeven_at_r: float = Field(default=1.0, ge=0)
+    trail_after_r: float = Field(default=2.0, ge=0)
+    trail_sma: int = Field(default=20, gt=0)
+    sma_buffer_pct: float = Field(default=0.005, ge=0)
+    max_holding_days: int = Field(default=20, gt=0)
+    time_stop_days: int = Field(default=15, gt=0)
+    time_stop_min_r: float = Field(default=0.5, ge=0)
+    benchmark: str = "SPY"
 
 
 class StrategyIntelligenceLLM(BaseModel):

--- a/api/models/watchlist.py
+++ b/api/models/watchlist.py
@@ -8,6 +8,8 @@ from typing import Optional
 
 from pydantic import BaseModel, Field, field_validator
 
+from api.models.screener import PriceHistoryPoint
+
 
 class WatchItemUpsertRequest(BaseModel):
     watch_price: Optional[float] = Field(default=None, description="Price captured when watch is created.")
@@ -75,10 +77,18 @@ class WatchItem(BaseModel):
         return WatchItemUpsertRequest._normalize_source(value)
 
 
+class WatchlistItemView(WatchItem):
+    current_price: Optional[float] = None
+    last_bar: Optional[str] = None
+    signal: Optional[str] = None
+    signal_trigger_price: Optional[float] = None
+    distance_to_trigger_pct: Optional[float] = None
+    price_history: list[PriceHistoryPoint] = Field(default_factory=list)
+
+
 class WatchlistResponse(BaseModel):
-    items: list[WatchItem] = Field(default_factory=list)
+    items: list[WatchlistItemView] = Field(default_factory=list)
 
 
 class WatchlistDeleteResponse(BaseModel):
     deleted: bool
-

--- a/api/routers/daily_review.py
+++ b/api/routers/daily_review.py
@@ -5,7 +5,9 @@ from api.models.daily_review import DailyReview, DailyReviewComputeRequest
 from api.services.daily_review_service import DailyReviewService
 from api.services.screener_service import ScreenerService
 from api.services.portfolio_service import PortfolioService
+from api.services.watchlist_service import WatchlistService
 from api.dependencies import (
+    get_watchlist_service,
     get_screener_service,
     get_portfolio_service,
 )
@@ -24,9 +26,10 @@ def _dump_payload_item(item):
 def get_daily_review_service(
     screener_service: ScreenerService = Depends(get_screener_service),
     portfolio_service: PortfolioService = Depends(get_portfolio_service),
+    watchlist_service: WatchlistService = Depends(get_watchlist_service),
 ) -> DailyReviewService:
     """Dependency injection for DailyReviewService."""
-    return DailyReviewService(screener_service, portfolio_service)
+    return DailyReviewService(screener_service, portfolio_service, watchlist_service=watchlist_service)
 
 
 @router.get("", response_model=DailyReview)

--- a/api/routers/portfolio.py
+++ b/api/routers/portfolio.py
@@ -43,9 +43,25 @@ router = APIRouter()
 async def get_positions(
     status: Optional[str] = None,
     service: PortfolioService = Depends(get_portfolio_service),
+    config_repo: ConfigRepository = Depends(get_config_repo),
+    strategy_repo: StrategyRepository = Depends(get_strategy_repo),
 ):
     """Get all positions, optionally filtered by status."""
-    return service.list_positions(status=status)
+    manage = config_repo.get().manage
+    time_stop_days = int(manage.time_stop_days)
+    time_stop_min_r = float(manage.time_stop_min_r)
+    try:
+        active_strategy = strategy_repo.get_active_strategy()
+        strategy_manage = active_strategy.get("manage", {})
+        time_stop_days = int(strategy_manage.get("time_stop_days", time_stop_days))
+        time_stop_min_r = float(strategy_manage.get("time_stop_min_r", time_stop_min_r))
+    except (TypeError, ValueError):
+        pass
+    return service.list_positions(
+        status=status,
+        time_stop_days=time_stop_days,
+        time_stop_min_r=time_stop_min_r,
+    )
 
 
 @router.post("/positions", response_model=Position)

--- a/api/routers/watchlist.py
+++ b/api/routers/watchlist.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import ValidationError
 
-from api.dependencies import get_watchlist_repo
+from api.dependencies import get_watchlist_repo, get_watchlist_service
 from api.models.watchlist import (
     WatchItem,
     WatchItemUpsertRequest,
@@ -12,15 +12,16 @@ from api.models.watchlist import (
     WatchlistResponse,
 )
 from api.repositories.watchlist_repo import WatchlistRepository
+from api.services.watchlist_service import WatchlistService
 
 router = APIRouter()
 
 
 @router.get("", response_model=WatchlistResponse)
 async def list_watchlist(
-    repo: WatchlistRepository = Depends(get_watchlist_repo),
+    service: WatchlistService = Depends(get_watchlist_service),
 ):
-    return WatchlistResponse(items=repo.list_items())
+    return WatchlistResponse(items=service.list_items())
 
 
 @router.put("/{ticker}", response_model=WatchItem)

--- a/api/services/daily_review_service.py
+++ b/api/services/daily_review_service.py
@@ -95,7 +95,12 @@ class DailyReviewService:
         add_on_candidates = [_to_daily_candidate(c) for c in candidates if c.same_symbol is not None and c.same_symbol.mode == "ADD_ON"]
         
         # 2. Analyze all open positions
-        positions_response = self.portfolio.list_positions(status="open")
+        active_manage = self._active_manage_cfg_payload()
+        positions_response = self.portfolio.list_positions(
+            status="open",
+            time_stop_days=int(active_manage.get("time_stop_days", 15)),
+            time_stop_min_r=float(active_manage.get("time_stop_min_r", 0.5)),
+        )
         positions = positions_response.positions
         
         positions_hold: list[DailyReviewPositionHold] = []
@@ -121,6 +126,7 @@ class DailyReviewService:
                         stop_price=pos.stop_price,
                         current_price=pos.current_price or pos.entry_price,
                         r_now=0.0,
+                        **self._time_stop_payload_from_position(pos, 0.0, active_manage),
                         reason=f"Stop suggestion unavailable: {reason}",
                     )
                 )
@@ -138,6 +144,7 @@ class DailyReviewService:
                         stop_price=pos.stop_price,
                         current_price=pos.current_price or pos.entry_price,
                         r_now=0.0,
+                        **self._time_stop_payload_from_position(pos, 0.0, active_manage),
                         reason=f"Stop suggestion unavailable: {exc}",
                     )
                 )
@@ -153,6 +160,7 @@ class DailyReviewService:
                         stop_price=pos.stop_price,
                         current_price=suggestion.last,
                         r_now=suggestion.r_now,
+                        **self._time_stop_payload_from_position(pos, suggestion.r_now, active_manage),
                         reason=suggestion.reason,
                     )
                 )
@@ -167,6 +175,7 @@ class DailyReviewService:
                         stop_suggested=suggestion.stop_suggested,
                         current_price=suggestion.last,
                         r_now=suggestion.r_now,
+                        **self._time_stop_payload_from_position(pos, suggestion.r_now, active_manage),
                         reason=suggestion.reason,
                     )
                 )
@@ -180,6 +189,7 @@ class DailyReviewService:
                         stop_price=pos.stop_price,
                         current_price=suggestion.last,
                         r_now=suggestion.r_now,
+                        **self._time_stop_payload_from_position(pos, suggestion.r_now, active_manage),
                         reason=suggestion.reason,
                     )
                 )
@@ -209,6 +219,45 @@ class DailyReviewService:
         
         return review
 
+    def _active_manage_cfg_payload(self) -> dict:
+        strategy_repo = getattr(self.screener, "_strategy_repo", None)
+        if strategy_repo is None:
+            return {}
+        try:
+            strategy = strategy_repo.get_active_strategy()
+        except Exception:
+            logger.exception("Unable to resolve active strategy manage config for daily review")
+            return {}
+        manage = strategy.get("manage", {}) if isinstance(strategy, dict) else {}
+        return manage if isinstance(manage, dict) else {}
+
+    @staticmethod
+    def _time_stop_payload(position: dict, r_now: float, manage_payload: dict) -> dict:
+        try:
+            entry_dt = date.fromisoformat(str(position.get("entry_date") or ""))
+            days_open = max((date.today() - entry_dt).days, 0)
+        except ValueError:
+            days_open = 0
+        time_stop_days = int(manage_payload.get("time_stop_days", 15))
+        time_stop_min_r = float(manage_payload.get("time_stop_min_r", 0.5))
+        return {
+            "days_open": days_open,
+            "time_stop_warning": (
+                position.get("status") == "open"
+                and days_open >= time_stop_days
+                and r_now < time_stop_min_r
+            ),
+        }
+
+    def _time_stop_payload_from_position(self, position, r_now: float, manage_payload: dict) -> dict:
+        days_open = getattr(position, "days_open", None)
+        time_stop_warning = getattr(position, "time_stop_warning", None)
+        if days_open is not None and time_stop_warning is not None:
+            return {"days_open": int(days_open), "time_stop_warning": bool(time_stop_warning)}
+        model_dump = getattr(position, "model_dump", None)
+        payload = model_dump() if callable(model_dump) else dict(position)
+        return self._time_stop_payload(payload, r_now, manage_payload)
+
     @staticmethod
     def _manage_cfg_payload_from_strategy(strategy: dict) -> dict:
         manage = strategy.get("manage", {}) if isinstance(strategy, dict) else {}
@@ -218,6 +267,8 @@ class DailyReviewService:
             trail_after_R=float(manage.get("trail_after_r", 2.0)),
             sma_buffer_pct=float(manage.get("sma_buffer_pct", 0.005)),
             max_holding_days=int(manage.get("max_holding_days", 20)),
+            time_stop_days=int(manage.get("time_stop_days", 15)),
+            time_stop_min_r=float(manage.get("time_stop_min_r", 0.5)),
         )
         return {
             "breakeven_at_r": cfg.breakeven_at_R,
@@ -225,6 +276,8 @@ class DailyReviewService:
             "trail_sma": cfg.trail_sma,
             "sma_buffer_pct": cfg.sma_buffer_pct,
             "max_holding_days": cfg.max_holding_days,
+            "time_stop_days": cfg.time_stop_days,
+            "time_stop_min_r": cfg.time_stop_min_r,
         }
 
     def compute_daily_review_from_state(
@@ -314,6 +367,7 @@ class DailyReviewService:
                         stop_price=float(pos.get("stop_price", 0.0)),
                         current_price=float(pos.get("current_price") or pos.get("entry_price") or 0.0),
                         r_now=0.0,
+                        **self._time_stop_payload(pos, 0.0, manage_payload),
                         reason=f"Stop suggestion unavailable: {reason}",
                     )
                 )
@@ -331,6 +385,7 @@ class DailyReviewService:
                         stop_price=float(pos.get("stop_price", 0.0)),
                         current_price=float(pos.get("current_price") or pos.get("entry_price") or 0.0),
                         r_now=0.0,
+                        **self._time_stop_payload(pos, 0.0, manage_payload),
                         reason=f"Stop suggestion unavailable: {exc}",
                     )
                 )
@@ -345,6 +400,7 @@ class DailyReviewService:
                         stop_price=suggestion.stop_old,
                         current_price=suggestion.last,
                         r_now=suggestion.r_now,
+                        **self._time_stop_payload(pos, suggestion.r_now, manage_payload),
                         reason=suggestion.reason,
                     )
                 )
@@ -358,6 +414,7 @@ class DailyReviewService:
                         stop_suggested=suggestion.stop_suggested,
                         current_price=suggestion.last,
                         r_now=suggestion.r_now,
+                        **self._time_stop_payload(pos, suggestion.r_now, manage_payload),
                         reason=suggestion.reason,
                     )
                 )
@@ -370,6 +427,7 @@ class DailyReviewService:
                         stop_price=suggestion.stop_old,
                         current_price=suggestion.last,
                         r_now=suggestion.r_now,
+                        **self._time_stop_payload(pos, suggestion.r_now, manage_payload),
                         reason=suggestion.reason,
                     )
                 )

--- a/api/services/daily_review_service.py
+++ b/api/services/daily_review_service.py
@@ -17,6 +17,7 @@ from api.models.daily_review import (
 from api.models.screener import ScreenerRequest
 from api.services.screener_service import ScreenerService
 from api.services.portfolio_service import PortfolioService
+from api.services.watchlist_service import WatchlistService
 from swing_screener.portfolio.state import ManageConfig as ManageStateConfig
 
 logger = logging.getLogger(__name__)
@@ -29,10 +30,12 @@ class DailyReviewService:
         self,
         screener_service: ScreenerService,
         portfolio_service: PortfolioService,
+        watchlist_service: WatchlistService | None = None,
         data_dir: Path = Path("data"),
     ):
         self.screener = screener_service
         self.portfolio = portfolio_service
+        self.watchlist = watchlist_service
         self.data_dir = data_dir
         self.daily_reviews_dir = data_dir / "daily_reviews"
         self.daily_reviews_dir.mkdir(parents=True, exist_ok=True)
@@ -93,6 +96,7 @@ class DailyReviewService:
             )
         new_candidates = [_to_daily_candidate(c) for c in candidates if c.same_symbol is None or c.same_symbol.mode == "NEW_ENTRY"]
         add_on_candidates = [_to_daily_candidate(c) for c in candidates if c.same_symbol is not None and c.same_symbol.mode == "ADD_ON"]
+        watchlist_near_trigger = self._watchlist_near_trigger_items()
         
         # 2. Analyze all open positions
         active_manage = self._active_manage_cfg_payload()
@@ -202,10 +206,12 @@ class DailyReviewService:
             close_positions=len(positions_close),
             new_candidates=len(new_candidates),
             add_on_candidates=len(add_on_candidates),
+            watchlist_near_trigger=len(watchlist_near_trigger),
             review_date=date.today(),
         )
-        
+
         review = DailyReview(
+            watchlist_near_trigger=watchlist_near_trigger,
             new_candidates=new_candidates,
             positions_add_on_candidates=add_on_candidates,
             positions_hold=positions_hold,
@@ -218,6 +224,25 @@ class DailyReviewService:
         self._save_review(review, "default")
         
         return review
+
+    def _watchlist_near_trigger_items(self) -> list:
+        if self.watchlist is None:
+            return []
+        try:
+            items = self.watchlist.list_items()
+        except Exception:
+            logger.exception("Unable to build watchlist near-trigger section for daily review")
+            return []
+        near_trigger = []
+        for item in items:
+            distance = (
+                item.distance_to_trigger_pct
+                if hasattr(item, "distance_to_trigger_pct")
+                else item.get("distance_to_trigger_pct")
+            )
+            if distance is not None and -3.0 <= float(distance) <= 0.0:
+                near_trigger.append(item)
+        return near_trigger
 
     def _active_manage_cfg_payload(self) -> dict:
         strategy_repo = getattr(self.screener, "_strategy_repo", None)
@@ -433,6 +458,7 @@ class DailyReviewService:
                 )
 
         return DailyReview(
+            watchlist_near_trigger=[],
             new_candidates=new_candidates,
             positions_add_on_candidates=add_on_candidates,
             positions_hold=positions_hold,
@@ -445,6 +471,7 @@ class DailyReviewService:
                 close_positions=len(positions_close),
                 new_candidates=len(new_candidates),
                 add_on_candidates=len(add_on_candidates),
+                watchlist_near_trigger=0,
                 review_date=date.today(),
             ),
         )

--- a/api/services/portfolio_service.py
+++ b/api/services/portfolio_service.py
@@ -168,6 +168,8 @@ def _manage_cfg_from_app() -> ManageStateConfig:
         trail_after_R=manage.trail_after_r,
         sma_buffer_pct=manage.sma_buffer_pct,
         max_holding_days=manage.max_holding_days,
+        time_stop_days=manage.time_stop_days,
+        time_stop_min_r=manage.time_stop_min_r,
     )
 
 
@@ -316,6 +318,9 @@ class PortfolioService:
         position: dict,
         current_prices: dict[str, float],
         eurusd_rate: float,
+        *,
+        time_stop_days: int | None = None,
+        time_stop_min_r: float | None = None,
     ) -> PositionWithMetrics:
         state_position = _to_state_position(position)
         ticker = state_position.ticker.upper()
@@ -332,19 +337,46 @@ class PortfolioService:
         if state_position.status == "open" and live_price is not None:
             payload["current_price"] = live_price
 
+        days_open = self._days_open(state_position.entry_date)
+        r_now = calculate_r_now(state_position, current_price_for_metrics)
+        manage_defaults = ManageStateConfig()
+        stale_days = int(time_stop_days or manage_defaults.time_stop_days)
+        min_progress_r = float(time_stop_min_r if time_stop_min_r is not None else manage_defaults.time_stop_min_r)
+        time_stop_warning = (
+            state_position.status == "open"
+            and days_open >= stale_days
+            and r_now < min_progress_r
+        )
+
         return PositionWithMetrics(
             **payload,
             pnl=pnl,
             fees_eur=entry_fee_eur,
             pnl_percent=pnl_percent,
-            r_now=calculate_r_now(state_position, current_price_for_metrics),
+            r_now=r_now,
             entry_value=entry_value,
             current_value=calculate_current_position_value(current_price_for_metrics, state_position.shares),
             per_share_risk=per_share_risk,
             total_risk=per_share_risk * state_position.shares,
+            days_open=days_open,
+            time_stop_warning=time_stop_warning,
         )
 
-    def list_positions(self, status: Optional[str] = None) -> PositionsWithMetricsResponse:
+    @staticmethod
+    def _days_open(entry_date: str) -> int:
+        try:
+            entry_dt = dt.date.fromisoformat(str(entry_date))
+        except ValueError:
+            return 0
+        return max((dt.date.today() - entry_dt).days, 0)
+
+    def list_positions(
+        self,
+        status: Optional[str] = None,
+        *,
+        time_stop_days: int | None = None,
+        time_stop_min_r: float | None = None,
+    ) -> PositionsWithMetricsResponse:
         positions, asof = self._positions_repo.list_positions(status=status)
         current_prices = self._attach_live_prices(positions)
         has_usd_positions = any(
@@ -354,7 +386,13 @@ class PortfolioService:
         eurusd_rate = self._eurusd_rate() if has_usd_positions else 1.0
 
         positions_with_metrics = [
-            self._build_position_with_metrics(position, current_prices, eurusd_rate)
+            self._build_position_with_metrics(
+                position,
+                current_prices,
+                eurusd_rate,
+                time_stop_days=time_stop_days,
+                time_stop_min_r=time_stop_min_r,
+            )
             for position in positions
         ]
         return PositionsWithMetricsResponse(positions=positions_with_metrics, asof=asof)
@@ -937,6 +975,8 @@ class PortfolioService:
             trail_after_R=float(payload.get("trail_after_r", 2.0)),
             sma_buffer_pct=float(payload.get("sma_buffer_pct", 0.005)),
             max_holding_days=int(payload.get("max_holding_days", 20)),
+            time_stop_days=int(payload.get("time_stop_days", 15)),
+            time_stop_min_r=float(payload.get("time_stop_min_r", 0.5)),
         )
 
     def _suggest_position_stop_from_dict(

--- a/api/services/watchlist_service.py
+++ b/api/services/watchlist_service.py
@@ -1,0 +1,149 @@
+"""Watchlist enrichment service."""
+from __future__ import annotations
+
+import logging
+from dataclasses import replace
+from typing import Optional
+
+import pandas as pd
+
+from api.models.screener import PriceHistoryPoint
+from api.models.watchlist import WatchItem, WatchlistItemView
+from api.repositories.strategy_repo import StrategyRepository
+from api.repositories.watchlist_repo import WatchlistRepository
+from api.utils.files import get_today_str
+from swing_screener.data.providers import MarketDataProvider, get_default_provider
+from swing_screener.selection.entries import build_signal_board
+from swing_screener.strategy.config import build_entry_config
+from swing_screener.utils.dataframe_helpers import get_close_matrix
+from swing_screener.utils.date_helpers import get_default_history_start
+
+logger = logging.getLogger(__name__)
+
+WATCHLIST_SPARKLINE_BARS = 5
+
+
+def _to_iso(ts) -> Optional[str]:
+    if ts is None or pd.isna(ts):
+        return None
+    if isinstance(ts, pd.Timestamp):
+        ts = ts.to_pydatetime()
+    if hasattr(ts, "isoformat"):
+        return ts.isoformat()
+    return str(ts)
+
+
+def _last_close_map(ohlcv: pd.DataFrame) -> tuple[dict[str, float], dict[str, str]]:
+    prices: dict[str, float] = {}
+    bars: dict[str, str] = {}
+    if ohlcv is None or ohlcv.empty:
+        return prices, bars
+    close = get_close_matrix(ohlcv)
+    for ticker in close.columns:
+        series = close[ticker].dropna()
+        if series.empty:
+            continue
+        prices[str(ticker)] = float(series.iloc[-1])
+        iso = _to_iso(series.index[-1])
+        if iso:
+            bars[str(ticker)] = iso
+    return prices, bars
+
+
+def _sparkline_history_map(ohlcv: pd.DataFrame, tickers: list[str]) -> dict[str, list[PriceHistoryPoint]]:
+    out: dict[str, list[PriceHistoryPoint]] = {}
+    if ohlcv is None or ohlcv.empty:
+        return out
+    close = get_close_matrix(ohlcv)
+    for ticker in tickers:
+        if ticker not in close.columns:
+            out[ticker] = []
+            continue
+        series = close[ticker].dropna().tail(WATCHLIST_SPARKLINE_BARS)
+        out[ticker] = [
+            PriceHistoryPoint(date=str(idx.date().isoformat() if hasattr(idx, "date") else idx), close=float(value))
+            for idx, value in series.items()
+        ]
+    return out
+
+
+def _compute_distance_pct(current_price: Optional[float], trigger_price: Optional[float]) -> Optional[float]:
+    if (
+        current_price is None
+        or trigger_price is None
+        or not pd.notna(current_price)
+        or not pd.notna(trigger_price)
+        or float(trigger_price) <= 0
+    ):
+        return None
+    return ((float(current_price) - float(trigger_price)) / float(trigger_price)) * 100.0
+
+
+class WatchlistService:
+    def __init__(
+        self,
+        repo: WatchlistRepository,
+        strategy_repo: StrategyRepository,
+        provider: Optional[MarketDataProvider] = None,
+    ) -> None:
+        self._repo = repo
+        self._strategy_repo = strategy_repo
+        self._provider = provider or get_default_provider()
+
+    def list_items(self) -> list[WatchlistItemView]:
+        items = self._repo.list_items()
+        if not items:
+            return []
+
+        tickers = [item.ticker for item in items]
+        enriched = {item.ticker: WatchlistItemView(**item.model_dump()) for item in items}
+
+        try:
+            strategy = self._strategy_repo.get_active_strategy()
+            signals_cfg = build_entry_config(strategy)
+            # The watchlist view should still compute trigger distance for names that do
+            # not yet have a full long-history candidate profile.
+            signals_cfg = replace(signals_cfg, min_history=min(int(signals_cfg.min_history), 60))
+            ohlcv = self._provider.fetch_ohlcv(
+                tickers,
+                start_date=get_default_history_start(),
+                end_date=get_today_str(),
+            )
+            if ohlcv is None or ohlcv.empty:
+                return self._sorted_items(items, enriched)
+
+            board = build_signal_board(ohlcv, tickers, cfg=signals_cfg)
+            last_prices, last_bars = _last_close_map(ohlcv)
+            sparkline_history = _sparkline_history_map(ohlcv, tickers)
+
+            for ticker in tickers:
+                row = board.loc[ticker] if ticker in board.index else None
+                trigger_price = None
+                signal = None
+                if row is not None:
+                    raw_trigger = row.get("breakout_level")
+                    trigger_price = float(raw_trigger) if pd.notna(raw_trigger) else None
+                    raw_signal = row.get("signal")
+                    signal = str(raw_signal) if pd.notna(raw_signal) else None
+                payload = enriched[ticker].model_dump()
+                payload.update(
+                    current_price=last_prices.get(ticker),
+                    last_bar=last_bars.get(ticker),
+                    signal=signal,
+                    signal_trigger_price=trigger_price,
+                    distance_to_trigger_pct=_compute_distance_pct(last_prices.get(ticker), trigger_price),
+                    price_history=sparkline_history.get(ticker, []),
+                )
+                enriched[ticker] = WatchlistItemView(**payload)
+        except Exception:
+            logger.exception("Failed to enrich watchlist pipeline view")
+
+        return self._sorted_items(items, enriched)
+
+    @staticmethod
+    def _sorted_items(items: list[WatchItem], enriched: dict[str, WatchlistItemView]) -> list[WatchlistItemView]:
+        def sort_key(item: WatchlistItemView) -> tuple[bool, float, str]:
+            distance = item.distance_to_trigger_pct
+            return (distance is None, distance if distance is not None else float("inf"), item.ticker)
+
+        return sorted((enriched[item.ticker] for item in items), key=sort_key)

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -26,6 +26,8 @@ app_config:
     trail_sma: 20
     sma_buffer_pct: 0.005
     max_holding_days: 20
+    time_stop_days: 15
+    time_stop_min_r: 0.5
   positions_file: data/positions.json
   orders_file: data/orders.json
 
@@ -87,6 +89,8 @@ strategy:
     trail_sma: 20
     sma_buffer_pct: 0.005
     max_holding_days: 20
+    time_stop_days: 15
+    time_stop_min_r: 0.5
     benchmark: SPY
   market_intelligence:
     enabled: false

--- a/docs/superpowers/plans/2026-05-03-feature-6-time-stop-nudge.md
+++ b/docs/superpowers/plans/2026-05-03-feature-6-time-stop-nudge.md
@@ -1,0 +1,394 @@
+# Time Stop Nudge — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> Read `docs/superpowers/plans/handover-context.md` before starting.
+
+**Goal:** Show an ambient warning badge on position rows when a trade has been open too long without adequate profit, prompting the trader to make a deliberate exit/hold decision — without forcing an automatic close.
+
+**Architecture:** Add two config fields (`time_stop_days`, `time_stop_min_r`) to `ManageConfig` in `src/swing_screener/portfolio/state.py` and `config/defaults.yaml`. Add `days_open: int` and `time_stop_warning: bool` to `PositionWithMetrics` in the API layer. The backend computes both fields in `_build_position_with_metrics()`. The frontend `PositionWithMetrics` type gains these fields and the position row component shows a coloured badge when `timeStopWarning` is `true`.
+
+**Important distinction:** The hard `CLOSE_TIME_EXIT` action already exists in `ManageConfig` (fires in the daily review CLI workflow when `bars_since >= max_holding_days`). This feature is a **separate soft nudge** — a UI badge visible at all times in the Book page. It does NOT trigger any automatic close. It uses its own config fields (`time_stop_days` and `time_stop_min_r`) so thresholds can differ from `max_holding_days`.
+
+**Tech Stack:** Python/FastAPI backend, React 18/TypeScript frontend
+
+---
+
+## Implementation status - 2026-05-04
+
+Status: implemented on `codex/time-stop-nudge`.
+
+Branch stack:
+
+- Branch: `codex/time-stop-nudge`
+- Base: `codex/concentration-warning`
+- PR: pending
+
+What changed:
+
+- Added `time_stop_days` and `time_stop_min_r` manage settings with defaults of 15 days and 0.5R.
+- Added `days_open` and `time_stop_warning` to portfolio position metrics.
+- Daily review position rows now receive the same stale-trade warning payload.
+- Book position rows and Today action rows show a small amber stale-trade badge when the warning is active.
+- Strategy advanced manage settings expose the two soft time-stop thresholds.
+- Local persistence mode mirrors the same derived fields.
+
+Validation run:
+
+- `pytest tests/api/test_time_stop_nudge.py -v`
+- `cd web-ui && npx vitest run src/components/domain/workspace/PortfolioTable.test.tsx`
+- `cd web-ui && npm run typecheck`
+
+---
+
+## File map
+
+| File | Change |
+|---|---|
+| `src/swing_screener/portfolio/state.py` | Add `time_stop_days: int` and `time_stop_min_r: float` to `ManageConfig` |
+| `config/defaults.yaml` | Add `time_stop_days: 15` and `time_stop_min_r: 0.5` under `manage:` |
+| `api/models/portfolio.py` | Add `days_open: int` and `time_stop_warning: bool` to `PositionWithMetrics` |
+| `api/services/portfolio_service.py` | Compute `days_open` and `time_stop_warning` in `_build_position_with_metrics()` |
+| `web-ui/src/features/portfolio/api.ts` | Add `daysOpen`, `timeStopWarning` to `PositionWithMetricsApiResponse` and `PositionWithMetrics`; transform in `transformPositionWithMetrics()` |
+| `web-ui/src/i18n/messages.en.ts` | Add `book.positions.timeStopWarning` key |
+| `web-ui/src/components/domain/portfolio/PositionRow.tsx` (or wherever position rows render) | Render badge when `timeStopWarning` is true |
+| `tests/api/test_time_stop_nudge.py` | Backend tests |
+
+---
+
+### Task 1: Backend — config fields, model fields, and computed values
+
+**Files:**
+- Modify: `src/swing_screener/portfolio/state.py`
+- Modify: `config/defaults.yaml`
+- Modify: `api/models/portfolio.py`
+- Modify: `api/services/portfolio_service.py`
+- Test: `tests/api/test_time_stop_nudge.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/api/test_time_stop_nudge.py`:
+
+```python
+"""Tests for the time-stop nudge feature."""
+import json
+import pytest
+from datetime import date, timedelta
+from fastapi.testclient import TestClient
+from api.main import app
+import api.dependencies as deps
+
+def make_position(entry_date_str: str, r_now_approx: float = 0.0) -> dict:
+    """Build a minimal open position dict. exit_price=None => open."""
+    entry_price = 100.0
+    stop_price = 90.0  # 1R = 10
+    shares = 10
+    # Make current_price reproduce r_now_approx: current = entry + r_now * (entry - stop)
+    current_price = entry_price + r_now_approx * (entry_price - stop_price)
+    return {
+        "position_id": "POS-TST-001",
+        "ticker": "TEST",
+        "status": "open",
+        "entry_date": entry_date_str,
+        "entry_price": entry_price,
+        "stop_price": stop_price,
+        "shares": shares,
+        "initial_risk": 100.0,
+        "current_price": current_price,
+        "notes": "",
+        "tags": [],
+    }
+
+@pytest.fixture
+def client_with_old_flat_position(tmp_path, monkeypatch):
+    """Position open 20 days at 0R — should trigger warning with defaults."""
+    entry_date = (date.today() - timedelta(days=20)).isoformat()
+    pos = make_position(entry_date, r_now_approx=0.0)
+    positions_file = tmp_path / "positions.json"
+    orders_file = tmp_path / "orders.json"
+    positions_file.write_text(json.dumps({"asof": date.today().isoformat(), "positions": [pos]}))
+    orders_file.write_text(json.dumps({"asof": date.today().isoformat(), "orders": []}))
+    monkeypatch.setattr(deps, "_positions_path", positions_file)
+    monkeypatch.setattr(deps, "_orders_path", orders_file)
+    return TestClient(app)
+
+@pytest.fixture
+def client_with_new_profitable_position(tmp_path, monkeypatch):
+    """Position open 5 days at 2R — should NOT trigger warning."""
+    entry_date = (date.today() - timedelta(days=5)).isoformat()
+    pos = make_position(entry_date, r_now_approx=2.0)
+    positions_file = tmp_path / "positions.json"
+    orders_file = tmp_path / "orders.json"
+    positions_file.write_text(json.dumps({"asof": date.today().isoformat(), "positions": [pos]}))
+    orders_file.write_text(json.dumps({"asof": date.today().isoformat(), "orders": []}))
+    monkeypatch.setattr(deps, "_positions_path", positions_file)
+    monkeypatch.setattr(deps, "_orders_path", orders_file)
+    return TestClient(app)
+
+def test_position_includes_days_open(client_with_old_flat_position):
+    response = client_with_old_flat_position.get("/api/portfolio/positions")
+    assert response.status_code == 200
+    positions = response.json()["positions"]
+    assert len(positions) == 1
+    assert "days_open" in positions[0]
+    assert positions[0]["days_open"] >= 20
+
+def test_time_stop_warning_fires_for_old_flat_position(client_with_old_flat_position):
+    response = client_with_old_flat_position.get("/api/portfolio/positions")
+    positions = response.json()["positions"]
+    assert positions[0]["time_stop_warning"] is True
+
+def test_time_stop_warning_absent_for_new_profitable_position(client_with_new_profitable_position):
+    response = client_with_new_profitable_position.get("/api/portfolio/positions")
+    positions = response.json()["positions"]
+    assert positions[0]["time_stop_warning"] is False
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+```bash
+pytest tests/api/test_time_stop_nudge.py -v
+```
+Expected: FAIL — `days_open` not in response
+
+- [ ] **Step 3: Add config fields to ManageConfig**
+
+In `src/swing_screener/portfolio/state.py`, in class `ManageConfig` (around line 50):
+
+```python
+# Existing fields:
+max_holding_days: int = 20  # time exit (hard close in daily review workflow)
+
+# Add below:
+time_stop_days: int = 15   # soft nudge threshold (UI badge only — no automatic close)
+time_stop_min_r: float = 0.5  # minimum R to avoid nudge even after time_stop_days
+```
+
+- [ ] **Step 4: Add config defaults**
+
+In `config/defaults.yaml`, under the `manage:` section, add after `max_holding_days`:
+
+```yaml
+manage:
+  # ... existing keys ...
+  max_holding_days: 20
+  time_stop_days: 15       # days open before soft nudge appears
+  time_stop_min_r: 0.5     # nudge suppressed when r_now >= this value
+```
+
+- [ ] **Step 5: Add fields to PositionWithMetrics model**
+
+In `api/models/portfolio.py`, in class `PositionWithMetrics` (after `total_risk`):
+
+```python
+days_open: int = Field(default=0, description="Calendar days since entry_date")
+time_stop_warning: bool = Field(default=False, description="True when trade is stale and underperforming")
+```
+
+- [ ] **Step 6: Compute fields in _build_position_with_metrics**
+
+In `api/services/portfolio_service.py`, in `_build_position_with_metrics()`, after the `r_now` calculation and before the `return PositionWithMetrics(...)`:
+
+```python
+from datetime import date as _date
+
+# Compute days_open
+days_open = 0
+entry_date_str = str(position.get("entry_date") or "")
+if entry_date_str:
+    try:
+        entry_dt = _date.fromisoformat(entry_date_str)
+        days_open = (_date.today() - entry_dt).days
+    except ValueError:
+        pass
+
+# Read time-stop config (defaults from ManageConfig if not in strategy config)
+from swing_screener.portfolio.state import ManageConfig as _ManageConfig
+_manage_defaults = _ManageConfig()
+from swing_screener.settings import get_settings_manager as _get_sm
+_sm_manage = getattr(getattr(_get_sm().get(), "manage", None), "__dict__", {})
+time_stop_days = int(_sm_manage.get("time_stop_days", _manage_defaults.time_stop_days))
+time_stop_min_r = float(_sm_manage.get("time_stop_min_r", _manage_defaults.time_stop_min_r))
+r_now_val = calculate_r_now(state_position, current_price_for_metrics)
+time_stop_warning = (
+    state_position.status == "open"
+    and days_open >= time_stop_days
+    and r_now_val < time_stop_min_r
+)
+```
+
+Then in the `return PositionWithMetrics(...)` call, add:
+```python
+days_open=days_open,
+time_stop_warning=time_stop_warning,
+```
+
+Note: `r_now_val` is already computed above — remove the duplicate `r_now=calculate_r_now(...)` in the return and use `r_now=r_now_val`.
+
+- [ ] **Step 7: Run tests**
+
+```bash
+pytest tests/api/test_time_stop_nudge.py -v
+```
+Expected: 3 PASSED
+
+- [ ] **Step 8: Run full backend suite**
+
+```bash
+pytest -q
+```
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/swing_screener/portfolio/state.py config/defaults.yaml api/models/portfolio.py api/services/portfolio_service.py tests/api/test_time_stop_nudge.py
+git commit -m "feat: add days_open and time_stop_warning to position metrics"
+```
+
+---
+
+### Task 2: Frontend — display time stop warning badge
+
+**Files:**
+- Modify: `web-ui/src/features/portfolio/api.ts`
+- Modify: `web-ui/src/i18n/messages.en.ts`
+- Identify and modify the position row component (search `web-ui/src/` for where `rNow` or `ticker` is rendered in a list — likely `web-ui/src/components/domain/portfolio/`)
+
+- [ ] **Step 1: Find the position row component**
+
+```bash
+grep -rn "rNow\|time_stop\|timeStop" web-ui/src/components/domain/portfolio/ | head -20
+```
+
+Note which file renders individual position rows.
+
+- [ ] **Step 2: Add fields to frontend types**
+
+In `web-ui/src/features/portfolio/api.ts`:
+
+In `PositionWithMetricsApiResponse` interface (after `fees_eur`):
+```typescript
+days_open?: number;
+time_stop_warning?: boolean;
+```
+
+In `PositionWithMetrics` interface (after `feesEur`):
+```typescript
+daysOpen: number;
+timeStopWarning: boolean;
+```
+
+In `transformPositionWithMetrics()` (after `feesEur: data.fees_eur ?? 0`):
+```typescript
+daysOpen: data.days_open ?? 0,
+timeStopWarning: data.time_stop_warning ?? false,
+```
+
+- [ ] **Step 3: Add i18n string**
+
+In `web-ui/src/i18n/messages.en.ts`, locate the `book` section (search for `book:`) and add in the positions subsection:
+
+```typescript
+timeStopWarning: 'Stale trade — consider closing or setting a reason to hold',
+timeStopBadge: 'Stale',
+```
+
+- [ ] **Step 4: Write a failing test**
+
+Find the position row component filename from Step 1 (e.g. `PositionRow.tsx`). Create a test file next to it (e.g. `PositionRow.test.tsx`):
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '@/test/utils';
+import { t } from '@/i18n/t';
+// Adjust import path based on actual component found in Step 1:
+import PositionRow from './PositionRow';
+import type { PositionWithMetrics } from '@/features/portfolio/api';
+
+function makePosition(overrides: Partial<PositionWithMetrics> = {}): PositionWithMetrics {
+  return {
+    ticker: 'TEST',
+    status: 'open',
+    entryDate: '2026-01-01',
+    entryPrice: 100,
+    stopPrice: 90,
+    shares: 10,
+    pnl: 0,
+    pnlPercent: 0,
+    rNow: 0,
+    entryValue: 1000,
+    currentValue: 1000,
+    perShareRisk: 10,
+    totalRisk: 100,
+    feesEur: 0,
+    daysOpen: 0,
+    timeStopWarning: false,
+    notes: '',
+    tags: [],
+    ...overrides,
+  };
+}
+
+describe('PositionRow — time stop warning badge', () => {
+  it('does not show warning badge when timeStopWarning is false', () => {
+    renderWithProviders(<PositionRow position={makePosition({ timeStopWarning: false })} />);
+    expect(screen.queryByText(t('book.positions.timeStopBadge'))).not.toBeInTheDocument();
+  });
+
+  it('shows warning badge when timeStopWarning is true', () => {
+    renderWithProviders(<PositionRow position={makePosition({ timeStopWarning: true })} />);
+    expect(screen.getByText(t('book.positions.timeStopBadge'))).toBeInTheDocument();
+  });
+
+  it('badge has accessible title with full warning text', () => {
+    renderWithProviders(<PositionRow position={makePosition({ timeStopWarning: true })} />);
+    const badge = screen.getByTitle(t('book.positions.timeStopWarning'));
+    expect(badge).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 5: Run to confirm failure**
+
+```bash
+cd web-ui && npx vitest run src/components/domain/portfolio/PositionRow.test.tsx
+```
+Expected: FAIL — component renders without badge
+
+- [ ] **Step 6: Add the warning badge to the position row component**
+
+In the position row component found in Step 1, add the badge conditionally. The badge should be:
+- Small, amber/yellow coloured (indicates warning, not critical error)
+- Shown next to the ticker or position ID
+- Has `title` attribute for the full tooltip text
+
+```tsx
+{position.timeStopWarning && (
+  <span
+    className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300"
+    title={t('book.positions.timeStopWarning')}
+  >
+    {t('book.positions.timeStopBadge')}
+  </span>
+)}
+```
+
+- [ ] **Step 7: Run tests**
+
+```bash
+cd web-ui && npx vitest run src/components/domain/portfolio/PositionRow.test.tsx
+```
+Expected: 3 PASSED
+
+- [ ] **Step 8: Run full suite**
+
+```bash
+pytest -q && cd web-ui && npx vitest run
+```
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add web-ui/src/features/portfolio/api.ts web-ui/src/i18n/messages.en.ts web-ui/src/components/domain/portfolio/
+git commit -m "feat: show time stop warning badge on stale position rows"
+```

--- a/docs/superpowers/plans/2026-05-04-feature-7-watchlist-pipeline.md
+++ b/docs/superpowers/plans/2026-05-04-feature-7-watchlist-pipeline.md
@@ -1,0 +1,54 @@
+# Watchlist Pipeline View — Implementation Plan
+
+> Read `docs/superpowers/plans/handover-context.md` before starting.
+
+**Goal:** Turn the watchlist from a static symbol list into a ranked pipeline that shows which names are closest to triggering, with enough context to review them quickly from Research and Daily Review.
+
+**Architecture:** Keep persisted watchlist storage unchanged and add a dedicated enrichment layer in the API. `WatchlistService` reads raw watchlist items from `WatchlistRepository`, fetches recent OHLCV with the existing market-data provider, computes the breakout trigger using the existing selection signal board, derives `distance_to_trigger_pct`, and returns a richer `WatchlistItemView`. Daily Review consumes the same service and filters names within 3% of the trigger zone into a new `watchlist_near_trigger` section. The frontend adds a Watchlist tab in Research and a compact near-trigger section in Today.
+
+**Tech Stack:** Python/FastAPI backend, React 18/TypeScript frontend, existing OHLCV provider and screener signal logic
+
+---
+
+## Implementation status - 2026-05-04
+
+Status: implemented on `codex/watchlist-pipeline`.
+
+Branch stack:
+
+- Branch: `codex/watchlist-pipeline`
+- Base: `codex/time-stop-nudge`
+- PR: pending
+
+What changed:
+
+- Added `WatchlistService` to enrich watchlist rows with `current_price`, `signal_trigger_price`, `distance_to_trigger_pct`, `signal`, `last_bar`, and a 5-bar `price_history` sparkline payload.
+- Extended the watchlist API response shape with `WatchlistItemView` while keeping `watchlist.json` persistence untouched.
+- Added a Research > Watchlist tab with a pipeline table sorted by distance to trigger and a 5-day sparkline.
+- Added a Daily Review section `watchlist_near_trigger` surfaced above new candidates for names within 3% of the buy zone.
+- Added focused backend and frontend coverage for the enrichment path, Daily Review mapping, and the new UI panel.
+
+Validation run:
+
+- `pytest tests/api/test_watchlist_service.py tests/api/test_daily_review_service.py tests/api/test_watchlist_endpoints.py`
+- `cd web-ui && npm test -- --run src/components/domain/watchlist/WatchlistPipelinePanel.test.tsx src/features/dailyReview/types.test.ts src/pages/Today.test.tsx src/features/watchlist/hooks.test.tsx`
+- `cd web-ui && npm run typecheck`
+
+---
+
+## File map
+
+| File | Change |
+|---|---|
+| `api/models/watchlist.py` | Add `WatchlistItemView` with enriched trigger-distance fields |
+| `api/services/watchlist_service.py` | New enrichment service for pipeline ordering and sparkline history |
+| `api/routers/watchlist.py` | Serve enriched watchlist items via `WatchlistService` |
+| `api/models/daily_review.py` | Add `watchlist_near_trigger` to the Daily Review payload |
+| `api/services/daily_review_service.py` | Pull near-trigger watchlist names into Today |
+| `web-ui/src/components/domain/watchlist/WatchlistPipelinePanel.tsx` | New Research watchlist pipeline panel |
+| `web-ui/src/pages/Research.tsx` | Add Watchlist tab and ticker handoff into analysis |
+| `web-ui/src/pages/Today.tsx` | Render the near-trigger watchlist section above candidates |
+| `web-ui/src/features/watchlist/types.ts` | Extend watchlist client types with enrichment fields |
+| `web-ui/src/features/dailyReview/types.ts` | Map the new Daily Review watchlist section |
+| `tests/api/test_watchlist_service.py` | Backend enrichment and sorting coverage |
+| `web-ui/src/components/domain/watchlist/WatchlistPipelinePanel.test.tsx` | Frontend watchlist panel coverage |

--- a/docs/superpowers/plans/handover-context.md
+++ b/docs/superpowers/plans/handover-context.md
@@ -4,17 +4,18 @@ Read this before picking up any feature plan. It describes the codebase conventi
 
 ---
 
-## Current implementation status - 2026-05-03
+## Current implementation status - 2026-05-04
 
-The 2026-05-03 plan work is being shipped as sequential stacked PRs:
+Tier 1 (all 6 features) is in progress as sequential stacked PRs:
 
 | Feature | Branch | Base | PR | Status |
 |---|---|---|---|---|
-| Feature 1 - Trade tagging | `codex/trade-tagging` | `main` | https://github.com/matteolongo/swing_screener/pull/232 | Draft, implemented |
-| Feature 2 - Edge breakdown | `codex/edge-breakdown` | `codex/trade-tagging` | https://github.com/matteolongo/swing_screener/pull/233 | Draft, implemented |
-| Feature 3 - Account equity auto-update | `codex/account-equity` | `codex/edge-breakdown` | https://github.com/matteolongo/swing_screener/pull/234 | Draft, implemented |
-| Feature 4 - Earnings proximity warning | `codex/earnings-warning` | `codex/account-equity` | https://github.com/matteolongo/swing_screener/pull/235 | Draft, implemented |
-| Feature 5 - Concentration warning | `codex/concentration-warning` | `codex/earnings-warning` | https://github.com/matteolongo/swing_screener/pull/236 | Draft, implemented |
+| Feature 1 - Trade tagging | `codex/trade-tagging` | `main` | https://github.com/matteolongo/swing_screener/pull/232 | Draft, fully implemented |
+| Feature 2 - Edge breakdown | `codex/edge-breakdown` | `codex/trade-tagging` | https://github.com/matteolongo/swing_screener/pull/233 | Draft, fully implemented |
+| Feature 3 - Account equity auto-update | `codex/account-equity` | `codex/edge-breakdown` | https://github.com/matteolongo/swing_screener/pull/234 | Draft, fully implemented (incl. Settings toggle) |
+| Feature 4 - Earnings proximity warning | `codex/earnings-warning` | `codex/account-equity` | https://github.com/matteolongo/swing_screener/pull/235 | Draft, fully implemented (incl. cache-hit test) |
+| Feature 5 - Concentration warning | `codex/concentration-warning` | `codex/earnings-warning` | https://github.com/matteolongo/swing_screener/pull/236 | Draft, fully implemented (incl. order modal warning) |
+| Feature 6 - Time stop nudge | `codex/time-stop-nudge` | `codex/concentration-warning` | pending | Implemented locally |
 
 Review agents should review the PRs in order. Each branch intentionally builds on the previous one, so diffs should be compared against the listed base branch, not always against `main`.
 
@@ -22,16 +23,14 @@ Known local dirty files that were not part of this work and should not be includ
 
 - `config/intelligence.yaml`
 - `data/screener_history.json`
-- `docs/superpowers/plans/2026-05-03-feature-3-account-equity-auto-update.md`
-- `docs/superpowers/plans/2026-05-03-feature-6-time-stop-nudge.md`
 
 Validation already run during implementation:
 
 - Feature 1: backend trade tagging test, frontend typecheck, focused modal/journal tests, frontend suite during the feature work.
 - Feature 2: focused `EdgeBreakdownTable` test and frontend suite during the feature work.
-- Feature 3: `pytest tests/api/test_account_equity.py -v`, `pytest -q`, `cd web-ui && npm run typecheck`, `cd web-ui && npx vitest run`.
-- Feature 4: `pytest tests/api/test_earnings_proximity.py -v` including cache-hit coverage, `pytest -q`, `cd web-ui && npm run typecheck`, `cd web-ui && npx vitest run`.
-- Feature 5: `pytest tests/api/test_concentration.py -v`, focused concentration/order review frontend tests, `pytest -q`, `cd web-ui && npm run typecheck`, `cd web-ui && npx vitest run`.
+- Feature 3: `pytest tests/api/test_account_equity.py -v`, `pytest -q`, `cd web-ui && npm run typecheck`, `cd web-ui && npx vitest run src/components/domain/strategy/EnhancedRiskCard.test.tsx`, `cd web-ui && npx vitest run`.
+- Feature 4: `pytest tests/api/test_earnings_proximity.py -v` (includes cache-hit coverage), `pytest -q`, `cd web-ui && npm run typecheck`, `cd web-ui && npx vitest run`.
+- Feature 5: `pytest tests/api/test_concentration.py -v`, `cd web-ui && npx vitest run src/components/domain/portfolio/ConcentrationBar.test.tsx`, focused order review frontend tests, `pytest -q`, `cd web-ui && npm run typecheck`, `cd web-ui && npx vitest run`.
 
 ## What this app is
 
@@ -133,4 +132,6 @@ Use `locked_read_json` / `locked_write_json` from `api/utils/file_lock.py` — n
 
 ## Active branch
 
-Current stacked feature work lives on `codex/account-equity`, based on `codex/edge-breakdown`, which is based on `codex/trade-tagging`.
+Current stacked feature work is on `codex/time-stop-nudge`. Tier 1 is complete once PR #6 is merged.
+
+Next work should start Tier 2 planning from Feature 7 — Watchlist pipeline.

--- a/docs/superpowers/plans/handover-context.md
+++ b/docs/superpowers/plans/handover-context.md
@@ -6,7 +6,7 @@ Read this before picking up any feature plan. It describes the codebase conventi
 
 ## Current implementation status - 2026-05-04
 
-Tier 1 (all 6 features) is in progress as sequential stacked PRs:
+Tier 1 is complete locally and Tier 2 has started as sequential stacked PRs:
 
 | Feature | Branch | Base | PR | Status |
 |---|---|---|---|---|
@@ -16,12 +16,15 @@ Tier 1 (all 6 features) is in progress as sequential stacked PRs:
 | Feature 4 - Earnings proximity warning | `codex/earnings-warning` | `codex/account-equity` | https://github.com/matteolongo/swing_screener/pull/235 | Draft, fully implemented (incl. cache-hit test) |
 | Feature 5 - Concentration warning | `codex/concentration-warning` | `codex/earnings-warning` | https://github.com/matteolongo/swing_screener/pull/236 | Draft, fully implemented (incl. order modal warning) |
 | Feature 6 - Time stop nudge | `codex/time-stop-nudge` | `codex/concentration-warning` | pending | Implemented locally |
+| Feature 7 - Watchlist pipeline | `codex/watchlist-pipeline` | `codex/time-stop-nudge` | pending | Implemented locally |
 
 Review agents should review the PRs in order. Each branch intentionally builds on the previous one, so diffs should be compared against the listed base branch, not always against `main`.
 
 Known local dirty files that were not part of this work and should not be included unless explicitly requested:
 
 - `config/intelligence.yaml`
+- `config/strategies.yaml`
+- `config/user.yaml`
 - `data/screener_history.json`
 
 Validation already run during implementation:
@@ -31,6 +34,8 @@ Validation already run during implementation:
 - Feature 3: `pytest tests/api/test_account_equity.py -v`, `pytest -q`, `cd web-ui && npm run typecheck`, `cd web-ui && npx vitest run src/components/domain/strategy/EnhancedRiskCard.test.tsx`, `cd web-ui && npx vitest run`.
 - Feature 4: `pytest tests/api/test_earnings_proximity.py -v` (includes cache-hit coverage), `pytest -q`, `cd web-ui && npm run typecheck`, `cd web-ui && npx vitest run`.
 - Feature 5: `pytest tests/api/test_concentration.py -v`, `cd web-ui && npx vitest run src/components/domain/portfolio/ConcentrationBar.test.tsx`, focused order review frontend tests, `pytest -q`, `cd web-ui && npm run typecheck`, `cd web-ui && npx vitest run`.
+- Feature 6: `pytest tests/api/test_time_stop_nudge.py -v`, `cd web-ui && npx vitest run src/components/domain/workspace/PortfolioTable.test.tsx`, `cd web-ui && npm run typecheck`.
+- Feature 7: `pytest tests/api/test_watchlist_service.py tests/api/test_daily_review_service.py tests/api/test_watchlist_endpoints.py`, `cd web-ui && npm test -- --run src/components/domain/watchlist/WatchlistPipelinePanel.test.tsx src/features/dailyReview/types.test.ts src/pages/Today.test.tsx src/features/watchlist/hooks.test.tsx`, `cd web-ui && npm run typecheck`.
 
 ## What this app is
 
@@ -132,6 +137,6 @@ Use `locked_read_json` / `locked_write_json` from `api/utils/file_lock.py` — n
 
 ## Active branch
 
-Current stacked feature work is on `codex/time-stop-nudge`. Tier 1 is complete once PR #6 is merged.
+Current stacked feature work is on `codex/watchlist-pipeline`. Tier 2 has started on top of the Tier 1 stack.
 
-Next work should start Tier 2 planning from Feature 7 — Watchlist pipeline.
+Next work should continue Tier 2 from Feature 8 — Volume quality signal.

--- a/docs/superpowers/specs/2026-05-03-swing-trading-feature-roadmap.md
+++ b/docs/superpowers/specs/2026-05-03-swing-trading-feature-roadmap.md
@@ -18,7 +18,7 @@ Features are grouped into tiers. Ship all of Tier 1 before starting Tier 2.
 
 ## Implementation status - 2026-05-04
 
-Tier 1 is being shipped as sequential stacked PRs:
+Tier 1 is implemented locally and Tier 2 has started as sequential stacked PRs:
 
 | # | Feature | Branch | Base | PR | Status |
 |---|---|---|---|---|---|
@@ -28,6 +28,7 @@ Tier 1 is being shipped as sequential stacked PRs:
 | 4 | Earnings warning | `codex/earnings-warning` | `codex/account-equity` | https://github.com/matteolongo/swing_screener/pull/235 | Draft, implemented |
 | 5 | Concentration warning | `codex/concentration-warning` | `codex/earnings-warning` | https://github.com/matteolongo/swing_screener/pull/236 | Draft, implemented |
 | 6 | Time stop nudge | `codex/time-stop-nudge` | `codex/concentration-warning` | pending | Implemented locally |
+| 7 | Watchlist pipeline view | `codex/watchlist-pipeline` | `codex/time-stop-nudge` | pending | Implemented locally |
 
 Review stacked PRs in order and compare each PR against its listed base branch.
 

--- a/docs/superpowers/specs/2026-05-03-swing-trading-feature-roadmap.md
+++ b/docs/superpowers/specs/2026-05-03-swing-trading-feature-roadmap.md
@@ -27,7 +27,7 @@ Tier 1 is being shipped as sequential stacked PRs:
 | 3 | Account equity auto-update | `codex/account-equity` | `codex/edge-breakdown` | https://github.com/matteolongo/swing_screener/pull/234 | Draft, implemented |
 | 4 | Earnings warning | `codex/earnings-warning` | `codex/account-equity` | https://github.com/matteolongo/swing_screener/pull/235 | Draft, implemented |
 | 5 | Concentration warning | `codex/concentration-warning` | `codex/earnings-warning` | https://github.com/matteolongo/swing_screener/pull/236 | Draft, implemented |
-| 6 | Time stop nudge | - | - | - | Plan exists, not implemented |
+| 6 | Time stop nudge | `codex/time-stop-nudge` | `codex/concentration-warning` | pending | Implemented locally |
 
 Review stacked PRs in order and compare each PR against its listed base branch.
 
@@ -316,19 +316,21 @@ The screener works on daily bars. A daily breakout that contradicts the weekly t
 
 ## Implementation order summary
 
-| # | Feature | Tier | Designer | UX | Dev | Value delivered |
-|---|---------|------|----------|----|-----|----------------|
-| 1 | Trade tagging | 1 | Tag taxonomy | Close flow | Model + filter | Queryable journal |
-| 2 | Performance by setup | 1 | Stats layout | Empty state | Client aggregation | See your edge |
-| 3 | Account equity auto-update | 1 | Settings UI | Mode toggle | P&L calc | Accurate sizing |
-| 4 | Earnings warning | 1 | Warning banner | Non-blocking | yfinance fetch | Avoid earnings traps |
-| 5 | Concentration warning | 1 | Portfolio section | Order warning | Country grouping | Prevent correlated bets |
-| 6 | Time stop nudge | 1 | Badge design | Nudge copy | Metrics flag | Kill dead capital |
-| 7 | Watchlist pipeline | 2 | Table column | Sort + sparkline | Distance calc | Spot setups early |
-| 8 | Volume quality | 2 | Signal indicator | Caution note | Volume ratio | Better entry timing |
-| 9 | Liquidity filter | 2 | Settings field | Warning copy | Pipeline filter | Avoid illiquid names |
-| 10 | Partial exits | 2 | Close modal | Share picker | Position events | Scale-out capability |
-| 11 | Regime performance | 3 | Stats section | — | Regime backfill | Size to conditions |
-| 12 | FX-adjusted R | 3 | Secondary display | Tooltip | FX rate fetch | True R visibility |
-| 13 | Trail customization | 3 | Method selector | Live preview | Branch logic | Setup-specific trails |
-| 14 | MTF trend filter | 3 | Filter toggle | Indicator chip | Weekly resample | Fewer false signals |
+Last updated: 2026-05-04
+
+| # | Feature | Tier | Status | Value delivered |
+|---|---------|------|--------|----------------|
+| 1 | Trade tagging | 1 | ✅ Done — `codex/trade-tagging` / PR #232 | Queryable journal |
+| 2 | Performance by setup | 1 | ✅ Done — `codex/edge-breakdown` / PR #233 | See your edge |
+| 3 | Account equity auto-update | 1 | ✅ Done — `codex/account-equity` / PR #234 | Accurate sizing |
+| 4 | Earnings warning | 1 | ✅ Done — `codex/earnings-warning` / PR #235 | Avoid earnings traps |
+| 5 | Concentration warning | 1 | ✅ Done — `codex/concentration-warning` / PR #236 | Prevent correlated bets |
+| 6 | Time stop nudge | 1 | ✅ Done — `codex/time-stop-nudge` / PR pending | Kill dead capital |
+| 7 | Watchlist pipeline | 2 | 🔲 No plan yet | Spot setups early |
+| 8 | Volume quality | 2 | 🔲 No plan yet | Better entry timing |
+| 9 | Liquidity filter | 2 | 🔲 No plan yet | Avoid illiquid names |
+| 10 | Partial exits | 2 | 🔲 No plan yet | Scale-out capability |
+| 11 | Regime performance | 3 | 🔲 No plan yet | Size to conditions |
+| 12 | FX-adjusted R | 3 | 🔲 No plan yet | True R visibility |
+| 13 | Trail customization | 3 | 🔲 No plan yet | Setup-specific trails |
+| 14 | MTF trend filter | 3 | 🔲 No plan yet | Fewer false signals |

--- a/src/swing_screener/portfolio/state.py
+++ b/src/swing_screener/portfolio/state.py
@@ -48,6 +48,8 @@ class ManageConfig:
     trail_after_R: float = 2.0
     sma_buffer_pct: float = 0.005  # buffer under SMA (0.5%)
     max_holding_days: int = 20  # time exit
+    time_stop_days: int = 15  # soft stale-trade nudge threshold
+    time_stop_min_r: float = 0.5  # suppress nudge once trade has made this much progress
     benchmark: str = "SPY"
 
 

--- a/src/swing_screener/strategy/config.py
+++ b/src/swing_screener/strategy/config.py
@@ -42,6 +42,8 @@ def build_manage_config(strategy: dict) -> ManageConfig:
         trail_sma=raw.get("trail_sma", 20),
         sma_buffer_pct=raw.get("sma_buffer_pct", 0.005),
         max_holding_days=raw.get("max_holding_days", 20),
+        time_stop_days=raw.get("time_stop_days", 15),
+        time_stop_min_r=raw.get("time_stop_min_r", 0.5),
         benchmark=raw.get("benchmark", "SPY"),
     )
 

--- a/src/swing_screener/strategy/storage.py
+++ b/src/swing_screener/strategy/storage.py
@@ -135,6 +135,17 @@ def _normalize_document(doc: dict[str, Any]) -> tuple[dict[str, Any], bool]:
                 filt["currencies"] = ["USD", "EUR"]
                 dirty = True
 
+        manage = strategy.get("manage")
+        default_manage = defaults.get("manage", {})
+        if not isinstance(manage, dict):
+            strategy["manage"] = deepcopy(default_manage if isinstance(default_manage, dict) else {})
+            dirty = True
+        elif isinstance(default_manage, dict):
+            for key, value in default_manage.items():
+                if manage.get(key) is None:
+                    manage[key] = deepcopy(value)
+                    dirty = True
+
         market_intelligence = strategy.get("market_intelligence")
         if not isinstance(market_intelligence, dict):
             strategy["market_intelligence"] = deepcopy(market_intelligence_default)

--- a/tests/api/test_daily_review_service.py
+++ b/tests/api/test_daily_review_service.py
@@ -430,6 +430,50 @@ def test_generate_daily_review_no_candidates(mock_portfolio_service, tmp_path):
     assert review.summary.total_positions == 3
 
 
+def test_generate_daily_review_includes_watchlist_near_trigger(
+    mock_screener_service,
+    mock_portfolio_service,
+    tmp_path,
+):
+    watchlist_service = Mock()
+    watchlist_service.list_items.return_value = [
+        {
+            "ticker": "ASML",
+            "watched_at": "2026-05-01T10:00:00Z",
+            "watch_price": 660.0,
+            "currency": "EUR",
+            "source": "screener",
+            "current_price": 671.0,
+            "signal_trigger_price": 680.0,
+            "distance_to_trigger_pct": -1.32,
+            "price_history": [],
+        },
+        {
+            "ticker": "SAP",
+            "watched_at": "2026-05-01T10:00:00Z",
+            "watch_price": 250.0,
+            "currency": "EUR",
+            "source": "screener",
+            "current_price": 260.0,
+            "signal_trigger_price": 270.0,
+            "distance_to_trigger_pct": -3.7,
+            "price_history": [],
+        },
+    ]
+
+    service = DailyReviewService(
+        mock_screener_service,
+        mock_portfolio_service,
+        watchlist_service=watchlist_service,
+        data_dir=tmp_path,
+    )
+
+    review = service.generate_daily_review(top_n=10)
+
+    assert [item.ticker for item in review.watchlist_near_trigger] == ["ASML"]
+    assert review.summary.watchlist_near_trigger == 1
+
+
 def test_generate_daily_review_survives_stop_suggestion_error(
     mock_screener_service,
     mock_portfolio_service,

--- a/tests/api/test_time_stop_nudge.py
+++ b/tests/api/test_time_stop_nudge.py
@@ -1,0 +1,84 @@
+"""Tests for stale-position time-stop nudges."""
+from __future__ import annotations
+
+import json
+from datetime import date, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+
+import api.dependencies as deps
+from api.main import app
+
+
+class FakeStrategyRepo:
+    def get_active_strategy(self) -> dict:
+        return {"manage": {"time_stop_days": 15, "time_stop_min_r": 0.5}}
+
+
+def make_position(entry_date: str, r_now: float) -> dict:
+    entry_price = 100.0
+    stop_price = 90.0
+    return {
+        "position_id": "POS-TIME-001",
+        "ticker": "TEST",
+        "status": "open",
+        "entry_date": entry_date,
+        "entry_price": entry_price,
+        "stop_price": stop_price,
+        "shares": 10,
+        "initial_risk": None,
+        "current_price": entry_price + r_now * (entry_price - stop_price),
+        "notes": "",
+        "tags": [],
+    }
+
+
+@pytest.fixture
+def client_with_positions(tmp_path, monkeypatch):
+    positions_file = tmp_path / "positions.json"
+    orders_file = tmp_path / "orders.json"
+
+    def write_positions(positions: list[dict]) -> None:
+        positions_file.write_text(
+            json.dumps({"asof": date.today().isoformat(), "positions": positions}),
+            encoding="utf-8",
+        )
+        orders_file.write_text(json.dumps({"asof": date.today().isoformat(), "orders": []}), encoding="utf-8")
+
+    monkeypatch.setattr(deps, "_positions_path", positions_file)
+    monkeypatch.setattr(deps, "_orders_path", orders_file)
+    app.dependency_overrides[deps.get_strategy_repo] = lambda: FakeStrategyRepo()
+    yield TestClient(app), write_positions
+    app.dependency_overrides.pop(deps.get_strategy_repo, None)
+
+
+def test_position_includes_days_open(client_with_positions):
+    client, write_positions = client_with_positions
+    write_positions([make_position((date.today() - timedelta(days=20)).isoformat(), r_now=0.0)])
+
+    response = client.get("/api/portfolio/positions")
+
+    assert response.status_code == 200
+    position = response.json()["positions"][0]
+    assert position["days_open"] >= 20
+
+
+def test_time_stop_warning_fires_for_old_flat_position(client_with_positions):
+    client, write_positions = client_with_positions
+    write_positions([make_position((date.today() - timedelta(days=20)).isoformat(), r_now=0.0)])
+
+    response = client.get("/api/portfolio/positions")
+
+    assert response.status_code == 200
+    assert response.json()["positions"][0]["time_stop_warning"] is True
+
+
+def test_time_stop_warning_absent_for_new_profitable_position(client_with_positions):
+    client, write_positions = client_with_positions
+    write_positions([make_position((date.today() - timedelta(days=5)).isoformat(), r_now=2.0)])
+
+    response = client.get("/api/portfolio/positions")
+
+    assert response.status_code == 200
+    assert response.json()["positions"][0]["time_stop_warning"] is False

--- a/tests/api/test_watchlist_service.py
+++ b/tests/api/test_watchlist_service.py
@@ -1,0 +1,43 @@
+from unittest.mock import Mock
+
+import pytest
+import pandas as pd
+
+from api.models.watchlist import WatchItemUpsertRequest
+from api.repositories.watchlist_repo import WatchlistRepository
+from api.services.watchlist_service import WatchlistService
+from swing_screener.strategy.storage import _default_strategy_payload
+
+
+class _FakeProvider:
+    def fetch_ohlcv(self, tickers, start_date: str, end_date: str):  # noqa: ANN001
+        index = pd.date_range("2026-02-20", periods=70, freq="D")
+        columns = pd.MultiIndex.from_product([["Close"], tickers])
+        data = [[95.0 + idx * 0.1, 49.0 + idx * 0.05] for idx in range(len(index))]
+        data[-2] = [101.0, 52.0]
+        data[-1] = [102.0, 52.5]
+        return pd.DataFrame(data, index=index, columns=columns)
+
+
+def test_watchlist_service_enriches_and_sorts_items(tmp_path):
+    repo = WatchlistRepository(tmp_path / "watchlist.json")
+    repo.upsert_item("AAPL", WatchItemUpsertRequest(watch_price=90.0, currency="USD", source="screener"))
+    repo.upsert_item("MSFT", WatchItemUpsertRequest(watch_price=45.0, currency="USD", source="screener"))
+
+    strategy_repo = Mock()
+    strategy_repo.get_active_strategy.return_value = _default_strategy_payload()  # noqa: SLF001
+
+    service = WatchlistService(repo=repo, strategy_repo=strategy_repo, provider=_FakeProvider())
+    items = service.list_items()
+
+    assert [item.ticker for item in items] == ["MSFT", "AAPL"]
+    msft, aapl = items
+    assert aapl.current_price == 102.0
+    assert aapl.signal_trigger_price is not None
+    assert aapl.signal_trigger_price < aapl.current_price
+    assert aapl.distance_to_trigger_pct == pytest.approx(
+        100.0 * (aapl.current_price - aapl.signal_trigger_price) / aapl.signal_trigger_price
+    )
+    assert len(aapl.price_history) == 5
+    assert aapl.price_history[-1].close == 102.0
+    assert msft.distance_to_trigger_pct <= aapl.distance_to_trigger_pct

--- a/web-ui/src/components/domain/onboarding/OnboardingStrategySetupStep.test.tsx
+++ b/web-ui/src/components/domain/onboarding/OnboardingStrategySetupStep.test.tsx
@@ -63,6 +63,8 @@ function buildStrategy(): any {
       trailSma: 20,
       smaBufferPct: 1,
       maxHoldingDays: 20,
+      timeStopDays: 15,
+      timeStopMinR: 0.5,
       benchmark: 'SPY',
     },
     marketIntelligence: {

--- a/web-ui/src/components/domain/portfolio/EdgeBreakdownTable.tsx
+++ b/web-ui/src/components/domain/portfolio/EdgeBreakdownTable.tsx
@@ -16,7 +16,7 @@ const MIN_TRADES_FOR_DISPLAY = 5;
 
 function finalR(position: Position): number | null {
   if (!position.initialRisk || position.initialRisk <= 0 || position.exitPrice == null) return null;
-  return (position.exitPrice - position.entryPrice) / position.initialRisk;
+  return (position.exitPrice - position.entryPrice) * position.shares / position.initialRisk;
 }
 
 function tagLabel(tag: string): string {

--- a/web-ui/src/components/domain/strategy/EnhancedRiskCard.test.tsx
+++ b/web-ui/src/components/domain/strategy/EnhancedRiskCard.test.tsx
@@ -51,6 +51,8 @@ function makeStrategy(riskOverrides: Partial<Strategy['risk']> = {}): Strategy {
       trailSma: 20,
       smaBufferPct: 0.005,
       maxHoldingDays: 20,
+      timeStopDays: 15,
+      timeStopMinR: 0.5,
       benchmark: 'SPY',
     },
     marketIntelligence: {

--- a/web-ui/src/components/domain/strategy/StrategyAdvancedSettingsCard.tsx
+++ b/web-ui/src/components/domain/strategy/StrategyAdvancedSettingsCard.tsx
@@ -501,6 +501,30 @@ export default function StrategyAdvancedSettingsCard({
                   step={1}
                   min={1}
                 />
+                <NumberInput
+                  label={t('strategyPage.advanced.fields.timeStopDays')}
+                  value={draft.manage.timeStopDays}
+                  onChange={(value) =>
+                    setDraft({
+                      ...draft,
+                      manage: { ...draft.manage, timeStopDays: value },
+                    })
+                  }
+                  step={1}
+                  min={1}
+                />
+                <NumberInput
+                  label={t('strategyPage.advanced.fields.timeStopMinR')}
+                  value={draft.manage.timeStopMinR}
+                  onChange={(value) =>
+                    setDraft({
+                      ...draft,
+                      manage: { ...draft.manage, timeStopMinR: value },
+                    })
+                  }
+                  step={0.1}
+                  min={0}
+                />
                 <TextInput
                   label={t('strategyPage.advanced.fields.benchmark')}
                   value={draft.manage.benchmark}

--- a/web-ui/src/components/domain/strategy/StrategyCapitalRiskSummary.test.tsx
+++ b/web-ui/src/components/domain/strategy/StrategyCapitalRiskSummary.test.tsx
@@ -47,6 +47,8 @@ const strategy: Strategy = {
     trailSma: 20,
     smaBufferPct: 0.005,
     maxHoldingDays: 20,
+    timeStopDays: 15,
+    timeStopMinR: 0.5,
     benchmark: 'SPY',
   },
   marketIntelligence: {

--- a/web-ui/src/components/domain/strategy/StrategyPresets.test.ts
+++ b/web-ui/src/components/domain/strategy/StrategyPresets.test.ts
@@ -66,6 +66,8 @@ function buildStrategy(): Strategy {
       trailSma: 20,
       smaBufferPct: 0.005,
       maxHoldingDays: 20,
+      timeStopDays: 15,
+      timeStopMinR: 0.5,
       benchmark: 'SPY',
     },
     marketIntelligence: {

--- a/web-ui/src/components/domain/watchlist/WatchlistPipelinePanel.test.tsx
+++ b/web-ui/src/components/domain/watchlist/WatchlistPipelinePanel.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '@/test/utils';
+import WatchlistPipelinePanel from '@/components/domain/watchlist/WatchlistPipelinePanel';
+
+vi.mock('@/features/watchlist/hooks', () => ({
+  useWatchlist: () => ({
+    data: [
+      {
+        ticker: 'ASML',
+        watchedAt: '2026-05-01T10:00:00Z',
+        watchPrice: 660,
+        currentPrice: 671,
+        currency: 'EUR',
+        source: 'screener',
+        signal: 'breakout',
+        signalTriggerPrice: 680,
+        distanceToTriggerPct: -1.3,
+        priceHistory: [
+          { date: '2026-04-28', close: 650 },
+          { date: '2026-04-29', close: 655 },
+          { date: '2026-04-30', close: 662 },
+          { date: '2026-05-01', close: 668 },
+          { date: '2026-05-02', close: 671 },
+        ],
+      },
+    ],
+    isLoading: false,
+    isError: false,
+  }),
+}));
+
+describe('WatchlistPipelinePanel', () => {
+  it('renders distance-to-trigger copy and sparkline row', () => {
+    renderWithProviders(<WatchlistPipelinePanel />);
+
+    expect(screen.getByText('Watchlist Pipeline')).toBeInTheDocument();
+    expect(screen.getByText('ASML')).toBeInTheDocument();
+    expect(screen.getByText('-1.3% to buy zone')).toBeInTheDocument();
+    expect(screen.getByText('Trigger €680.00')).toBeInTheDocument();
+    expect(screen.getByText('BREAKOUT')).toBeInTheDocument();
+  });
+});

--- a/web-ui/src/components/domain/watchlist/WatchlistPipelinePanel.tsx
+++ b/web-ui/src/components/domain/watchlist/WatchlistPipelinePanel.tsx
@@ -1,0 +1,175 @@
+import { useMemo } from 'react';
+import { ArrowUpRight, TrendingUp } from 'lucide-react';
+import WatchMetaInline from '@/components/domain/watchlist/WatchMetaInline';
+import { useWatchlist } from '@/features/watchlist/hooks';
+import type { WatchItem } from '@/features/watchlist/types';
+import { t } from '@/i18n/t';
+import { cn } from '@/utils/cn';
+import { formatCurrency, formatPercent } from '@/utils/formatters';
+
+interface WatchlistPipelinePanelProps {
+  onTickerSelect?: (ticker: string) => void;
+}
+
+function DistanceCell({ item }: { item: WatchItem }) {
+  if (item.distanceToTriggerPct == null) {
+    return <span className="text-sm text-gray-400 dark:text-gray-500">—</span>;
+  }
+  const distance = item.distanceToTriggerPct;
+  const isBelow = distance <= 0;
+  return (
+    <div className="flex flex-col items-end">
+      <span
+        className={cn(
+          'text-sm font-semibold tabular-nums',
+          isBelow ? 'text-amber-700 dark:text-amber-300' : 'text-emerald-700 dark:text-emerald-300',
+        )}
+      >
+        {isBelow
+          ? t('watchlist.pipeline.distanceToBuyZone', { value: formatPercent(distance) })
+          : t('watchlist.pipeline.aboveBuyZone', { value: formatPercent(distance) })}
+      </span>
+      {item.signalTriggerPrice != null ? (
+        <span className="text-[11px] text-gray-500 dark:text-gray-400">
+          {t('watchlist.pipeline.triggerPrice', {
+            value: formatCurrency(item.signalTriggerPrice, item.currency ?? 'USD'),
+          })}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+function Sparkline({ item }: { item: WatchItem }) {
+  const points = item.priceHistory ?? [];
+  const polyline = useMemo(() => {
+    if (points.length < 2) {
+      return '';
+    }
+    const values = points.map((point) => point.close);
+    const min = Math.min(...values);
+    const max = Math.max(...values);
+    const range = max - min || 1;
+    return values
+      .map((value, index) => {
+        const x = (index / (values.length - 1)) * 56;
+        const y = 20 - ((value - min) / range) * 16;
+        return `${x.toFixed(1)},${y.toFixed(1)}`;
+      })
+      .join(' ');
+  }, [points]);
+
+  if (!polyline) {
+    return <span className="text-xs text-gray-400 dark:text-gray-500">—</span>;
+  }
+
+  const first = points[0]?.close ?? 0;
+  const last = points[points.length - 1]?.close ?? 0;
+  const positive = last >= first;
+
+  return (
+    <svg viewBox="0 0 56 20" className="h-6 w-16 overflow-visible" aria-hidden="true">
+      <polyline
+        fill="none"
+        stroke={positive ? 'currentColor' : 'currentColor'}
+        strokeWidth="1.75"
+        points={polyline}
+        className={positive ? 'text-emerald-600 dark:text-emerald-400' : 'text-rose-600 dark:text-rose-400'}
+      />
+    </svg>
+  );
+}
+
+export default function WatchlistPipelinePanel({ onTickerSelect }: WatchlistPipelinePanelProps) {
+  const watchlistQuery = useWatchlist();
+  const items = watchlistQuery.data ?? [];
+
+  if (watchlistQuery.isLoading) {
+    return <div className="py-10 text-sm text-gray-500 dark:text-gray-400">{t('watchlist.pipeline.loading')}</div>;
+  }
+
+  if (watchlistQuery.isError) {
+    return (
+      <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900/50 dark:bg-red-950/30 dark:text-red-300">
+        {t('watchlist.pipeline.error')}
+      </div>
+    );
+  }
+
+  if (items.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed border-gray-300 px-4 py-10 text-center text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400">
+        {t('watchlist.pipeline.empty')}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">{t('watchlist.pipeline.title')}</h2>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">{t('watchlist.pipeline.subtitle')}</p>
+        </div>
+        <div className="inline-flex items-center gap-2 rounded-full bg-amber-50 px-3 py-1 text-xs font-medium text-amber-700 dark:bg-amber-950/40 dark:text-amber-300">
+          <TrendingUp className="h-3.5 w-3.5" />
+          {t('watchlist.pipeline.sortedByDistance')}
+        </div>
+      </div>
+
+      <div className="overflow-hidden rounded-lg border border-border">
+        <table className="min-w-full divide-y divide-border text-sm">
+          <thead className="bg-gray-50 dark:bg-gray-900/50">
+            <tr className="text-left text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+              <th className="px-4 py-3 font-semibold">{t('watchlist.pipeline.columns.symbol')}</th>
+              <th className="px-4 py-3 font-semibold">{t('watchlist.pipeline.columns.current')}</th>
+              <th className="px-4 py-3 font-semibold">{t('watchlist.pipeline.columns.distance')}</th>
+              <th className="px-4 py-3 font-semibold">{t('watchlist.pipeline.columns.sparkline')}</th>
+              <th className="px-4 py-3 font-semibold">{t('watchlist.pipeline.columns.status')}</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border bg-white dark:bg-gray-950/20">
+            {items.map((item) => (
+              <tr
+                key={item.ticker}
+                className={cn(
+                  'align-top transition-colors',
+                  onTickerSelect ? 'cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-900/30' : '',
+                )}
+                onClick={() => onTickerSelect?.(item.ticker)}
+              >
+                <td className="px-4 py-3">
+                  <div className="flex items-center gap-2">
+                    <span className="font-semibold text-gray-900 dark:text-gray-100">{item.ticker}</span>
+                    {onTickerSelect ? <ArrowUpRight className="h-3.5 w-3.5 text-gray-400" /> : null}
+                  </div>
+                  <WatchMetaInline
+                    watchedAt={item.watchedAt}
+                    watchPrice={item.watchPrice}
+                    currentPrice={item.currentPrice}
+                    currency={item.currency}
+                    className="mt-1 flex flex-wrap items-center gap-2 text-[11px]"
+                  />
+                </td>
+                <td className="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">
+                  {item.currentPrice != null ? formatCurrency(item.currentPrice, item.currency ?? 'USD') : '—'}
+                </td>
+                <td className="px-4 py-3">
+                  <DistanceCell item={item} />
+                </td>
+                <td className="px-4 py-3">
+                  <Sparkline item={item} />
+                </td>
+                <td className="px-4 py-3">
+                  <span className="inline-flex rounded-full bg-gray-100 px-2 py-1 text-[11px] font-medium text-gray-700 dark:bg-gray-800 dark:text-gray-300">
+                    {(item.signal ?? 'none').toUpperCase()}
+                  </span>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/web-ui/src/components/domain/workspace/PortfolioTable.test.tsx
+++ b/web-ui/src/components/domain/workspace/PortfolioTable.test.tsx
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+
+import PortfolioTable from '@/components/domain/workspace/PortfolioTable';
+import { t } from '@/i18n/t';
+import { renderWithProviders } from '@/test/utils';
+import type { PositionWithMetrics } from '@/features/portfolio/api';
+
+const { positionsMock } = vi.hoisted(() => ({
+  positionsMock: vi.fn(),
+}));
+
+vi.mock('@/features/portfolio/hooks', () => ({
+  usePositions: () => ({
+    data: positionsMock(),
+    isLoading: false,
+    isFetched: true,
+    isError: false,
+  }),
+  useOrders: () => ({
+    data: [],
+    isLoading: false,
+    isFetched: true,
+    isError: false,
+  }),
+  useUpdateStopMutation: () => ({ mutate: vi.fn(), isPending: false, error: null }),
+  useClosePositionMutation: () => ({ mutate: vi.fn(), isPending: false, error: null }),
+  useFillOrderMutation: () => ({ mutate: vi.fn(), isPending: false, error: null }),
+  useCancelOrderMutation: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+function makePosition(overrides: Partial<PositionWithMetrics> = {}): PositionWithMetrics {
+  return {
+    ticker: 'TEST',
+    status: 'open',
+    entryDate: '2026-01-01',
+    entryPrice: 100,
+    stopPrice: 90,
+    shares: 10,
+    positionId: 'POS-TEST',
+    pnl: 0,
+    pnlPercent: 0,
+    rNow: 0,
+    entryValue: 1000,
+    currentValue: 1000,
+    perShareRisk: 10,
+    totalRisk: 100,
+    feesEur: 0,
+    daysOpen: 0,
+    timeStopWarning: false,
+    notes: '',
+    tags: [],
+    ...overrides,
+  };
+}
+
+describe('PortfolioTable time stop nudge', () => {
+  it('shows stale-trade badge for positions with time stop warning', () => {
+    positionsMock.mockReturnValue([
+      makePosition({ daysOpen: 16, rNow: 0.3, timeStopWarning: true }),
+    ]);
+
+    renderWithProviders(<PortfolioTable />);
+
+    expect(screen.getByText(t('bookPage.positions.timeStopBadge', { days: '16', r: '+0.30' }))).toBeInTheDocument();
+    expect(screen.getByTitle(t('bookPage.positions.timeStopWarning'))).toBeInTheDocument();
+  });
+
+  it('hides stale-trade badge when warning is false', () => {
+    positionsMock.mockReturnValue([
+      makePosition({ daysOpen: 16, rNow: 1.1, timeStopWarning: false }),
+    ]);
+
+    renderWithProviders(<PortfolioTable />);
+
+    expect(screen.queryByTitle(t('bookPage.positions.timeStopWarning'))).not.toBeInTheDocument();
+  });
+});

--- a/web-ui/src/components/domain/workspace/PortfolioTable.tsx
+++ b/web-ui/src/components/domain/workspace/PortfolioTable.tsx
@@ -44,6 +44,22 @@ function formatOptionalCurrency(value: number | null): string {
   return value == null ? t('common.placeholders.dash') : formatCurrency(value);
 }
 
+function TimeStopBadge({ position }: { position: PositionWithMetrics | null }) {
+  if (!position?.timeStopWarning) return null;
+  const label = t('bookPage.positions.timeStopBadge', {
+    days: String(position.daysOpen),
+    r: `${position.rNow >= 0 ? '+' : ''}${position.rNow.toFixed(2)}`,
+  });
+  return (
+    <span
+      className="inline-flex items-center rounded bg-amber-100 px-1.5 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-900/40 dark:text-amber-300"
+      title={t('bookPage.positions.timeStopWarning')}
+    >
+      {label}
+    </span>
+  );
+}
+
 /** Compact actions dropdown using native <details> */
 function ActionsDropdown({ children }: { children: React.ReactNode }) {
   return (
@@ -242,6 +258,7 @@ export default function PortfolioTable() {
         <div className="flex items-center gap-1.5">
           <span className="font-semibold text-sm">{row.ticker}</span>
           <Badge variant={row.status === 'open' ? 'success' : 'warning'} >{row.status}</Badge>
+          <TimeStopBadge position={row.position} />
         </div>
       ),
     },

--- a/web-ui/src/features/dailyReview/types.test.ts
+++ b/web-ui/src/features/dailyReview/types.test.ts
@@ -4,6 +4,19 @@ import { transformDailyReview, type DailyReviewAPI } from '@/features/dailyRevie
 describe('transformDailyReview', () => {
   it('maps candidate close and execution guidance fields', () => {
     const apiPayload: DailyReviewAPI = {
+      watchlist_near_trigger: [
+        {
+          ticker: 'ASML',
+          watched_at: '2026-05-01T10:00:00Z',
+          watch_price: 660,
+          currency: 'EUR',
+          source: 'screener',
+          current_price: 671,
+          signal_trigger_price: 680,
+          distance_to_trigger_pct: -1.3,
+          price_history: [],
+        },
+      ],
       new_candidates: [
         {
           ticker: 'AAPL',
@@ -67,11 +80,14 @@ describe('transformDailyReview', () => {
         close_positions: 0,
         new_candidates: 1,
         add_on_candidates: 0,
+        watchlist_near_trigger: 1,
         review_date: '2026-03-02',
       },
     };
 
     const result = transformDailyReview(apiPayload);
+    expect(result.watchlistNearTrigger[0].ticker).toBe('ASML');
+    expect(result.summary.watchlistNearTrigger).toBe(1);
     expect(result.newCandidates[0].close).toBe(100);
     expect(result.newCandidates[0].currency).toBe('USD');
     expect(result.newCandidates[0].score).toBe(83.2);

--- a/web-ui/src/features/dailyReview/types.ts
+++ b/web-ui/src/features/dailyReview/types.ts
@@ -58,6 +58,8 @@ export interface DailyReviewPositionHoldAPI {
   stop_price: number;
   current_price: number;
   r_now: number;
+  days_open?: number;
+  time_stop_warning?: boolean;
   reason: string;
 }
 
@@ -69,6 +71,8 @@ export interface DailyReviewPositionUpdateAPI {
   stop_suggested: number;
   current_price: number;
   r_now: number;
+  days_open?: number;
+  time_stop_warning?: boolean;
   reason: string;
 }
 
@@ -79,6 +83,8 @@ export interface DailyReviewPositionCloseAPI {
   stop_price: number;
   current_price: number;
   r_now: number;
+  days_open?: number;
+  time_stop_warning?: boolean;
   reason: string;
 }
 
@@ -139,6 +145,8 @@ export interface DailyReviewPositionHold {
   stopPrice: number;
   currentPrice: number;
   rNow: number;
+  daysOpen: number;
+  timeStopWarning: boolean;
   reason: string;
 }
 
@@ -150,6 +158,8 @@ export interface DailyReviewPositionUpdate {
   stopSuggested: number;
   currentPrice: number;
   rNow: number;
+  daysOpen: number;
+  timeStopWarning: boolean;
   reason: string;
 }
 
@@ -160,6 +170,8 @@ export interface DailyReviewPositionClose {
   stopPrice: number;
   currentPrice: number;
   rNow: number;
+  daysOpen: number;
+  timeStopWarning: boolean;
   reason: string;
 }
 
@@ -273,6 +285,8 @@ export function transformPositionHold(api: DailyReviewPositionHoldAPI): DailyRev
     stopPrice: api.stop_price,
     currentPrice: api.current_price,
     rNow: api.r_now,
+    daysOpen: api.days_open ?? 0,
+    timeStopWarning: api.time_stop_warning ?? false,
     reason: api.reason,
   };
 }
@@ -286,6 +300,8 @@ export function transformPositionUpdate(api: DailyReviewPositionUpdateAPI): Dail
     stopSuggested: api.stop_suggested,
     currentPrice: api.current_price,
     rNow: api.r_now,
+    daysOpen: api.days_open ?? 0,
+    timeStopWarning: api.time_stop_warning ?? false,
     reason: api.reason,
   };
 }
@@ -298,6 +314,8 @@ export function transformPositionClose(api: DailyReviewPositionCloseAPI): DailyR
     stopPrice: api.stop_price,
     currentPrice: api.current_price,
     rNow: api.r_now,
+    daysOpen: api.days_open ?? 0,
+    timeStopWarning: api.time_stop_warning ?? false,
     reason: api.reason,
   };
 }

--- a/web-ui/src/features/dailyReview/types.ts
+++ b/web-ui/src/features/dailyReview/types.ts
@@ -8,6 +8,7 @@ import {
   type DecisionSummaryAPI,
   type SameSymbolCandidateContext,
 } from '@/features/screener/types';
+import { type WatchItem, type WatchItemAPI, transformWatchItem } from '@/features/watchlist/types';
 
 // API response types (snake_case from backend)
 export interface DailyReviewCandidateAPI {
@@ -95,10 +96,12 @@ export interface DailyReviewSummaryAPI {
   close_positions: number;
   new_candidates: number;
   add_on_candidates: number;
+  watchlist_near_trigger?: number;
   review_date: string;
 }
 
 export interface DailyReviewAPI {
+  watchlist_near_trigger?: WatchItemAPI[];
   new_candidates: DailyReviewCandidateAPI[];
   positions_add_on_candidates: DailyReviewCandidateAPI[];
   positions_hold: DailyReviewPositionHoldAPI[];
@@ -182,10 +185,12 @@ export interface DailyReviewSummary {
   closePositions: number;
   newCandidates: number;
   addOnCandidates: number;
+  watchlistNearTrigger: number;
   reviewDate: string;
 }
 
 export interface DailyReview {
+  watchlistNearTrigger: WatchItem[];
   newCandidates: DailyReviewCandidate[];
   positionsAddOnCandidates: DailyReviewCandidate[];
   positionsHold: DailyReviewPositionHold[];
@@ -328,12 +333,14 @@ export function transformSummary(api: DailyReviewSummaryAPI): DailyReviewSummary
     closePositions: api.close_positions,
     newCandidates: api.new_candidates,
     addOnCandidates: api.add_on_candidates,
+    watchlistNearTrigger: api.watchlist_near_trigger ?? 0,
     reviewDate: api.review_date,
   };
 }
 
 export function transformDailyReview(api: DailyReviewAPI): DailyReview {
   return {
+    watchlistNearTrigger: (api.watchlist_near_trigger ?? []).map(transformWatchItem),
     newCandidates: api.new_candidates.map(transformCandidate),
     positionsAddOnCandidates: (api.positions_add_on_candidates ?? []).map(transformCandidate),
     positionsHold: api.positions_hold.map(transformPositionHold),

--- a/web-ui/src/features/persistence/defaultStrategyFixture.json
+++ b/web-ui/src/features/persistence/defaultStrategyFixture.json
@@ -60,6 +60,8 @@
     "trail_sma": 20,
     "sma_buffer_pct": 0.005,
     "max_holding_days": 20,
+    "time_stop_days": 15,
+    "time_stop_min_r": 0.5,
     "benchmark": "SPY"
   },
   "market_intelligence": {

--- a/web-ui/src/features/persistence/portfolioService.ts
+++ b/web-ui/src/features/persistence/portfolioService.ts
@@ -36,6 +36,8 @@ export interface LocalPositionWithMetrics extends Position {
   perShareRisk: number;
   totalRisk: number;
   feesEur: number;
+  daysOpen: number;
+  timeStopWarning: boolean;
 }
 
 export interface LocalConcentrationGroup {
@@ -183,6 +185,13 @@ function perShareRisk(position: Position): number {
   return computed > 0 ? computed : 0;
 }
 
+function daysBetween(startIso: string, endIso: string): number {
+  const start = new Date(`${startIso}T00:00:00`);
+  const end = new Date(`${endIso}T00:00:00`);
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) return 0;
+  return Math.max(Math.floor((end.getTime() - start.getTime()) / 86_400_000), 0);
+}
+
 function toPositionWithMetrics(position: Position, feesByPosition: Map<string, number>): LocalPositionWithMetrics {
   const currentPrice = currentPriceForPosition(position);
   const entryValue = position.entryPrice * position.shares;
@@ -191,18 +200,26 @@ function toPositionWithMetrics(position: Position, feesByPosition: Map<string, n
   const pnl = (currentPrice - position.entryPrice) * position.shares - fee;
   const riskPerShare = perShareRisk(position);
   const totalRisk = riskPerShare * position.shares;
+  const store = readTradingStore();
+  const active = store.strategies.find((strategy) => strategy.id === store.activeStrategyId);
+  const daysOpen = daysBetween(position.entryDate, currentDateIso());
+  const rNow = totalRisk > 0 ? pnl / totalRisk : 0;
+  const timeStopDays = active?.manage.timeStopDays ?? 15;
+  const timeStopMinR = active?.manage.timeStopMinR ?? 0.5;
 
   return {
     ...cloneValue(position),
     currentPrice: position.status === 'open' ? currentPrice : position.currentPrice,
     pnl,
     pnlPercent: entryValue > 0 ? (pnl / entryValue) * 100 : 0,
-    rNow: totalRisk > 0 ? pnl / totalRisk : 0,
+    rNow,
     entryValue,
     currentValue,
     perShareRisk: riskPerShare,
     totalRisk,
     feesEur: fee,
+    daysOpen,
+    timeStopWarning: position.status === 'open' && daysOpen >= timeStopDays && rNow < timeStopMinR,
   };
 }
 

--- a/web-ui/src/features/portfolio/api.ts
+++ b/web-ui/src/features/portfolio/api.ts
@@ -53,6 +53,8 @@ interface PositionWithMetricsApiResponse extends PositionApiResponse {
   per_share_risk: number;
   total_risk: number;
   fees_eur: number;
+  days_open?: number;
+  time_stop_warning?: boolean;
 }
 
 interface PortfolioSummaryApiResponse {
@@ -108,6 +110,8 @@ export interface PositionWithMetrics extends Position {
   perShareRisk: number;
   totalRisk: number;
   feesEur: number;
+  daysOpen: number;
+  timeStopWarning: boolean;
 }
 
 export interface PortfolioSummary {
@@ -414,6 +418,8 @@ export async function fetchPositionStopSuggestion(positionId: string): Promise<P
           trail_sma: strategy.manage.trailSma,
           sma_buffer_pct: strategy.manage.smaBufferPct,
           max_holding_days: strategy.manage.maxHoldingDays,
+          time_stop_days: strategy.manage.timeStopDays,
+          time_stop_min_r: strategy.manage.timeStopMinR,
         },
       }),
     });
@@ -532,6 +538,8 @@ function transformPositionWithMetrics(data: PositionWithMetricsApiResponse): Pos
     perShareRisk: data.per_share_risk,
     totalRisk: data.total_risk,
     feesEur: data.fees_eur ?? 0,
+    daysOpen: data.days_open ?? 0,
+    timeStopWarning: data.time_stop_warning ?? false,
   };
 }
 

--- a/web-ui/src/features/strategy/types.ts
+++ b/web-ui/src/features/strategy/types.ts
@@ -70,6 +70,8 @@ export interface StrategyManage {
   trailSma: number;
   smaBufferPct: number;
   maxHoldingDays: number;
+  timeStopDays: number;
+  timeStopMinR: number;
   benchmark: string;
 }
 
@@ -204,6 +206,8 @@ export interface StrategyManageAPI {
   trail_sma: number;
   sma_buffer_pct: number;
   max_holding_days: number;
+  time_stop_days?: number;
+  time_stop_min_r?: number;
   benchmark: string;
 }
 
@@ -364,6 +368,8 @@ export function transformStrategy(api: StrategyAPI): Strategy {
       trailSma: api.manage.trail_sma,
       smaBufferPct: api.manage.sma_buffer_pct,
       maxHoldingDays: api.manage.max_holding_days,
+      timeStopDays: api.manage.time_stop_days ?? 15,
+      timeStopMinR: api.manage.time_stop_min_r ?? 0.5,
       benchmark: api.manage.benchmark,
     },
     marketIntelligence: {
@@ -478,6 +484,8 @@ export function toStrategyUpdateRequest(strategy: Strategy): StrategyUpdateReque
       trail_sma: strategy.manage.trailSma,
       sma_buffer_pct: strategy.manage.smaBufferPct,
       max_holding_days: strategy.manage.maxHoldingDays,
+      time_stop_days: strategy.manage.timeStopDays,
+      time_stop_min_r: strategy.manage.timeStopMinR,
       benchmark: strategy.manage.benchmark,
     },
     market_intelligence: {

--- a/web-ui/src/features/strategy/useStrategyReadiness.test.ts
+++ b/web-ui/src/features/strategy/useStrategyReadiness.test.ts
@@ -61,6 +61,8 @@ const createMockStrategy = (overrides?: Partial<Strategy>): Strategy => ({
     trailSma: 10,
     smaBufferPct: 0.5,
     maxHoldingDays: 90,
+    timeStopDays: 15,
+    timeStopMinR: 0.5,
     benchmark: 'SPY',
   },
   marketIntelligence: {

--- a/web-ui/src/features/watchlist/api.ts
+++ b/web-ui/src/features/watchlist/api.ts
@@ -21,6 +21,7 @@ export async function fetchWatchlist(): Promise<WatchItem[]> {
       watchPrice: item.watchPrice ?? undefined,
       currency: item.currency ?? undefined,
       source: item.source,
+      priceHistory: [],
     }));
   }
 
@@ -51,6 +52,7 @@ export async function watchSymbol(request: WatchSymbolRequest): Promise<WatchIte
       watchPrice: saved.watchPrice ?? undefined,
       currency: saved.currency ?? undefined,
       source: saved.source,
+      priceHistory: [],
     };
   }
 
@@ -109,4 +111,3 @@ export async function unwatchSymbol(ticker: string): Promise<void> {
     throw new Error(message);
   }
 }
-

--- a/web-ui/src/features/watchlist/hooks.test.tsx
+++ b/web-ui/src/features/watchlist/hooks.test.tsx
@@ -46,6 +46,7 @@ describe('watchlist hooks', () => {
         watchPrice: 180,
         currency: 'USD',
         source: 'screener',
+        priceHistory: [],
       },
     ]);
 
@@ -70,6 +71,7 @@ describe('watchlist hooks', () => {
       watchPrice: 180,
       currency: 'USD',
       source: 'screener',
+      priceHistory: [],
     });
 
     const { result } = renderHook(() => useWatchSymbolMutation(), {
@@ -111,4 +113,3 @@ describe('watchlist hooks', () => {
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.watchlist() });
   });
 });
-

--- a/web-ui/src/features/watchlist/types.ts
+++ b/web-ui/src/features/watchlist/types.ts
@@ -1,9 +1,17 @@
+import type { PriceHistoryPoint } from '@/features/screener/types';
+
 export interface WatchItemAPI {
   ticker: string;
   watched_at: string;
   watch_price?: number | null;
   currency?: string | null;
   source: string;
+  current_price?: number | null;
+  last_bar?: string | null;
+  signal?: string | null;
+  signal_trigger_price?: number | null;
+  distance_to_trigger_pct?: number | null;
+  price_history?: PriceHistoryPoint[] | null;
 }
 
 export interface WatchlistResponseAPI {
@@ -16,6 +24,12 @@ export interface WatchItem {
   watchPrice?: number;
   currency?: string;
   source: string;
+  currentPrice?: number;
+  lastBar?: string;
+  signal?: string;
+  signalTriggerPrice?: number;
+  distanceToTriggerPct?: number;
+  priceHistory: PriceHistoryPoint[];
 }
 
 export interface WatchSymbolRequest {
@@ -32,6 +46,11 @@ export function transformWatchItem(api: WatchItemAPI): WatchItem {
     watchPrice: api.watch_price ?? undefined,
     currency: api.currency?.trim().toUpperCase() || undefined,
     source: api.source,
+    currentPrice: api.current_price ?? undefined,
+    lastBar: api.last_bar ?? undefined,
+    signal: api.signal ?? undefined,
+    signalTriggerPrice: api.signal_trigger_price ?? undefined,
+    distanceToTriggerPct: api.distance_to_trigger_pct ?? undefined,
+    priceHistory: api.price_history ?? [],
   };
 }
-

--- a/web-ui/src/i18n/messages.en.ts
+++ b/web-ui/src/i18n/messages.en.ts
@@ -1711,6 +1711,8 @@ export const messagesEn = {
         trailSma: 'Trail SMA',
         smaBuffer: 'SMA Buffer',
         maxHoldingDays: 'Max Holding Days',
+        timeStopDays: 'Time Stop Days',
+        timeStopMinR: 'Time Stop Min R',
         takeProfitR: 'Take Profit (R)',
         commission: 'Commission',
         minHistory: 'Min History',
@@ -2033,6 +2035,10 @@ export const messagesEn = {
       performance: 'Performance',
       review: 'Weekly Review',
     },
+    positions: {
+      timeStopBadge: '{{days}}d / {{r}}R',
+      timeStopWarning: 'Stale trade: consider closing or documenting a reason to hold.',
+    },
   },
   pendingOrdersTab: {
     title: 'Pending Orders',
@@ -2091,6 +2097,8 @@ export const messagesEn = {
       loading: "Loading today's review...",
       closeAction: 'Close →',
       updateAction: 'Update →',
+      timeStopBadge: '{{days}}d / {{r}}R',
+      timeStopWarning: 'Stale trade: consider closing or documenting a reason to hold.',
     },
     keyboard: {
       hint: 'j/k navigate · Enter select',

--- a/web-ui/src/i18n/messages.en.ts
+++ b/web-ui/src/i18n/messages.en.ts
@@ -53,6 +53,26 @@ export const messagesEn = {
       unavailable: '—',
       value: '{{abs}} ({{pct}})',
     },
+    pipeline: {
+      title: 'Watchlist Pipeline',
+      subtitle: 'Track which names are closest to their trigger zone.',
+      sortedByDistance: 'Closest first',
+      loading: 'Loading watchlist pipeline...',
+      error: 'Unable to load the watchlist pipeline.',
+      empty: 'No watchlist symbols yet.',
+      distanceToBuyZone: '{{value}} to buy zone',
+      aboveBuyZone: '{{value}} above buy zone',
+      triggerPrice: 'Trigger {{value}}',
+      columns: {
+        symbol: 'Symbol',
+        current: 'Current',
+        distance: 'Distance to Trigger',
+        sparkline: '5D',
+        status: 'Signal',
+      },
+      dailyReviewTitle: 'Watchlist nearing trigger',
+      dailyReviewSubtitle: '{{count}} names within 3% of the buy zone.',
+    },
   },
   modal: {
     closeAria: 'Close modal',
@@ -2074,6 +2094,7 @@ export const messagesEn = {
     tabs: {
       intelligence: 'Intelligence',
       fundamentals: 'Fundamentals',
+      watchlist: 'Watchlist',
       calendar: 'Calendar',
     },
     symbolSearch: {
@@ -2087,6 +2108,7 @@ export const messagesEn = {
       screener: 'Screener',
     },
     actionList: {
+      watchlistNearTrigger: 'Watchlist Near Trigger',
       requiresAction: 'Requires Action',
       opportunities: 'New Opportunities',
       holding: 'Holding',

--- a/web-ui/src/pages/Research.tsx
+++ b/web-ui/src/pages/Research.tsx
@@ -4,20 +4,23 @@ import { t } from '@/i18n/t';
 import IntelligencePage from './Intelligence';
 import FundamentalsPage from './Fundamentals';
 import EventsCalendar from '@/components/domain/calendar/EventsCalendar';
+import WatchlistPipelinePanel from '@/components/domain/watchlist/WatchlistPipelinePanel';
 import { usePositions } from '@/features/portfolio/hooks';
 import { useWatchlist } from '@/features/watchlist/hooks';
+import { useWorkspaceStore } from '@/stores/workspaceStore';
 
 const STORAGE_KEY = 'research.activeTab';
-type ResearchTab = 'intelligence' | 'fundamentals' | 'calendar';
+type ResearchTab = 'intelligence' | 'fundamentals' | 'watchlist' | 'calendar';
 
 export default function Research() {
   const [activeTab, setActiveTab] = useState<ResearchTab>(() => {
     const stored = localStorage.getItem(STORAGE_KEY);
-    if (stored === 'intelligence' || stored === 'fundamentals' || stored === 'calendar') {
+    if (stored === 'intelligence' || stored === 'fundamentals' || stored === 'watchlist' || stored === 'calendar') {
       return stored;
     }
     return 'intelligence';
   });
+  const setSelectedTicker = useWorkspaceStore((state) => state.setSelectedTicker);
 
   const openPositionsQuery = usePositions('open');
   const watchlistQuery = useWatchlist();
@@ -39,6 +42,7 @@ export default function Research() {
   const tabs: { key: ResearchTab; label: string }[] = [
     { key: 'intelligence', label: t('researchPage.tabs.intelligence') },
     { key: 'fundamentals', label: t('researchPage.tabs.fundamentals') },
+    { key: 'watchlist', label: t('researchPage.tabs.watchlist') },
     { key: 'calendar', label: t('researchPage.tabs.calendar') },
   ];
 
@@ -105,6 +109,16 @@ export default function Research() {
       <div>
         {activeTab === 'intelligence' && <IntelligencePage initialSymbol={committedSymbol} />}
         {activeTab === 'fundamentals' && <FundamentalsPage initialSymbol={committedSymbol} />}
+        {activeTab === 'watchlist' && (
+          <WatchlistPipelinePanel
+            onTickerSelect={(ticker) => {
+              setSharedSymbol(ticker);
+              setCommittedSymbol(ticker);
+              setSelectedTicker(ticker, 'screener');
+              setActiveTab('intelligence');
+            }}
+          />
+        )}
         {activeTab === 'calendar' && (
           <EventsCalendar symbols={calendarSymbols} daysAhead={30} />
         )}

--- a/web-ui/src/pages/Today.test.tsx
+++ b/web-ui/src/pages/Today.test.tsx
@@ -52,4 +52,48 @@ describe('Today page — pending orders badge', () => {
       screen.queryByText(t('todayPage.pendingBadge.singular', { count: '1' }))
     ).not.toBeInTheDocument();
   });
+
+  it('shows watchlist near-trigger section when daily review returns matches', async () => {
+    server.use(
+      http.get('*/api/portfolio/orders/local', () =>
+        HttpResponse.json({ orders: [], asof: '2026-04-28' })
+      ),
+      http.get('*/api/daily-review', () =>
+        HttpResponse.json({
+          watchlist_near_trigger: [
+            {
+              ticker: 'ASML',
+              watched_at: '2026-05-01T10:00:00Z',
+              watch_price: 660,
+              currency: 'EUR',
+              source: 'screener',
+              current_price: 671,
+              signal_trigger_price: 680,
+              distance_to_trigger_pct: -1.3,
+              price_history: [],
+            },
+          ],
+          new_candidates: [],
+          positions_add_on_candidates: [],
+          positions_hold: [],
+          positions_update_stop: [],
+          positions_close: [],
+          summary: {
+            total_positions: 0,
+            no_action: 0,
+            update_stop: 0,
+            close_positions: 0,
+            new_candidates: 0,
+            add_on_candidates: 0,
+            watchlist_near_trigger: 1,
+            review_date: '2026-05-04',
+          },
+        })
+      )
+    );
+
+    renderWithProviders(<Today />);
+    expect(await screen.findByText(new RegExp(t('watchlist.pipeline.dailyReviewTitle'), 'i'))).toBeInTheDocument();
+    expect(screen.getByText('ASML')).toBeInTheDocument();
+  });
 });

--- a/web-ui/src/pages/Today.tsx
+++ b/web-ui/src/pages/Today.tsx
@@ -29,6 +29,27 @@ import type {
 
 // ─── Action item row components ─────────────────────────────────────────────
 
+interface TimeStopBadgeProps {
+  daysOpen: number;
+  rNow: number;
+  show: boolean;
+}
+
+function TimeStopBadge({ daysOpen, rNow, show }: TimeStopBadgeProps) {
+  if (!show) return null;
+  return (
+    <span
+      className="text-xs font-medium px-1.5 py-0.5 rounded bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400"
+      title={t('todayPage.actionList.timeStopWarning')}
+    >
+      {t('todayPage.actionList.timeStopBadge', {
+        days: String(daysOpen),
+        r: `${rNow >= 0 ? '+' : ''}${formatNumber(rNow, 2)}`,
+      })}
+    </span>
+  );
+}
+
 interface CloseItemProps {
   item: DailyReviewPositionClose;
   onClick: (ticker: string) => void;
@@ -57,6 +78,7 @@ function CloseItem({ item, onClick, onAction, isDone, isFocused }: CloseItemProp
       <span className={cn('text-xs font-semibold tabular-nums', item.rNow >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400')}>
         {item.rNow >= 0 ? '+' : ''}{formatNumber(item.rNow, 2)}R
       </span>
+      <TimeStopBadge daysOpen={item.daysOpen} rNow={item.rNow} show={item.timeStopWarning} />
       <span className="text-xs text-gray-500 dark:text-gray-400 truncate flex-1">{item.reason}</span>
       {isDone ? (
         <CheckCircle2 className="w-4 h-4 text-green-500 shrink-0" />
@@ -103,6 +125,7 @@ function UpdateStopItem({ item, onClick, onAction, isDone, isFocused }: UpdateSt
       <span className={cn('text-xs font-semibold tabular-nums', item.rNow >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400')}>
         {item.rNow >= 0 ? '+' : ''}{formatNumber(item.rNow, 2)}R
       </span>
+      <TimeStopBadge daysOpen={item.daysOpen} rNow={item.rNow} show={item.timeStopWarning} />
       <span className="text-xs text-gray-500 dark:text-gray-400 truncate flex-1">{item.reason}</span>
       {isDone ? (
         <CheckCircle2 className="w-4 h-4 text-green-500 shrink-0" />
@@ -185,6 +208,7 @@ function HoldItem({ item, onClick, isFocused }: HoldItemProps) {
       <span className={cn('text-xs font-semibold tabular-nums', item.rNow >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400')}>
         {item.rNow >= 0 ? '+' : ''}{formatNumber(item.rNow, 2)}R
       </span>
+      <TimeStopBadge daysOpen={item.daysOpen} rNow={item.rNow} show={item.timeStopWarning} />
       <span className="text-xs text-gray-400 dark:text-gray-500 truncate flex-1">{item.reason}</span>
     </button>
   );

--- a/web-ui/src/pages/Today.tsx
+++ b/web-ui/src/pages/Today.tsx
@@ -5,6 +5,7 @@ import FloatingChatWidget from '@/components/domain/workspace/FloatingChatWidget
 import ScreenerInboxPanel from '@/components/domain/workspace/ScreenerInboxPanel';
 import ClosePositionModalForm from '@/components/domain/positions/ClosePositionModalForm';
 import UpdateStopModalForm from '@/components/domain/positions/UpdateStopModalForm';
+import WatchMetaInline from '@/components/domain/watchlist/WatchMetaInline';
 import { useSymbolIntelligenceRunner } from '@/features/intelligence/useSymbolIntelligenceRunner';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
 import { useDailyReview } from '@/features/dailyReview/api';
@@ -26,6 +27,7 @@ import type {
   DailyReviewPositionHold,
   DailyReviewPositionUpdate,
 } from '@/features/dailyReview/types';
+import type { WatchItem } from '@/features/watchlist/types';
 
 // ─── Action item row components ─────────────────────────────────────────────
 
@@ -214,6 +216,41 @@ function HoldItem({ item, onClick, isFocused }: HoldItemProps) {
   );
 }
 
+function WatchlistNearTriggerItem({ item, onClick, isFocused }: { item: WatchItem; onClick: (ticker: string) => void; isFocused?: boolean }) {
+  const distance = item.distanceToTriggerPct;
+  return (
+    <button
+      type="button"
+      onClick={() => onClick(item.ticker)}
+      className={cn(
+        'w-full text-left flex items-start gap-3 px-3 py-2 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors border-l-2 border-amber-400',
+        isFocused && 'ring-1 ring-primary',
+      )}
+    >
+      <span className="text-sm font-semibold text-gray-900 dark:text-gray-100 min-w-[60px]">
+        {item.ticker}
+      </span>
+      <span className="text-xs font-medium px-1.5 py-0.5 rounded bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">
+        {t('todayPage.actionList.watchlistNearTrigger')}
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="text-xs font-semibold tabular-nums text-amber-700 dark:text-amber-300">
+          {distance != null
+            ? t('watchlist.pipeline.distanceToBuyZone', { value: `${distance >= 0 ? '+' : ''}${formatNumber(distance, 1)}%` })
+            : '—'}
+        </div>
+        <WatchMetaInline
+          watchedAt={item.watchedAt}
+          watchPrice={item.watchPrice}
+          currentPrice={item.currentPrice}
+          currency={item.currency}
+          className="mt-0.5 flex flex-wrap items-center gap-2 text-[11px]"
+        />
+      </div>
+    </button>
+  );
+}
+
 // ─── Section header ──────────────────────────────────────────────────────────
 
 interface SectionHeaderProps {
@@ -353,6 +390,7 @@ function TodayActionList({ onTickerSelect }: TodayActionListProps) {
   // Flat ordered list for keyboard navigation
   const flatItems = useMemo(
     () => [
+      ...(review?.watchlistNearTrigger.map((i) => ({ ticker: i.ticker, id: `watch-${i.ticker}` })) ?? []),
       ...(review?.positionsClose.map((i) => ({ ticker: i.ticker, id: i.positionId })) ?? []),
       ...(review?.positionsUpdateStop.map((i) => ({ ticker: i.ticker, id: i.positionId })) ?? []),
       ...filteredCandidates.map((i) => ({ ticker: i.ticker, id: i.ticker })),
@@ -387,6 +425,7 @@ function TodayActionList({ onTickerSelect }: TodayActionListProps) {
 
   const requiresActionCount =
     (review?.positionsClose.length ?? 0) + (review?.positionsUpdateStop.length ?? 0);
+  const watchlistNearTriggerCount = review?.watchlistNearTrigger.length ?? 0;
   const opportunitiesCount = filteredCandidates.length + filteredAddOns.length;
   const holdCount = review?.positionsHold.length ?? 0;
 
@@ -406,7 +445,7 @@ function TodayActionList({ onTickerSelect }: TodayActionListProps) {
     );
   }
 
-  const isEmpty = requiresActionCount === 0 && opportunitiesCount === 0 && holdCount === 0;
+  const isEmpty = requiresActionCount === 0 && watchlistNearTriggerCount === 0 && opportunitiesCount === 0 && holdCount === 0;
 
   return (
     <div className="flex flex-col h-full overflow-hidden">
@@ -479,6 +518,31 @@ function TodayActionList({ onTickerSelect }: TodayActionListProps) {
           <p className="text-sm text-gray-500 dark:text-gray-400 px-2 py-4 text-center">
             {t('todayPage.actionList.empty')}
           </p>
+        )}
+
+        {/* Requires Action section */}
+        {watchlistNearTriggerCount > 0 && (
+          <div className="space-y-1">
+            <div className="px-3 py-1 text-xs font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-300 bg-amber-50 dark:bg-amber-900/20 rounded">
+              {t('watchlist.pipeline.dailyReviewTitle')} · {watchlistNearTriggerCount}
+            </div>
+            <p className="px-3 text-[11px] text-gray-500 dark:text-gray-400">
+              {t('watchlist.pipeline.dailyReviewSubtitle', { count: String(watchlistNearTriggerCount) })}
+            </p>
+            <div className="space-y-0.5">
+              {review?.watchlistNearTrigger.map((item) => {
+                const idx = flatItems.findIndex((fi) => fi.id === `watch-${item.ticker}`);
+                return (
+                  <WatchlistNearTriggerItem
+                    key={item.ticker}
+                    item={item}
+                    onClick={onTickerSelect}
+                    isFocused={focusedIndex === idx}
+                  />
+                );
+              })}
+            </div>
+          </div>
         )}
 
         {/* Requires Action section */}

--- a/web-ui/src/test/mocks/handlers.ts
+++ b/web-ui/src/test/mocks/handlers.ts
@@ -602,6 +602,12 @@ type WatchlistItemPayload = {
   watch_price: number | null
   currency: string | null
   source: string
+  current_price?: number | null
+  last_bar?: string | null
+  signal?: string | null
+  signal_trigger_price?: number | null
+  distance_to_trigger_pct?: number | null
+  price_history?: Array<{ date: string; close: number }>
 }
 let watchlistItems: WatchlistItemPayload[] = []
 
@@ -982,6 +988,55 @@ export const handlers = [
       return HttpResponse.json({ detail: `Watch item not found: ${ticker}` }, { status: 404 })
     }
     return HttpResponse.json({ deleted: true })
+  }),
+
+  // Daily review endpoints
+  http.get(`${API_BASE_URL}/api/daily-review`, () => {
+    return HttpResponse.json({
+      watchlist_near_trigger: watchlistItems.filter((item) => {
+        const distance = item.distance_to_trigger_pct
+        return typeof distance === 'number' && distance >= -3 && distance <= 0
+      }),
+      new_candidates: [],
+      positions_add_on_candidates: [],
+      positions_hold: [],
+      positions_update_stop: [],
+      positions_close: [],
+      summary: {
+        total_positions: 0,
+        no_action: 0,
+        update_stop: 0,
+        close_positions: 0,
+        new_candidates: 0,
+        add_on_candidates: 0,
+        watchlist_near_trigger: watchlistItems.filter((item) => {
+          const distance = item.distance_to_trigger_pct
+          return typeof distance === 'number' && distance >= -3 && distance <= 0
+        }).length,
+        review_date: '2026-05-04',
+      },
+    })
+  }),
+
+  http.post(`${API_BASE_URL}/api/daily-review/compute`, () => {
+    return HttpResponse.json({
+      watchlist_near_trigger: [],
+      new_candidates: [],
+      positions_add_on_candidates: [],
+      positions_hold: [],
+      positions_update_stop: [],
+      positions_close: [],
+      summary: {
+        total_positions: 0,
+        no_action: 0,
+        update_stop: 0,
+        close_positions: 0,
+        new_candidates: 0,
+        add_on_candidates: 0,
+        watchlist_near_trigger: 0,
+        review_date: '2026-05-04',
+      },
+    })
   }),
 
   // Screener endpoints

--- a/web-ui/src/types/config.ts
+++ b/web-ui/src/types/config.ts
@@ -27,6 +27,8 @@ export interface ManageConfig {
   trailSma: number;
   smaBufferPct: number;
   maxHoldingDays: number;
+  timeStopDays: number;
+  timeStopMinR: number;
 }
 
 export interface AppConfig {
@@ -66,6 +68,8 @@ export interface ManageConfigAPI {
   trail_sma: number;
   sma_buffer_pct: number;
   max_holding_days: number;
+  time_stop_days?: number;
+  time_stop_min_r?: number;
 }
 
 export interface AppConfigAPI {
@@ -105,6 +109,8 @@ export function transformAppConfig(api: AppConfigAPI): AppConfig {
       trailSma: api.manage.trail_sma,
       smaBufferPct: api.manage.sma_buffer_pct,
       maxHoldingDays: api.manage.max_holding_days,
+      timeStopDays: api.manage.time_stop_days ?? 15,
+      timeStopMinR: api.manage.time_stop_min_r ?? 0.5,
     },
     positionsFile: api.positions_file,
     ordersFile: api.orders_file,
@@ -140,6 +146,8 @@ export function toAppConfigAPI(config: AppConfig): AppConfigAPI {
       trail_sma: config.manage.trailSma,
       sma_buffer_pct: config.manage.smaBufferPct,
       max_holding_days: config.manage.maxHoldingDays,
+      time_stop_days: config.manage.timeStopDays,
+      time_stop_min_r: config.manage.timeStopMinR,
     },
     positions_file: config.positionsFile,
     orders_file: config.ordersFile,


### PR DESCRIPTION
## Summary

- Adds soft stale-trade thresholds (`time_stop_days`, `time_stop_min_r`) to manage config and strategy settings.
- Adds `days_open` and `time_stop_warning` to portfolio metrics and daily review position payloads.
- Shows amber stale-trade badges in Book position rows and Today action rows when a position is old and below the configured R threshold.
- Mirrors the behavior in local persistence mode and documents Feature 6 as the final Tier 1 stacked PR.

## Validation

- `pytest tests/api/test_time_stop_nudge.py -v`
- `pytest tests/api/test_daily_review_service.py tests/api/test_time_stop_nudge.py -q`
- `pytest -q`
- `cd web-ui && npx vitest run src/components/domain/workspace/PortfolioTable.test.tsx`
- `cd web-ui && npx vitest run`
- `cd web-ui && npm run typecheck`

## Stack

Base: `codex/concentration-warning`
Head: `codex/time-stop-nudge`