### PR TITLE
Feature 7: add watchlist pipeline view

### DIFF
--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -22,6 +22,7 @@ from api.services.intelligence_service import IntelligenceService
 from api.services.portfolio_service import PortfolioService
 from api.services.screener_service import ScreenerService
 from api.services.strategy_service import StrategyService
+from api.services.watchlist_service import WatchlistService
 from api.services.workspace_context_service import WorkspaceContextService
 from api.utils.files import read_json_file, write_json_file, get_today_str
 from swing_screener.settings import data_dir, get_settings_manager, project_root
@@ -77,6 +78,13 @@ def get_watchlist_repo() -> WatchlistRepository:
 
 def get_strategy_repo() -> StrategyRepository:
     return StrategyRepository()
+
+
+def get_watchlist_service(
+    watchlist_repo: WatchlistRepository = Depends(get_watchlist_repo),
+    strategy_repo: StrategyRepository = Depends(get_strategy_repo),
+) -> WatchlistService:
+    return WatchlistService(repo=watchlist_repo, strategy_repo=strategy_repo)
 
 
 def get_intelligence_config_repo() -> IntelligenceConfigRepository:

--- a/api/models/daily_review.py
+++ b/api/models/daily_review.py
@@ -6,6 +6,7 @@ from api.models.recommendation import Recommendation
 from api.models.portfolio import Position
 from api.models.screener import SameSymbolCandidateContext
 from api.models.strategy import Strategy
+from api.models.watchlist import WatchlistItemView
 from swing_screener.recommendation.models import DecisionSummary
 
 
@@ -88,11 +89,13 @@ class DailyReviewSummary(BaseModel):
     close_positions: int
     new_candidates: int
     add_on_candidates: int = 0
+    watchlist_near_trigger: int = 0
     review_date: date
 
 
 class DailyReview(BaseModel):
     """Complete daily review with action items."""
+    watchlist_near_trigger: list[WatchlistItemView] = Field(default_factory=list)
     new_candidates: list[DailyReviewCandidate]
     positions_add_on_candidates: list[DailyReviewCandidate] = Field(default_factory=list)
     positions_hold: list[DailyReviewPositionHold]

--- a/api/models/watchlist.py
+++ b/api/models/watchlist.py
@@ -8,6 +8,8 @@ from typing import Optional
 
 from pydantic import BaseModel, Field, field_validator
 
+from api.models.screener import PriceHistoryPoint
+
 
 class WatchItemUpsertRequest(BaseModel):
     watch_price: Optional[float] = Field(default=None, description="Price captured when watch is created.")
@@ -75,10 +77,18 @@ class WatchItem(BaseModel):
         return WatchItemUpsertRequest._normalize_source(value)
 
 
+class WatchlistItemView(WatchItem):
+    current_price: Optional[float] = None
+    last_bar: Optional[str] = None
+    signal: Optional[str] = None
+    signal_trigger_price: Optional[float] = None
+    distance_to_trigger_pct: Optional[float] = None
+    price_history: list[PriceHistoryPoint] = Field(default_factory=list)
+
+
 class WatchlistResponse(BaseModel):
-    items: list[WatchItem] = Field(default_factory=list)
+    items: list[WatchlistItemView] = Field(default_factory=list)
 
 
 class WatchlistDeleteResponse(BaseModel):
     deleted: bool
-

--- a/api/routers/daily_review.py
+++ b/api/routers/daily_review.py
@@ -5,7 +5,9 @@ from api.models.daily_review import DailyReview, DailyReviewComputeRequest
 from api.services.daily_review_service import DailyReviewService
 from api.services.screener_service import ScreenerService
 from api.services.portfolio_service import PortfolioService
+from api.services.watchlist_service import WatchlistService
 from api.dependencies import (
+    get_watchlist_service,
     get_screener_service,
     get_portfolio_service,
 )
@@ -24,9 +26,10 @@ def _dump_payload_item(item):
 def get_daily_review_service(
     screener_service: ScreenerService = Depends(get_screener_service),
     portfolio_service: PortfolioService = Depends(get_portfolio_service),
+    watchlist_service: WatchlistService = Depends(get_watchlist_service),
 ) -> DailyReviewService:
     """Dependency injection for DailyReviewService."""
-    return DailyReviewService(screener_service, portfolio_service)
+    return DailyReviewService(screener_service, portfolio_service, watchlist_service=watchlist_service)
 
 
 @router.get("", response_model=DailyReview)

--- a/api/routers/watchlist.py
+++ b/api/routers/watchlist.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import ValidationError
 
-from api.dependencies import get_watchlist_repo
+from api.dependencies import get_watchlist_repo, get_watchlist_service
 from api.models.watchlist import (
     WatchItem,
     WatchItemUpsertRequest,
@@ -12,15 +12,16 @@ from api.models.watchlist import (
     WatchlistResponse,
 )
 from api.repositories.watchlist_repo import WatchlistRepository
+from api.services.watchlist_service import WatchlistService
 
 router = APIRouter()
 
 
 @router.get("", response_model=WatchlistResponse)
 async def list_watchlist(
-    repo: WatchlistRepository = Depends(get_watchlist_repo),
+    service: WatchlistService = Depends(get_watchlist_service),
 ):
-    return WatchlistResponse(items=repo.list_items())
+    return WatchlistResponse(items=service.list_items())
 
 
 @router.put("/{ticker}", response_model=WatchItem)

--- a/api/services/daily_review_service.py
+++ b/api/services/daily_review_service.py
@@ -17,6 +17,7 @@ from api.models.daily_review import (
 from api.models.screener import ScreenerRequest
 from api.services.screener_service import ScreenerService
 from api.services.portfolio_service import PortfolioService
+from api.services.watchlist_service import WatchlistService
 from swing_screener.portfolio.state import ManageConfig as ManageStateConfig
 
 logger = logging.getLogger(__name__)
@@ -29,10 +30,12 @@ class DailyReviewService:
         self,
         screener_service: ScreenerService,
         portfolio_service: PortfolioService,
+        watchlist_service: WatchlistService | None = None,
         data_dir: Path = Path("data"),
     ):
         self.screener = screener_service
         self.portfolio = portfolio_service
+        self.watchlist = watchlist_service
         self.data_dir = data_dir
         self.daily_reviews_dir = data_dir / "daily_reviews"
         self.daily_reviews_dir.mkdir(parents=True, exist_ok=True)
@@ -93,6 +96,7 @@ class DailyReviewService:
             )
         new_candidates = [_to_daily_candidate(c) for c in candidates if c.same_symbol is None or c.same_symbol.mode == "NEW_ENTRY"]
         add_on_candidates = [_to_daily_candidate(c) for c in candidates if c.same_symbol is not None and c.same_symbol.mode == "ADD_ON"]
+        watchlist_near_trigger = self._watchlist_near_trigger_items()
         
         # 2. Analyze all open positions
         active_manage = self._active_manage_cfg_payload()
@@ -202,10 +206,12 @@ class DailyReviewService:
             close_positions=len(positions_close),
             new_candidates=len(new_candidates),
             add_on_candidates=len(add_on_candidates),
+            watchlist_near_trigger=len(watchlist_near_trigger),
             review_date=date.today(),
         )
-        
+
         review = DailyReview(
+            watchlist_near_trigger=watchlist_near_trigger,
             new_candidates=new_candidates,
             positions_add_on_candidates=add_on_candidates,
             positions_hold=positions_hold,
@@ -218,6 +224,25 @@ class DailyReviewService:
         self._save_review(review, "default")
         
         return review
+
+    def _watchlist_near_trigger_items(self) -> list:
+        if self.watchlist is None:
+            return []
+        try:
+            items = self.watchlist.list_items()
+        except Exception:
+            logger.exception("Unable to build watchlist near-trigger section for daily review")
+            return []
+        near_trigger = []
+        for item in items:
+            distance = (
+                item.distance_to_trigger_pct
+                if hasattr(item, "distance_to_trigger_pct")
+                else item.get("distance_to_trigger_pct")
+            )
+            if distance is not None and -3.0 <= float(distance) <= 0.0:
+                near_trigger.append(item)
+        return near_trigger
 
     def _active_manage_cfg_payload(self) -> dict:
         strategy_repo = getattr(self.screener, "_strategy_repo", None)
@@ -433,6 +458,7 @@ class DailyReviewService:
                 )
 
         return DailyReview(
+            watchlist_near_trigger=[],
             new_candidates=new_candidates,
             positions_add_on_candidates=add_on_candidates,
             positions_hold=positions_hold,
@@ -445,6 +471,7 @@ class DailyReviewService:
                 close_positions=len(positions_close),
                 new_candidates=len(new_candidates),
                 add_on_candidates=len(add_on_candidates),
+                watchlist_near_trigger=0,
                 review_date=date.today(),
             ),
         )

--- a/api/services/watchlist_service.py
+++ b/api/services/watchlist_service.py
@@ -1,0 +1,149 @@
+"""Watchlist enrichment service."""
+from __future__ import annotations
+
+import logging
+from dataclasses import replace
+from typing import Optional
+
+import pandas as pd
+
+from api.models.screener import PriceHistoryPoint
+from api.models.watchlist import WatchItem, WatchlistItemView
+from api.repositories.strategy_repo import StrategyRepository
+from api.repositories.watchlist_repo import WatchlistRepository
+from api.utils.files import get_today_str
+from swing_screener.data.providers import MarketDataProvider, get_default_provider
+from swing_screener.selection.entries import build_signal_board
+from swing_screener.strategy.config import build_entry_config
+from swing_screener.utils.dataframe_helpers import get_close_matrix
+from swing_screener.utils.date_helpers import get_default_history_start
+
+logger = logging.getLogger(__name__)
+
+WATCHLIST_SPARKLINE_BARS = 5
+
+
+def _to_iso(ts) -> Optional[str]:
+    if ts is None or pd.isna(ts):
+        return None
+    if isinstance(ts, pd.Timestamp):
+        ts = ts.to_pydatetime()
+    if hasattr(ts, "isoformat"):
+        return ts.isoformat()
+    return str(ts)
+
+
+def _last_close_map(ohlcv: pd.DataFrame) -> tuple[dict[str, float], dict[str, str]]:
+    prices: dict[str, float] = {}
+    bars: dict[str, str] = {}
+    if ohlcv is None or ohlcv.empty:
+        return prices, bars
+    close = get_close_matrix(ohlcv)
+    for ticker in close.columns:
+        series = close[ticker].dropna()
+        if series.empty:
+            continue
+        prices[str(ticker)] = float(series.iloc[-1])
+        iso = _to_iso(series.index[-1])
+        if iso:
+            bars[str(ticker)] = iso
+    return prices, bars
+
+
+def _sparkline_history_map(ohlcv: pd.DataFrame, tickers: list[str]) -> dict[str, list[PriceHistoryPoint]]:
+    out: dict[str, list[PriceHistoryPoint]] = {}
+    if ohlcv is None or ohlcv.empty:
+        return out
+    close = get_close_matrix(ohlcv)
+    for ticker in tickers:
+        if ticker not in close.columns:
+            out[ticker] = []
+            continue
+        series = close[ticker].dropna().tail(WATCHLIST_SPARKLINE_BARS)
+        out[ticker] = [
+            PriceHistoryPoint(date=str(idx.date().isoformat() if hasattr(idx, "date") else idx), close=float(value))
+            for idx, value in series.items()
+        ]
+    return out
+
+
+def _compute_distance_pct(current_price: Optional[float], trigger_price: Optional[float]) -> Optional[float]:
+    if (
+        current_price is None
+        or trigger_price is None
+        or not pd.notna(current_price)
+        or not pd.notna(trigger_price)
+        or float(trigger_price) <= 0
+    ):
+        return None
+    return ((float(current_price) - float(trigger_price)) / float(trigger_price)) * 100.0
+
+
+class WatchlistService:
+    def __init__(
+        self,
+        repo: WatchlistRepository,
+        strategy_repo: StrategyRepository,
+        provider: Optional[MarketDataProvider] = None,
+    ) -> None:
+        self._repo = repo
+        self._strategy_repo = strategy_repo
+        self._provider = provider or get_default_provider()
+
+    def list_items(self) -> list[WatchlistItemView]:
+        items = self._repo.list_items()
+        if not items:
+            return []
+
+        tickers = [item.ticker for item in items]
+        enriched = {item.ticker: WatchlistItemView(**item.model_dump()) for item in items}
+
+        try:
+            strategy = self._strategy_repo.get_active_strategy()
+            signals_cfg = build_entry_config(strategy)
+            # The watchlist view should still compute trigger distance for names that do
+            # not yet have a full long-history candidate profile.
+            signals_cfg = replace(signals_cfg, min_history=min(int(signals_cfg.min_history), 60))
+            ohlcv = self._provider.fetch_ohlcv(
+                tickers,
+                start_date=get_default_history_start(),
+                end_date=get_today_str(),
+            )
+            if ohlcv is None or ohlcv.empty:
+                return self._sorted_items(items, enriched)
+
+            board = build_signal_board(ohlcv, tickers, cfg=signals_cfg)
+            last_prices, last_bars = _last_close_map(ohlcv)
+            sparkline_history = _sparkline_history_map(ohlcv, tickers)
+
+            for ticker in tickers:
+                row = board.loc[ticker] if ticker in board.index else None
+                trigger_price = None
+                signal = None
+                if row is not None:
+                    raw_trigger = row.get("breakout_level")
+                    trigger_price = float(raw_trigger) if pd.notna(raw_trigger) else None
+                    raw_signal = row.get("signal")
+                    signal = str(raw_signal) if pd.notna(raw_signal) else None
+                payload = enriched[ticker].model_dump()
+                payload.update(
+                    current_price=last_prices.get(ticker),
+                    last_bar=last_bars.get(ticker),
+                    signal=signal,
+                    signal_trigger_price=trigger_price,
+                    distance_to_trigger_pct=_compute_distance_pct(last_prices.get(ticker), trigger_price),
+                    price_history=sparkline_history.get(ticker, []),
+                )
+                enriched[ticker] = WatchlistItemView(**payload)
+        except Exception:
+            logger.exception("Failed to enrich watchlist pipeline view")
+
+        return self._sorted_items(items, enriched)
+
+    @staticmethod
+    def _sorted_items(items: list[WatchItem], enriched: dict[str, WatchlistItemView]) -> list[WatchlistItemView]:
+        def sort_key(item: WatchlistItemView) -> tuple[bool, float, str]:
+            distance = item.distance_to_trigger_pct
+            return (distance is None, distance if distance is not None else float("inf"), item.ticker)
+
+        return sorted((enriched[item.ticker] for item in items), key=sort_key)

--- a/docs/superpowers/plans/2026-05-04-feature-7-watchlist-pipeline.md
+++ b/docs/superpowers/plans/2026-05-04-feature-7-watchlist-pipeline.md
@@ -1,0 +1,54 @@
+# Watchlist Pipeline View — Implementation Plan
+
+> Read `docs/superpowers/plans/handover-context.md` before starting.
+
+**Goal:** Turn the watchlist from a static symbol list into a ranked pipeline that shows which names are closest to triggering, with enough context to review them quickly from Research and Daily Review.
+
+**Architecture:** Keep persisted watchlist storage unchanged and add a dedicated enrichment layer in the API. `WatchlistService` reads raw watchlist items from `WatchlistRepository`, fetches recent OHLCV with the existing market-data provider, computes the breakout trigger using the existing selection signal board, derives `distance_to_trigger_pct`, and returns a richer `WatchlistItemView`. Daily Review consumes the same service and filters names within 3% of the trigger zone into a new `watchlist_near_trigger` section. The frontend adds a Watchlist tab in Research and a compact near-trigger section in Today.
+
+**Tech Stack:** Python/FastAPI backend, React 18/TypeScript frontend, existing OHLCV provider and screener signal logic
+
+---
+
+## Implementation status - 2026-05-04
+
+Status: implemented on `codex/watchlist-pipeline`.
+
+Branch stack:
+
+- Branch: `codex/watchlist-pipeline`
+- Base: `codex/time-stop-nudge`
+- PR: pending
+
+What changed:
+
+- Added `WatchlistService` to enrich watchlist rows with `current_price`, `signal_trigger_price`, `distance_to_trigger_pct`, `signal`, `last_bar`, and a 5-bar `price_history` sparkline payload.
+- Extended the watchlist API response shape with `WatchlistItemView` while keeping `watchlist.json` persistence untouched.
+- Added a Research > Watchlist tab with a pipeline table sorted by distance to trigger and a 5-day sparkline.
+- Added a Daily Review section `watchlist_near_trigger` surfaced above new candidates for names within 3% of the buy zone.
+- Added focused backend and frontend coverage for the enrichment path, Daily Review mapping, and the new UI panel.
+
+Validation run:
+
+- `pytest tests/api/test_watchlist_service.py tests/api/test_daily_review_service.py tests/api/test_watchlist_endpoints.py`
+- `cd web-ui && npm test -- --run src/components/domain/watchlist/WatchlistPipelinePanel.test.tsx src/features/dailyReview/types.test.ts src/pages/Today.test.tsx src/features/watchlist/hooks.test.tsx`
+- `cd web-ui && npm run typecheck`
+
+---
+
+## File map
+
+| File | Change |
+|---|---|
+| `api/models/watchlist.py` | Add `WatchlistItemView` with enriched trigger-distance fields |
+| `api/services/watchlist_service.py` | New enrichment service for pipeline ordering and sparkline history |
+| `api/routers/watchlist.py` | Serve enriched watchlist items via `WatchlistService` |
+| `api/models/daily_review.py` | Add `watchlist_near_trigger` to the Daily Review payload |
+| `api/services/daily_review_service.py` | Pull near-trigger watchlist names into Today |
+| `web-ui/src/components/domain/watchlist/WatchlistPipelinePanel.tsx` | New Research watchlist pipeline panel |
+| `web-ui/src/pages/Research.tsx` | Add Watchlist tab and ticker handoff into analysis |
+| `web-ui/src/pages/Today.tsx` | Render the near-trigger watchlist section above candidates |
+| `web-ui/src/features/watchlist/types.ts` | Extend watchlist client types with enrichment fields |
+| `web-ui/src/features/dailyReview/types.ts` | Map the new Daily Review watchlist section |
+| `tests/api/test_watchlist_service.py` | Backend enrichment and sorting coverage |
+| `web-ui/src/components/domain/watchlist/WatchlistPipelinePanel.test.tsx` | Frontend watchlist panel coverage |

--- a/docs/superpowers/plans/handover-context.md
+++ b/docs/superpowers/plans/handover-context.md
@@ -6,7 +6,7 @@ Read this before picking up any feature plan. It describes the codebase conventi
 
 ## Current implementation status - 2026-05-04
 
-Tier 1 (all 6 features) is in progress as sequential stacked PRs:
+Tier 1 is complete locally and Tier 2 has started as sequential stacked PRs:
 
 | Feature | Branch | Base | PR | Status |
 |---|---|---|---|---|
@@ -16,12 +16,15 @@ Tier 1 (all 6 features) is in progress as sequential stacked PRs:
 | Feature 4 - Earnings proximity warning | `codex/earnings-warning` | `codex/account-equity` | https://github.com/matteolongo/swing_screener/pull/235 | Draft, fully implemented (incl. cache-hit test) |
 | Feature 5 - Concentration warning | `codex/concentration-warning` | `codex/earnings-warning` | https://github.com/matteolongo/swing_screener/pull/236 | Draft, fully implemented (incl. order modal warning) |
 | Feature 6 - Time stop nudge | `codex/time-stop-nudge` | `codex/concentration-warning` | pending | Implemented locally |
+| Feature 7 - Watchlist pipeline | `codex/watchlist-pipeline` | `codex/time-stop-nudge` | pending | Implemented locally |
 
 Review agents should review the PRs in order. Each branch intentionally builds on the previous one, so diffs should be compared against the listed base branch, not always against `main`.
 
 Known local dirty files that were not part of this work and should not be included unless explicitly requested:
 
 - `config/intelligence.yaml`
+- `config/strategies.yaml`
+- `config/user.yaml`
 - `data/screener_history.json`
 
 Validation already run during implementation:
@@ -31,6 +34,8 @@ Validation already run during implementation:
 - Feature 3: `pytest tests/api/test_account_equity.py -v`, `pytest -q`, `cd web-ui && npm run typecheck`, `cd web-ui && npx vitest run src/components/domain/strategy/EnhancedRiskCard.test.tsx`, `cd web-ui && npx vitest run`.
 - Feature 4: `pytest tests/api/test_earnings_proximity.py -v` (includes cache-hit coverage), `pytest -q`, `cd web-ui && npm run typecheck`, `cd web-ui && npx vitest run`.
 - Feature 5: `pytest tests/api/test_concentration.py -v`, `cd web-ui && npx vitest run src/components/domain/portfolio/ConcentrationBar.test.tsx`, focused order review frontend tests, `pytest -q`, `cd web-ui && npm run typecheck`, `cd web-ui && npx vitest run`.
+- Feature 6: `pytest tests/api/test_time_stop_nudge.py -v`, `cd web-ui && npx vitest run src/components/domain/workspace/PortfolioTable.test.tsx`, `cd web-ui && npm run typecheck`.
+- Feature 7: `pytest tests/api/test_watchlist_service.py tests/api/test_daily_review_service.py tests/api/test_watchlist_endpoints.py`, `cd web-ui && npm test -- --run src/components/domain/watchlist/WatchlistPipelinePanel.test.tsx src/features/dailyReview/types.test.ts src/pages/Today.test.tsx src/features/watchlist/hooks.test.tsx`, `cd web-ui && npm run typecheck`.
 
 ## What this app is
 
@@ -132,6 +137,6 @@ Use `locked_read_json` / `locked_write_json` from `api/utils/file_lock.py` — n
 
 ## Active branch
 
-Current stacked feature work is on `codex/time-stop-nudge`. Tier 1 is complete once PR #6 is merged.
+Current stacked feature work is on `codex/watchlist-pipeline`. Tier 2 has started on top of the Tier 1 stack.
 
-Next work should start Tier 2 planning from Feature 7 — Watchlist pipeline.
+Next work should continue Tier 2 from Feature 8 — Volume quality signal.

--- a/docs/superpowers/specs/2026-05-03-swing-trading-feature-roadmap.md
+++ b/docs/superpowers/specs/2026-05-03-swing-trading-feature-roadmap.md
@@ -18,7 +18,7 @@ Features are grouped into tiers. Ship all of Tier 1 before starting Tier 2.
 
 ## Implementation status - 2026-05-04
 
-Tier 1 is being shipped as sequential stacked PRs:
+Tier 1 is implemented locally and Tier 2 has started as sequential stacked PRs:
 
 | # | Feature | Branch | Base | PR | Status |
 |---|---|---|---|---|---|
@@ -28,6 +28,7 @@ Tier 1 is being shipped as sequential stacked PRs:
 | 4 | Earnings warning | `codex/earnings-warning` | `codex/account-equity` | https://github.com/matteolongo/swing_screener/pull/235 | Draft, implemented |
 | 5 | Concentration warning | `codex/concentration-warning` | `codex/earnings-warning` | https://github.com/matteolongo/swing_screener/pull/236 | Draft, implemented |
 | 6 | Time stop nudge | `codex/time-stop-nudge` | `codex/concentration-warning` | pending | Implemented locally |
+| 7 | Watchlist pipeline view | `codex/watchlist-pipeline` | `codex/time-stop-nudge` | pending | Implemented locally |
 
 Review stacked PRs in order and compare each PR against its listed base branch.
 

--- a/tests/api/test_daily_review_service.py
+++ b/tests/api/test_daily_review_service.py
@@ -430,6 +430,50 @@ def test_generate_daily_review_no_candidates(mock_portfolio_service, tmp_path):
     assert review.summary.total_positions == 3
 
 
+def test_generate_daily_review_includes_watchlist_near_trigger(
+    mock_screener_service,
+    mock_portfolio_service,
+    tmp_path,
+):
+    watchlist_service = Mock()
+    watchlist_service.list_items.return_value = [
+        {
+            "ticker": "ASML",
+            "watched_at": "2026-05-01T10:00:00Z",
+            "watch_price": 660.0,
+            "currency": "EUR",
+            "source": "screener",
+            "current_price": 671.0,
+            "signal_trigger_price": 680.0,
+            "distance_to_trigger_pct": -1.32,
+            "price_history": [],
+        },
+        {
+            "ticker": "SAP",
+            "watched_at": "2026-05-01T10:00:00Z",
+            "watch_price": 250.0,
+            "currency": "EUR",
+            "source": "screener",
+            "current_price": 260.0,
+            "signal_trigger_price": 270.0,
+            "distance_to_trigger_pct": -3.7,
+            "price_history": [],
+        },
+    ]
+
+    service = DailyReviewService(
+        mock_screener_service,
+        mock_portfolio_service,
+        watchlist_service=watchlist_service,
+        data_dir=tmp_path,
+    )
+
+    review = service.generate_daily_review(top_n=10)
+
+    assert [item.ticker for item in review.watchlist_near_trigger] == ["ASML"]
+    assert review.summary.watchlist_near_trigger == 1
+
+
 def test_generate_daily_review_survives_stop_suggestion_error(
     mock_screener_service,
     mock_portfolio_service,

--- a/tests/api/test_watchlist_service.py
+++ b/tests/api/test_watchlist_service.py
@@ -1,0 +1,43 @@
+from unittest.mock import Mock
+
+import pytest
+import pandas as pd
+
+from api.models.watchlist import WatchItemUpsertRequest
+from api.repositories.watchlist_repo import WatchlistRepository
+from api.services.watchlist_service import WatchlistService
+from swing_screener.strategy.storage import _default_strategy_payload
+
+
+class _FakeProvider:
+    def fetch_ohlcv(self, tickers, start_date: str, end_date: str):  # noqa: ANN001
+        index = pd.date_range("2026-02-20", periods=70, freq="D")
+        columns = pd.MultiIndex.from_product([["Close"], tickers])
+        data = [[95.0 + idx * 0.1, 49.0 + idx * 0.05] for idx in range(len(index))]
+        data[-2] = [101.0, 52.0]
+        data[-1] = [102.0, 52.5]
+        return pd.DataFrame(data, index=index, columns=columns)
+
+
+def test_watchlist_service_enriches_and_sorts_items(tmp_path):
+    repo = WatchlistRepository(tmp_path / "watchlist.json")
+    repo.upsert_item("AAPL", WatchItemUpsertRequest(watch_price=90.0, currency="USD", source="screener"))
+    repo.upsert_item("MSFT", WatchItemUpsertRequest(watch_price=45.0, currency="USD", source="screener"))
+
+    strategy_repo = Mock()
+    strategy_repo.get_active_strategy.return_value = _default_strategy_payload()  # noqa: SLF001
+
+    service = WatchlistService(repo=repo, strategy_repo=strategy_repo, provider=_FakeProvider())
+    items = service.list_items()
+
+    assert [item.ticker for item in items] == ["MSFT", "AAPL"]
+    msft, aapl = items
+    assert aapl.current_price == 102.0
+    assert aapl.signal_trigger_price is not None
+    assert aapl.signal_trigger_price < aapl.current_price
+    assert aapl.distance_to_trigger_pct == pytest.approx(
+        100.0 * (aapl.current_price - aapl.signal_trigger_price) / aapl.signal_trigger_price
+    )
+    assert len(aapl.price_history) == 5
+    assert aapl.price_history[-1].close == 102.0
+    assert msft.distance_to_trigger_pct <= aapl.distance_to_trigger_pct

--- a/web-ui/src/components/domain/watchlist/WatchlistPipelinePanel.test.tsx
+++ b/web-ui/src/components/domain/watchlist/WatchlistPipelinePanel.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '@/test/utils';
+import WatchlistPipelinePanel from '@/components/domain/watchlist/WatchlistPipelinePanel';
+
+vi.mock('@/features/watchlist/hooks', () => ({
+  useWatchlist: () => ({
+    data: [
+      {
+        ticker: 'ASML',
+        watchedAt: '2026-05-01T10:00:00Z',
+        watchPrice: 660,
+        currentPrice: 671,
+        currency: 'EUR',
+        source: 'screener',
+        signal: 'breakout',
+        signalTriggerPrice: 680,
+        distanceToTriggerPct: -1.3,
+        priceHistory: [
+          { date: '2026-04-28', close: 650 },
+          { date: '2026-04-29', close: 655 },
+          { date: '2026-04-30', close: 662 },
+          { date: '2026-05-01', close: 668 },
+          { date: '2026-05-02', close: 671 },
+        ],
+      },
+    ],
+    isLoading: false,
+    isError: false,
+  }),
+}));
+
+describe('WatchlistPipelinePanel', () => {
+  it('renders distance-to-trigger copy and sparkline row', () => {
+    renderWithProviders(<WatchlistPipelinePanel />);
+
+    expect(screen.getByText('Watchlist Pipeline')).toBeInTheDocument();
+    expect(screen.getByText('ASML')).toBeInTheDocument();
+    expect(screen.getByText('-1.3% to buy zone')).toBeInTheDocument();
+    expect(screen.getByText('Trigger €680.00')).toBeInTheDocument();
+    expect(screen.getByText('BREAKOUT')).toBeInTheDocument();
+  });
+});

--- a/web-ui/src/components/domain/watchlist/WatchlistPipelinePanel.tsx
+++ b/web-ui/src/components/domain/watchlist/WatchlistPipelinePanel.tsx
@@ -1,0 +1,175 @@
+import { useMemo } from 'react';
+import { ArrowUpRight, TrendingUp } from 'lucide-react';
+import WatchMetaInline from '@/components/domain/watchlist/WatchMetaInline';
+import { useWatchlist } from '@/features/watchlist/hooks';
+import type { WatchItem } from '@/features/watchlist/types';
+import { t } from '@/i18n/t';
+import { cn } from '@/utils/cn';
+import { formatCurrency, formatPercent } from '@/utils/formatters';
+
+interface WatchlistPipelinePanelProps {
+  onTickerSelect?: (ticker: string) => void;
+}
+
+function DistanceCell({ item }: { item: WatchItem }) {
+  if (item.distanceToTriggerPct == null) {
+    return <span className="text-sm text-gray-400 dark:text-gray-500">—</span>;
+  }
+  const distance = item.distanceToTriggerPct;
+  const isBelow = distance <= 0;
+  return (
+    <div className="flex flex-col items-end">
+      <span
+        className={cn(
+          'text-sm font-semibold tabular-nums',
+          isBelow ? 'text-amber-700 dark:text-amber-300' : 'text-emerald-700 dark:text-emerald-300',
+        )}
+      >
+        {isBelow
+          ? t('watchlist.pipeline.distanceToBuyZone', { value: formatPercent(distance) })
+          : t('watchlist.pipeline.aboveBuyZone', { value: formatPercent(distance) })}
+      </span>
+      {item.signalTriggerPrice != null ? (
+        <span className="text-[11px] text-gray-500 dark:text-gray-400">
+          {t('watchlist.pipeline.triggerPrice', {
+            value: formatCurrency(item.signalTriggerPrice, item.currency ?? 'USD'),
+          })}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+function Sparkline({ item }: { item: WatchItem }) {
+  const points = item.priceHistory ?? [];
+  const polyline = useMemo(() => {
+    if (points.length < 2) {
+      return '';
+    }
+    const values = points.map((point) => point.close);
+    const min = Math.min(...values);
+    const max = Math.max(...values);
+    const range = max - min || 1;
+    return values
+      .map((value, index) => {
+        const x = (index / (values.length - 1)) * 56;
+        const y = 20 - ((value - min) / range) * 16;
+        return `${x.toFixed(1)},${y.toFixed(1)}`;
+      })
+      .join(' ');
+  }, [points]);
+
+  if (!polyline) {
+    return <span className="text-xs text-gray-400 dark:text-gray-500">—</span>;
+  }
+
+  const first = points[0]?.close ?? 0;
+  const last = points[points.length - 1]?.close ?? 0;
+  const positive = last >= first;
+
+  return (
+    <svg viewBox="0 0 56 20" className="h-6 w-16 overflow-visible" aria-hidden="true">
+      <polyline
+        fill="none"
+        stroke={positive ? 'currentColor' : 'currentColor'}
+        strokeWidth="1.75"
+        points={polyline}
+        className={positive ? 'text-emerald-600 dark:text-emerald-400' : 'text-rose-600 dark:text-rose-400'}
+      />
+    </svg>
+  );
+}
+
+export default function WatchlistPipelinePanel({ onTickerSelect }: WatchlistPipelinePanelProps) {
+  const watchlistQuery = useWatchlist();
+  const items = watchlistQuery.data ?? [];
+
+  if (watchlistQuery.isLoading) {
+    return <div className="py-10 text-sm text-gray-500 dark:text-gray-400">{t('watchlist.pipeline.loading')}</div>;
+  }
+
+  if (watchlistQuery.isError) {
+    return (
+      <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900/50 dark:bg-red-950/30 dark:text-red-300">
+        {t('watchlist.pipeline.error')}
+      </div>
+    );
+  }
+
+  if (items.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed border-gray-300 px-4 py-10 text-center text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400">
+        {t('watchlist.pipeline.empty')}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">{t('watchlist.pipeline.title')}</h2>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">{t('watchlist.pipeline.subtitle')}</p>
+        </div>
+        <div className="inline-flex items-center gap-2 rounded-full bg-amber-50 px-3 py-1 text-xs font-medium text-amber-700 dark:bg-amber-950/40 dark:text-amber-300">
+          <TrendingUp className="h-3.5 w-3.5" />
+          {t('watchlist.pipeline.sortedByDistance')}
+        </div>
+      </div>
+
+      <div className="overflow-hidden rounded-lg border border-border">
+        <table className="min-w-full divide-y divide-border text-sm">
+          <thead className="bg-gray-50 dark:bg-gray-900/50">
+            <tr className="text-left text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+              <th className="px-4 py-3 font-semibold">{t('watchlist.pipeline.columns.symbol')}</th>
+              <th className="px-4 py-3 font-semibold">{t('watchlist.pipeline.columns.current')}</th>
+              <th className="px-4 py-3 font-semibold">{t('watchlist.pipeline.columns.distance')}</th>
+              <th className="px-4 py-3 font-semibold">{t('watchlist.pipeline.columns.sparkline')}</th>
+              <th className="px-4 py-3 font-semibold">{t('watchlist.pipeline.columns.status')}</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border bg-white dark:bg-gray-950/20">
+            {items.map((item) => (
+              <tr
+                key={item.ticker}
+                className={cn(
+                  'align-top transition-colors',
+                  onTickerSelect ? 'cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-900/30' : '',
+                )}
+                onClick={() => onTickerSelect?.(item.ticker)}
+              >
+                <td className="px-4 py-3">
+                  <div className="flex items-center gap-2">
+                    <span className="font-semibold text-gray-900 dark:text-gray-100">{item.ticker}</span>
+                    {onTickerSelect ? <ArrowUpRight className="h-3.5 w-3.5 text-gray-400" /> : null}
+                  </div>
+                  <WatchMetaInline
+                    watchedAt={item.watchedAt}
+                    watchPrice={item.watchPrice}
+                    currentPrice={item.currentPrice}
+                    currency={item.currency}
+                    className="mt-1 flex flex-wrap items-center gap-2 text-[11px]"
+                  />
+                </td>
+                <td className="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">
+                  {item.currentPrice != null ? formatCurrency(item.currentPrice, item.currency ?? 'USD') : '—'}
+                </td>
+                <td className="px-4 py-3">
+                  <DistanceCell item={item} />
+                </td>
+                <td className="px-4 py-3">
+                  <Sparkline item={item} />
+                </td>
+                <td className="px-4 py-3">
+                  <span className="inline-flex rounded-full bg-gray-100 px-2 py-1 text-[11px] font-medium text-gray-700 dark:bg-gray-800 dark:text-gray-300">
+                    {(item.signal ?? 'none').toUpperCase()}
+                  </span>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/web-ui/src/features/dailyReview/types.test.ts
+++ b/web-ui/src/features/dailyReview/types.test.ts
@@ -4,6 +4,19 @@ import { transformDailyReview, type DailyReviewAPI } from '@/features/dailyRevie
 describe('transformDailyReview', () => {
   it('maps candidate close and execution guidance fields', () => {
     const apiPayload: DailyReviewAPI = {
+      watchlist_near_trigger: [
+        {
+          ticker: 'ASML',
+          watched_at: '2026-05-01T10:00:00Z',
+          watch_price: 660,
+          currency: 'EUR',
+          source: 'screener',
+          current_price: 671,
+          signal_trigger_price: 680,
+          distance_to_trigger_pct: -1.3,
+          price_history: [],
+        },
+      ],
       new_candidates: [
         {
           ticker: 'AAPL',
@@ -67,11 +80,14 @@ describe('transformDailyReview', () => {
         close_positions: 0,
         new_candidates: 1,
         add_on_candidates: 0,
+        watchlist_near_trigger: 1,
         review_date: '2026-03-02',
       },
     };
 
     const result = transformDailyReview(apiPayload);
+    expect(result.watchlistNearTrigger[0].ticker).toBe('ASML');
+    expect(result.summary.watchlistNearTrigger).toBe(1);
     expect(result.newCandidates[0].close).toBe(100);
     expect(result.newCandidates[0].currency).toBe('USD');
     expect(result.newCandidates[0].score).toBe(83.2);

--- a/web-ui/src/features/dailyReview/types.ts
+++ b/web-ui/src/features/dailyReview/types.ts
@@ -8,6 +8,7 @@ import {
   type DecisionSummaryAPI,
   type SameSymbolCandidateContext,
 } from '@/features/screener/types';
+import { type WatchItem, type WatchItemAPI, transformWatchItem } from '@/features/watchlist/types';
 
 // API response types (snake_case from backend)
 export interface DailyReviewCandidateAPI {
@@ -95,10 +96,12 @@ export interface DailyReviewSummaryAPI {
   close_positions: number;
   new_candidates: number;
   add_on_candidates: number;
+  watchlist_near_trigger?: number;
   review_date: string;
 }
 
 export interface DailyReviewAPI {
+  watchlist_near_trigger?: WatchItemAPI[];
   new_candidates: DailyReviewCandidateAPI[];
   positions_add_on_candidates: DailyReviewCandidateAPI[];
   positions_hold: DailyReviewPositionHoldAPI[];
@@ -182,10 +185,12 @@ export interface DailyReviewSummary {
   closePositions: number;
   newCandidates: number;
   addOnCandidates: number;
+  watchlistNearTrigger: number;
   reviewDate: string;
 }
 
 export interface DailyReview {
+  watchlistNearTrigger: WatchItem[];
   newCandidates: DailyReviewCandidate[];
   positionsAddOnCandidates: DailyReviewCandidate[];
   positionsHold: DailyReviewPositionHold[];
@@ -328,12 +333,14 @@ export function transformSummary(api: DailyReviewSummaryAPI): DailyReviewSummary
     closePositions: api.close_positions,
     newCandidates: api.new_candidates,
     addOnCandidates: api.add_on_candidates,
+    watchlistNearTrigger: api.watchlist_near_trigger ?? 0,
     reviewDate: api.review_date,
   };
 }
 
 export function transformDailyReview(api: DailyReviewAPI): DailyReview {
   return {
+    watchlistNearTrigger: (api.watchlist_near_trigger ?? []).map(transformWatchItem),
     newCandidates: api.new_candidates.map(transformCandidate),
     positionsAddOnCandidates: (api.positions_add_on_candidates ?? []).map(transformCandidate),
     positionsHold: api.positions_hold.map(transformPositionHold),

--- a/web-ui/src/features/watchlist/api.ts
+++ b/web-ui/src/features/watchlist/api.ts
@@ -21,6 +21,7 @@ export async function fetchWatchlist(): Promise<WatchItem[]> {
       watchPrice: item.watchPrice ?? undefined,
       currency: item.currency ?? undefined,
       source: item.source,
+      priceHistory: [],
     }));
   }
 
@@ -51,6 +52,7 @@ export async function watchSymbol(request: WatchSymbolRequest): Promise<WatchIte
       watchPrice: saved.watchPrice ?? undefined,
       currency: saved.currency ?? undefined,
       source: saved.source,
+      priceHistory: [],
     };
   }
 
@@ -109,4 +111,3 @@ export async function unwatchSymbol(ticker: string): Promise<void> {
     throw new Error(message);
   }
 }
-

--- a/web-ui/src/features/watchlist/hooks.test.tsx
+++ b/web-ui/src/features/watchlist/hooks.test.tsx
@@ -46,6 +46,7 @@ describe('watchlist hooks', () => {
         watchPrice: 180,
         currency: 'USD',
         source: 'screener',
+        priceHistory: [],
       },
     ]);
 
@@ -70,6 +71,7 @@ describe('watchlist hooks', () => {
       watchPrice: 180,
       currency: 'USD',
       source: 'screener',
+      priceHistory: [],
     });
 
     const { result } = renderHook(() => useWatchSymbolMutation(), {
@@ -111,4 +113,3 @@ describe('watchlist hooks', () => {
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.watchlist() });
   });
 });
-

--- a/web-ui/src/features/watchlist/types.ts
+++ b/web-ui/src/features/watchlist/types.ts
@@ -1,9 +1,17 @@
+import type { PriceHistoryPoint } from '@/features/screener/types';
+
 export interface WatchItemAPI {
   ticker: string;
   watched_at: string;
   watch_price?: number | null;
   currency?: string | null;
   source: string;
+  current_price?: number | null;
+  last_bar?: string | null;
+  signal?: string | null;
+  signal_trigger_price?: number | null;
+  distance_to_trigger_pct?: number | null;
+  price_history?: PriceHistoryPoint[] | null;
 }
 
 export interface WatchlistResponseAPI {
@@ -16,6 +24,12 @@ export interface WatchItem {
   watchPrice?: number;
   currency?: string;
   source: string;
+  currentPrice?: number;
+  lastBar?: string;
+  signal?: string;
+  signalTriggerPrice?: number;
+  distanceToTriggerPct?: number;
+  priceHistory: PriceHistoryPoint[];
 }
 
 export interface WatchSymbolRequest {
@@ -32,6 +46,11 @@ export function transformWatchItem(api: WatchItemAPI): WatchItem {
     watchPrice: api.watch_price ?? undefined,
     currency: api.currency?.trim().toUpperCase() || undefined,
     source: api.source,
+    currentPrice: api.current_price ?? undefined,
+    lastBar: api.last_bar ?? undefined,
+    signal: api.signal ?? undefined,
+    signalTriggerPrice: api.signal_trigger_price ?? undefined,
+    distanceToTriggerPct: api.distance_to_trigger_pct ?? undefined,
+    priceHistory: api.price_history ?? [],
   };
 }
-

--- a/web-ui/src/i18n/messages.en.ts
+++ b/web-ui/src/i18n/messages.en.ts
@@ -53,6 +53,26 @@ export const messagesEn = {
       unavailable: '—',
       value: '{{abs}} ({{pct}})',
     },
+    pipeline: {
+      title: 'Watchlist Pipeline',
+      subtitle: 'Track which names are closest to their trigger zone.',
+      sortedByDistance: 'Closest first',
+      loading: 'Loading watchlist pipeline...',
+      error: 'Unable to load the watchlist pipeline.',
+      empty: 'No watchlist symbols yet.',
+      distanceToBuyZone: '{{value}} to buy zone',
+      aboveBuyZone: '{{value}} above buy zone',
+      triggerPrice: 'Trigger {{value}}',
+      columns: {
+        symbol: 'Symbol',
+        current: 'Current',
+        distance: 'Distance to Trigger',
+        sparkline: '5D',
+        status: 'Signal',
+      },
+      dailyReviewTitle: 'Watchlist nearing trigger',
+      dailyReviewSubtitle: '{{count}} names within 3% of the buy zone.',
+    },
   },
   modal: {
     closeAria: 'Close modal',
@@ -2074,6 +2094,7 @@ export const messagesEn = {
     tabs: {
       intelligence: 'Intelligence',
       fundamentals: 'Fundamentals',
+      watchlist: 'Watchlist',
       calendar: 'Calendar',
     },
     symbolSearch: {
@@ -2087,6 +2108,7 @@ export const messagesEn = {
       screener: 'Screener',
     },
     actionList: {
+      watchlistNearTrigger: 'Watchlist Near Trigger',
       requiresAction: 'Requires Action',
       opportunities: 'New Opportunities',
       holding: 'Holding',

--- a/web-ui/src/pages/Research.tsx
+++ b/web-ui/src/pages/Research.tsx
@@ -4,20 +4,23 @@ import { t } from '@/i18n/t';
 import IntelligencePage from './Intelligence';
 import FundamentalsPage from './Fundamentals';
 import EventsCalendar from '@/components/domain/calendar/EventsCalendar';
+import WatchlistPipelinePanel from '@/components/domain/watchlist/WatchlistPipelinePanel';
 import { usePositions } from '@/features/portfolio/hooks';
 import { useWatchlist } from '@/features/watchlist/hooks';
+import { useWorkspaceStore } from '@/stores/workspaceStore';
 
 const STORAGE_KEY = 'research.activeTab';
-type ResearchTab = 'intelligence' | 'fundamentals' | 'calendar';
+type ResearchTab = 'intelligence' | 'fundamentals' | 'watchlist' | 'calendar';
 
 export default function Research() {
   const [activeTab, setActiveTab] = useState<ResearchTab>(() => {
     const stored = localStorage.getItem(STORAGE_KEY);
-    if (stored === 'intelligence' || stored === 'fundamentals' || stored === 'calendar') {
+    if (stored === 'intelligence' || stored === 'fundamentals' || stored === 'watchlist' || stored === 'calendar') {
       return stored;
     }
     return 'intelligence';
   });
+  const setSelectedTicker = useWorkspaceStore((state) => state.setSelectedTicker);
 
   const openPositionsQuery = usePositions('open');
   const watchlistQuery = useWatchlist();
@@ -39,6 +42,7 @@ export default function Research() {
   const tabs: { key: ResearchTab; label: string }[] = [
     { key: 'intelligence', label: t('researchPage.tabs.intelligence') },
     { key: 'fundamentals', label: t('researchPage.tabs.fundamentals') },
+    { key: 'watchlist', label: t('researchPage.tabs.watchlist') },
     { key: 'calendar', label: t('researchPage.tabs.calendar') },
   ];
 
@@ -105,6 +109,16 @@ export default function Research() {
       <div>
         {activeTab === 'intelligence' && <IntelligencePage initialSymbol={committedSymbol} />}
         {activeTab === 'fundamentals' && <FundamentalsPage initialSymbol={committedSymbol} />}
+        {activeTab === 'watchlist' && (
+          <WatchlistPipelinePanel
+            onTickerSelect={(ticker) => {
+              setSharedSymbol(ticker);
+              setCommittedSymbol(ticker);
+              setSelectedTicker(ticker, 'screener');
+              setActiveTab('intelligence');
+            }}
+          />
+        )}
         {activeTab === 'calendar' && (
           <EventsCalendar symbols={calendarSymbols} daysAhead={30} />
         )}

--- a/web-ui/src/pages/Today.test.tsx
+++ b/web-ui/src/pages/Today.test.tsx
@@ -52,4 +52,48 @@ describe('Today page — pending orders badge', () => {
       screen.queryByText(t('todayPage.pendingBadge.singular', { count: '1' }))
     ).not.toBeInTheDocument();
   });
+
+  it('shows watchlist near-trigger section when daily review returns matches', async () => {
+    server.use(
+      http.get('*/api/portfolio/orders/local', () =>
+        HttpResponse.json({ orders: [], asof: '2026-04-28' })
+      ),
+      http.get('*/api/daily-review', () =>
+        HttpResponse.json({
+          watchlist_near_trigger: [
+            {
+              ticker: 'ASML',
+              watched_at: '2026-05-01T10:00:00Z',
+              watch_price: 660,
+              currency: 'EUR',
+              source: 'screener',
+              current_price: 671,
+              signal_trigger_price: 680,
+              distance_to_trigger_pct: -1.3,
+              price_history: [],
+            },
+          ],
+          new_candidates: [],
+          positions_add_on_candidates: [],
+          positions_hold: [],
+          positions_update_stop: [],
+          positions_close: [],
+          summary: {
+            total_positions: 0,
+            no_action: 0,
+            update_stop: 0,
+            close_positions: 0,
+            new_candidates: 0,
+            add_on_candidates: 0,
+            watchlist_near_trigger: 1,
+            review_date: '2026-05-04',
+          },
+        })
+      )
+    );
+
+    renderWithProviders(<Today />);
+    expect(await screen.findByText(new RegExp(t('watchlist.pipeline.dailyReviewTitle'), 'i'))).toBeInTheDocument();
+    expect(screen.getByText('ASML')).toBeInTheDocument();
+  });
 });

--- a/web-ui/src/pages/Today.tsx
+++ b/web-ui/src/pages/Today.tsx
@@ -5,6 +5,7 @@ import FloatingChatWidget from '@/components/domain/workspace/FloatingChatWidget
 import ScreenerInboxPanel from '@/components/domain/workspace/ScreenerInboxPanel';
 import ClosePositionModalForm from '@/components/domain/positions/ClosePositionModalForm';
 import UpdateStopModalForm from '@/components/domain/positions/UpdateStopModalForm';
+import WatchMetaInline from '@/components/domain/watchlist/WatchMetaInline';
 import { useSymbolIntelligenceRunner } from '@/features/intelligence/useSymbolIntelligenceRunner';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
 import { useDailyReview } from '@/features/dailyReview/api';
@@ -26,6 +27,7 @@ import type {
   DailyReviewPositionHold,
   DailyReviewPositionUpdate,
 } from '@/features/dailyReview/types';
+import type { WatchItem } from '@/features/watchlist/types';
 
 // ─── Action item row components ─────────────────────────────────────────────
 
@@ -214,6 +216,41 @@ function HoldItem({ item, onClick, isFocused }: HoldItemProps) {
   );
 }
 
+function WatchlistNearTriggerItem({ item, onClick, isFocused }: { item: WatchItem; onClick: (ticker: string) => void; isFocused?: boolean }) {
+  const distance = item.distanceToTriggerPct;
+  return (
+    <button
+      type="button"
+      onClick={() => onClick(item.ticker)}
+      className={cn(
+        'w-full text-left flex items-start gap-3 px-3 py-2 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors border-l-2 border-amber-400',
+        isFocused && 'ring-1 ring-primary',
+      )}
+    >
+      <span className="text-sm font-semibold text-gray-900 dark:text-gray-100 min-w-[60px]">
+        {item.ticker}
+      </span>
+      <span className="text-xs font-medium px-1.5 py-0.5 rounded bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">
+        {t('todayPage.actionList.watchlistNearTrigger')}
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="text-xs font-semibold tabular-nums text-amber-700 dark:text-amber-300">
+          {distance != null
+            ? t('watchlist.pipeline.distanceToBuyZone', { value: `${distance >= 0 ? '+' : ''}${formatNumber(distance, 1)}%` })
+            : '—'}
+        </div>
+        <WatchMetaInline
+          watchedAt={item.watchedAt}
+          watchPrice={item.watchPrice}
+          currentPrice={item.currentPrice}
+          currency={item.currency}
+          className="mt-0.5 flex flex-wrap items-center gap-2 text-[11px]"
+        />
+      </div>
+    </button>
+  );
+}
+
 // ─── Section header ──────────────────────────────────────────────────────────
 
 interface SectionHeaderProps {
@@ -353,6 +390,7 @@ function TodayActionList({ onTickerSelect }: TodayActionListProps) {
   // Flat ordered list for keyboard navigation
   const flatItems = useMemo(
     () => [
+      ...(review?.watchlistNearTrigger.map((i) => ({ ticker: i.ticker, id: `watch-${i.ticker}` })) ?? []),
       ...(review?.positionsClose.map((i) => ({ ticker: i.ticker, id: i.positionId })) ?? []),
       ...(review?.positionsUpdateStop.map((i) => ({ ticker: i.ticker, id: i.positionId })) ?? []),
       ...filteredCandidates.map((i) => ({ ticker: i.ticker, id: i.ticker })),
@@ -387,6 +425,7 @@ function TodayActionList({ onTickerSelect }: TodayActionListProps) {
 
   const requiresActionCount =
     (review?.positionsClose.length ?? 0) + (review?.positionsUpdateStop.length ?? 0);
+  const watchlistNearTriggerCount = review?.watchlistNearTrigger.length ?? 0;
   const opportunitiesCount = filteredCandidates.length + filteredAddOns.length;
   const holdCount = review?.positionsHold.length ?? 0;
 
@@ -406,7 +445,7 @@ function TodayActionList({ onTickerSelect }: TodayActionListProps) {
     );
   }
 
-  const isEmpty = requiresActionCount === 0 && opportunitiesCount === 0 && holdCount === 0;
+  const isEmpty = requiresActionCount === 0 && watchlistNearTriggerCount === 0 && opportunitiesCount === 0 && holdCount === 0;
 
   return (
     <div className="flex flex-col h-full overflow-hidden">
@@ -479,6 +518,31 @@ function TodayActionList({ onTickerSelect }: TodayActionListProps) {
           <p className="text-sm text-gray-500 dark:text-gray-400 px-2 py-4 text-center">
             {t('todayPage.actionList.empty')}
           </p>
+        )}
+
+        {/* Requires Action section */}
+        {watchlistNearTriggerCount > 0 && (
+          <div className="space-y-1">
+            <div className="px-3 py-1 text-xs font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-300 bg-amber-50 dark:bg-amber-900/20 rounded">
+              {t('watchlist.pipeline.dailyReviewTitle')} · {watchlistNearTriggerCount}
+            </div>
+            <p className="px-3 text-[11px] text-gray-500 dark:text-gray-400">
+              {t('watchlist.pipeline.dailyReviewSubtitle', { count: String(watchlistNearTriggerCount) })}
+            </p>
+            <div className="space-y-0.5">
+              {review?.watchlistNearTrigger.map((item) => {
+                const idx = flatItems.findIndex((fi) => fi.id === `watch-${item.ticker}`);
+                return (
+                  <WatchlistNearTriggerItem
+                    key={item.ticker}
+                    item={item}
+                    onClick={onTickerSelect}
+                    isFocused={focusedIndex === idx}
+                  />
+                );
+              })}
+            </div>
+          </div>
         )}
 
         {/* Requires Action section */}

--- a/web-ui/src/test/mocks/handlers.ts
+++ b/web-ui/src/test/mocks/handlers.ts
@@ -602,6 +602,12 @@ type WatchlistItemPayload = {
   watch_price: number | null
   currency: string | null
   source: string
+  current_price?: number | null
+  last_bar?: string | null
+  signal?: string | null
+  signal_trigger_price?: number | null
+  distance_to_trigger_pct?: number | null
+  price_history?: Array<{ date: string; close: number }>
 }
 let watchlistItems: WatchlistItemPayload[] = []
 
@@ -982,6 +988,55 @@ export const handlers = [
       return HttpResponse.json({ detail: `Watch item not found: ${ticker}` }, { status: 404 })
     }
     return HttpResponse.json({ deleted: true })
+  }),
+
+  // Daily review endpoints
+  http.get(`${API_BASE_URL}/api/daily-review`, () => {
+    return HttpResponse.json({
+      watchlist_near_trigger: watchlistItems.filter((item) => {
+        const distance = item.distance_to_trigger_pct
+        return typeof distance === 'number' && distance >= -3 && distance <= 0
+      }),
+      new_candidates: [],
+      positions_add_on_candidates: [],
+      positions_hold: [],
+      positions_update_stop: [],
+      positions_close: [],
+      summary: {
+        total_positions: 0,
+        no_action: 0,
+        update_stop: 0,
+        close_positions: 0,
+        new_candidates: 0,
+        add_on_candidates: 0,
+        watchlist_near_trigger: watchlistItems.filter((item) => {
+          const distance = item.distance_to_trigger_pct
+          return typeof distance === 'number' && distance >= -3 && distance <= 0
+        }).length,
+        review_date: '2026-05-04',
+      },
+    })
+  }),
+
+  http.post(`${API_BASE_URL}/api/daily-review/compute`, () => {
+    return HttpResponse.json({
+      watchlist_near_trigger: [],
+      new_candidates: [],
+      positions_add_on_candidates: [],
+      positions_hold: [],
+      positions_update_stop: [],
+      positions_close: [],
+      summary: {
+        total_positions: 0,
+        no_action: 0,
+        update_stop: 0,
+        close_positions: 0,
+        new_candidates: 0,
+        add_on_candidates: 0,
+        watchlist_near_trigger: 0,
+        review_date: '2026-05-04',
+      },
+    })
   }),
 
   // Screener endpoints


### PR DESCRIPTION
## Summary
- enrich watchlist items with live price, trigger price, distance-to-trigger, and 5-bar sparkline history
- add a Research watchlist pipeline tab sorted by distance to trigger
- surface a new Daily Review "watchlist nearing trigger" section and update the superpowers roadmap/handover docs

## Testing
- `pytest tests/api/test_watchlist_service.py tests/api/test_daily_review_service.py tests/api/test_watchlist_endpoints.py`
- `cd web-ui && npm test -- --run src/components/domain/watchlist/WatchlistPipelinePanel.test.tsx src/features/dailyReview/types.test.ts src/pages/Today.test.tsx src/features/watchlist/hooks.test.tsx`
- `cd web-ui && npm run typecheck`

## Notes
- stacked on `codex/time-stop-nudge`
- excluded unrelated local config/runtime dirt (`config/intelligence.yaml`, `config/strategies.yaml`, `config/user.yaml`, `data/screener_history.json`) from the commit