### PR TITLE
[codex] Fix EUR screener as-of date

### DIFF
--- a/web-ui/src/components/domain/workspace/ScreenerInboxPanel.test.tsx
+++ b/web-ui/src/components/domain/workspace/ScreenerInboxPanel.test.tsx
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+
+import { currencyFilterToRequest } from './ScreenerInboxPanel';
+
+describe('currencyFilterToRequest', () => {
+  it('does not force currencies when the filter is all', () => {
+    expect(currencyFilterToRequest('all')).toBeUndefined();
+  });
+
+  it('maps explicit filters to request currencies', () => {
+    expect(currencyFilterToRequest('usd')).toEqual(['USD']);
+    expect(currencyFilterToRequest('eur')).toEqual(['EUR']);
+  });
+});

--- a/web-ui/src/components/domain/workspace/ScreenerInboxPanel.tsx
+++ b/web-ui/src/components/domain/workspace/ScreenerInboxPanel.tsx
@@ -36,10 +36,10 @@ const DECISION_ACTION_FILTERS: DecisionActionFilter[] = [
 ];
 
 
-const currencyFilterToRequest = (value: CurrencyFilter): string[] => {
+export const currencyFilterToRequest = (value: CurrencyFilter): string[] | undefined => {
   if (value === 'usd') return ['USD'];
   if (value === 'eur') return ['EUR'];
-  return ['USD', 'EUR'];
+  return undefined;
 };
 
 const exchangeFilterToRequest = (value: ExchangeFilter): string[] | undefined => {


### PR DESCRIPTION
## What changed
- stop sending `currencies: ["USD", "EUR"]` when the screener currency filter is set to `all`
- let the backend infer currencies from the selected universe so Amsterdam-only runs resolve to the EUR market close
- add a focused regression test for the currency-filter request mapping

## Why
The frontend treated `all` as an explicit mixed US+EU request. That forced the backend to wait for the US close too, which left Amsterdam screens pinned to Friday, May 8, 2026 even after the European close on Monday, May 11, 2026.

## Impact
European-only universes now use the correct local market-close date when the user leaves the currency filter on `all`.

## Validation
- `npm run typecheck`
- `npm test -- --run src/components/domain/workspace/ScreenerInboxPanel.test.tsx`
