### PR TITLE
feat: per-position trail stop customization (F13)

### DIFF
--- a/api/models/portfolio.py
+++ b/api/models/portfolio.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 
 PositionStatus = Literal["open", "closed"]
 ActionType = Literal["NO_ACTION", "MOVE_STOP_UP", "CLOSE_STOP_HIT", "CLOSE_TIME_EXIT"]
+TrailMethod = Literal["sma20", "atr", "fixed_pct", "manual"]
 
 
 class Position(BaseModel):
@@ -44,6 +45,14 @@ class Position(BaseModel):
         default=None,
         description="FX rate (EURUSD) at position entry — used for FX-adjusted R display",
     )
+    trail_method: TrailMethod = Field(
+        default="sma20",
+        description="Trail stop method: sma20 | atr | fixed_pct | manual",
+    )
+    trail_param: Optional[float] = Field(
+        default=None,
+        description="Trail method parameter (ATR multiplier or fixed % value)",
+    )
 
 
 class PositionUpdate(BaseModel):
@@ -73,6 +82,14 @@ class UpdateStopRequest(BaseModel):
         if v > 100000:  # Reasonable upper bound
             raise ValueError("Stop price exceeds reasonable maximum (100,000)")
         return v
+
+
+class UpdateTrailMethodRequest(BaseModel):
+    trail_method: TrailMethod
+    trail_param: Optional[float] = Field(
+        default=None,
+        description="ATR multiplier (atr) or percentage (fixed_pct); null for sma20/manual",
+    )
 
 
 class PartialCloseEvent(BaseModel):

--- a/api/models/portfolio.py
+++ b/api/models/portfolio.py
@@ -88,6 +88,7 @@ class UpdateTrailMethodRequest(BaseModel):
     trail_method: TrailMethod
     trail_param: Optional[float] = Field(
         default=None,
+        ge=0,
         description="ATR multiplier (atr) or percentage (fixed_pct); null for sma20/manual",
     )
 

--- a/api/routers/portfolio.py
+++ b/api/routers/portfolio.py
@@ -20,6 +20,7 @@ from api.models.portfolio import (
     FillFromDegiroRequest,
     FillFromDegiroResponse,
     UpdateStopRequest,
+    UpdateTrailMethodRequest,
     ClosePositionRequest,
     PartialCloseRequest,
     StopSuggestionComputeRequest,
@@ -111,6 +112,16 @@ async def get_position_stop_suggestion(
 ):
     """Get suggested stop price for a position based on manage rules."""
     return service.suggest_position_stop(position_id)
+
+
+@router.patch("/positions/{position_id}/trail-method")
+async def update_position_trail_method(
+    position_id: str,
+    request: UpdateTrailMethodRequest,
+    service: PortfolioService = Depends(get_portfolio_service),
+):
+    """Update trail stop method for an open position."""
+    return service.update_trail_method(position_id, request)
 
 
 @router.post("/stop-suggestion/compute", response_model=PositionUpdate)

--- a/api/services/portfolio_service.py
+++ b/api/services/portfolio_service.py
@@ -29,6 +29,7 @@ from api.models.portfolio import (
     PositionMetrics,
     PortfolioSummary,
     UpdateStopRequest,
+    UpdateTrailMethodRequest,
     ClosePositionRequest,
 )
 from api.repositories.config_repo import ConfigRepository
@@ -238,6 +239,12 @@ def _to_state_position(position: dict) -> StatePosition:
         ),
         notes=str(position.get("notes", "")),
         exit_order_ids=position.get("exit_order_ids"),
+        trail_method=str(position.get("trail_method") or "sma20"),
+        trail_param=(
+            float(position["trail_param"])
+            if position.get("trail_param") is not None
+            else None
+        ),
     )
 
 
@@ -1184,6 +1191,26 @@ class PortfolioService:
         if position is None:
             raise HTTPException(status_code=404, detail=f"Position not found: {position_id}")
         return self._suggest_position_stop_from_dict(position)
+
+    def update_trail_method(self, position_id: str, request: UpdateTrailMethodRequest) -> dict:
+        data = self._positions_repo.read()
+        positions = data.get("positions", [])
+        for pos in positions:
+            if pos.get("position_id") == position_id:
+                if pos.get("status") != "open":
+                    raise HTTPException(
+                        status_code=400,
+                        detail="Cannot update trail method on a closed position",
+                    )
+                pos["trail_method"] = request.trail_method
+                pos["trail_param"] = request.trail_param
+                self._positions_repo.write(data)
+                return {
+                    "status": "ok",
+                    "position_id": position_id,
+                    "trail_method": request.trail_method,
+                }
+        raise HTTPException(status_code=404, detail=f"Position {position_id} not found")
 
     def list_degiro_orders(self) -> DegiroOrdersResponse:
         """Fetch live orders from DeGiro API."""

--- a/api/services/portfolio_service.py
+++ b/api/services/portfolio_service.py
@@ -1204,11 +1204,13 @@ class PortfolioService:
                     )
                 pos["trail_method"] = request.trail_method
                 pos["trail_param"] = request.trail_param
+                data["asof"] = get_today_str()
                 self._positions_repo.write(data)
                 return {
                     "status": "ok",
                     "position_id": position_id,
                     "trail_method": request.trail_method,
+                    "trail_param": request.trail_param,
                 }
         raise HTTPException(status_code=404, detail=f"Position {position_id} not found")
 

--- a/data/README.md
+++ b/data/README.md
@@ -17,6 +17,14 @@ User-authored configuration no longer lives under `data/`. Shared configuration 
 ## Daily Reviews
 - `daily_reviews/`: daily review snapshots (not committed)
 
+## positions.json schema notes
+
+New fields added in F13 (Trail Customization):
+- `trail_method`: `"sma20" | "atr" | "fixed_pct" | "manual"` — defaults to `"sma20"` when absent (backward-compatible)
+- `trail_param`: `float | null` — ATR multiplier for `atr`, percentage for `fixed_pct`; null for `sma20`/`manual`
+
+Existing positions without these fields behave identically to before (SMA20 trail is the default).
+
 ## Optional Database
 - `swing_screener.db`: SQLite database (module exists but not wired by default)
 - Migration notes: `docs/engineering/DATABASE_MIGRATION.md`

--- a/src/swing_screener/portfolio/state.py
+++ b/src/swing_screener/portfolio/state.py
@@ -155,6 +155,8 @@ def save_positions(
                 "broker_synced_at": pos.broker_synced_at,
                 "thesis": pos.thesis,
                 "lesson": pos.lesson,
+                "trail_method": pos.trail_method,
+                "trail_param": pos.trail_param,
             }
             for pos in positions
         ],

--- a/src/swing_screener/portfolio/state.py
+++ b/src/swing_screener/portfolio/state.py
@@ -38,6 +38,8 @@ class Position:
     broker_synced_at: Optional[str] = None
     thesis: Optional[str] = None
     lesson: Optional[str] = None
+    trail_method: str = "sma20"   # "sma20" | "atr" | "fixed_pct" | "manual"
+    trail_param: Optional[float] = None
 
 
 @dataclass
@@ -114,6 +116,12 @@ def load_positions(path: str | Path) -> list[Position]:
                 broker_synced_at=item.get("broker_synced_at", None),
                 thesis=item.get("thesis", None),
                 lesson=item.get("lesson", None),
+                trail_method=str(item.get("trail_method") or "sma20"),
+                trail_param=(
+                    float(item["trail_param"])
+                    if item.get("trail_param") is not None
+                    else None
+                ),
             )
         )
     return out
@@ -216,6 +224,21 @@ def _sma(s: pd.Series, window: int) -> float:
     if len(s) < window:
         return float("nan")
     return float(s.rolling(window).mean().iloc[-1])
+
+
+def _atr_stop(ohlcv: pd.DataFrame, ticker: str, last: float, multiplier: float, window: int = 14) -> float:
+    """Return ATR-based trail stop (last − ATR × multiplier), or NaN if data insufficient."""
+    try:
+        from swing_screener.indicators.volatility import compute_atr_per_ticker
+        high = ohlcv["High"][ticker].dropna()
+        low = ohlcv["Low"][ticker].dropna()
+        close = ohlcv["Close"][ticker].dropna()
+        atr_val = compute_atr_per_ticker(high, low, close, window)
+        if math.isnan(atr_val):
+            return float("nan")
+        return last - atr_val * multiplier
+    except (KeyError, Exception):
+        return float("nan")
 
 
 def _round_price(value: float) -> float:
@@ -331,13 +354,32 @@ def evaluate_positions(
             stop_suggested = max(stop_suggested, pos.entry_price)
             reason = f"Breakeven: R={r_now:.2f} >= {cfg.breakeven_at_R}"
 
-        # Rule 2: trail under SMA20 after +2R
+        # Rule 2: trail stop based on position's trail_method (after reaching trail_after_R)
         if r_now >= cfg.trail_after_R:
-            sma_val = _sma(s, cfg.trail_sma)
-            if not math.isnan(sma_val):
-                trail_stop = sma_val * (1.0 - cfg.sma_buffer_pct)
+            trail_method = pos.trail_method or "sma20"
+            trail_param = pos.trail_param
+
+            if trail_method == "sma20":
+                sma_val = _sma(s, cfg.trail_sma)
+                if not math.isnan(sma_val):
+                    trail_stop = sma_val * (1.0 - cfg.sma_buffer_pct)
+                    stop_suggested = max(stop_suggested, trail_stop)
+                    reason = f"Trail: R={r_now:.2f} >= {cfg.trail_after_R} and SMA{cfg.trail_sma} trail"
+
+            elif trail_method == "atr":
+                multiplier = trail_param if trail_param is not None else 2.0
+                trail_stop = _atr_stop(ohlcv, pos.ticker, last, multiplier)
+                if not math.isnan(trail_stop):
+                    stop_suggested = max(stop_suggested, trail_stop)
+                    reason = f"ATR trail: stop = last − ATR×{multiplier:.1f}"
+
+            elif trail_method == "fixed_pct":
+                param = trail_param if trail_param is not None else 5.0
+                trail_stop = last * (1.0 - param / 100.0)
                 stop_suggested = max(stop_suggested, trail_stop)
-                reason = f"Trail: R={r_now:.2f} >= {cfg.trail_after_R} and SMA{cfg.trail_sma} trail"
+                reason = f"Fixed % trail: stop = last × (1 − {param:.1f}%)"
+
+            # trail_method == "manual": no trail suggestion; only breakeven rule applies
 
         stop_old_rounded = _round_price(pos.stop_price)
         stop_suggested_rounded = _round_price(stop_suggested)

--- a/src/swing_screener/portfolio/state.py
+++ b/src/swing_screener/portfolio/state.py
@@ -239,7 +239,7 @@ def _atr_stop(ohlcv: pd.DataFrame, ticker: str, last: float, multiplier: float, 
         if math.isnan(atr_val):
             return float("nan")
         return last - atr_val * multiplier
-    except (KeyError, Exception):
+    except Exception:
         return float("nan")
 
 
@@ -369,14 +369,14 @@ def evaluate_positions(
                     reason = f"Trail: R={r_now:.2f} >= {cfg.trail_after_R} and SMA{cfg.trail_sma} trail"
 
             elif trail_method == "atr":
-                multiplier = trail_param if trail_param is not None else 2.0
+                multiplier = trail_param if trail_param is not None else 2.0  # 2× ATR is a common swing default
                 trail_stop = _atr_stop(ohlcv, pos.ticker, last, multiplier)
                 if not math.isnan(trail_stop):
                     stop_suggested = max(stop_suggested, trail_stop)
                     reason = f"ATR trail: stop = last − ATR×{multiplier:.1f}"
 
             elif trail_method == "fixed_pct":
-                param = trail_param if trail_param is not None else 5.0
+                param = trail_param if trail_param is not None else 5.0  # 5% is a conservative default
                 trail_stop = last * (1.0 - param / 100.0)
                 stop_suggested = max(stop_suggested, trail_stop)
                 reason = f"Fixed % trail: stop = last × (1 − {param:.1f}%)"

--- a/tests/api/test_trail_customization.py
+++ b/tests/api/test_trail_customization.py
@@ -73,6 +73,40 @@ def test_patch_trail_method_not_found(client):
     assert response.status_code == 404
 
 
+@pytest.fixture
+def client_closed(tmp_path, monkeypatch):
+    pos_file = tmp_path / "positions_closed.json"
+    ord_file = tmp_path / "orders_closed.json"
+    pos_file.write_text(json.dumps({
+        "asof": "2026-01-01",
+        "positions": [
+            {
+                "position_id": "POS-CLOSED",
+                "ticker": "AAPL",
+                "status": "closed",
+                "entry_date": "2025-10-01",
+                "entry_price": 150.0,
+                "stop_price": 140.0,
+                "shares": 10,
+                "exit_date": "2025-11-01",
+                "exit_price": 160.0,
+            }
+        ],
+    }))
+    ord_file.write_text(json.dumps({"orders": []}))
+    monkeypatch.setattr(deps, "_positions_path", pos_file)
+    monkeypatch.setattr(deps, "_orders_path", ord_file)
+    return TestClient(app)
+
+
+def test_patch_trail_method_closed_position_rejected(client_closed):
+    response = client_closed.patch(
+        "/api/portfolio/positions/POS-CLOSED/trail-method",
+        json={"trail_method": "atr", "trail_param": 2.0},
+    )
+    assert response.status_code == 400
+
+
 def test_positions_list_returns_trail_method(client):
     client.patch(
         "/api/portfolio/positions/POS-001/trail-method",

--- a/tests/api/test_trail_customization.py
+++ b/tests/api/test_trail_customization.py
@@ -1,0 +1,86 @@
+"""Tests for F13: per-position trail method PATCH endpoint."""
+import json
+import pytest
+from fastapi.testclient import TestClient
+from api.main import app
+import api.dependencies as deps
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    pos_file = tmp_path / "positions.json"
+    ord_file = tmp_path / "orders.json"
+    pos_file.write_text(json.dumps({
+        "asof": "2026-01-01",
+        "positions": [
+            {
+                "position_id": "POS-001",
+                "ticker": "AAPL",
+                "status": "open",
+                "entry_date": "2025-12-01",
+                "entry_price": 150.0,
+                "stop_price": 140.0,
+                "shares": 10,
+                "initial_risk": 10.0,
+            }
+        ],
+    }))
+    ord_file.write_text(json.dumps({"orders": []}))
+    monkeypatch.setattr(deps, "_positions_path", pos_file)
+    monkeypatch.setattr(deps, "_orders_path", ord_file)
+    return TestClient(app)
+
+
+def test_patch_trail_method_persists(client, tmp_path):
+    pos_file = tmp_path / "positions.json"
+    response = client.patch(
+        "/api/portfolio/positions/POS-001/trail-method",
+        json={"trail_method": "atr", "trail_param": 2.5},
+    )
+    assert response.status_code == 200
+    assert response.json()["trail_method"] == "atr"
+    stored = json.loads(pos_file.read_text())
+    pos = stored["positions"][0]
+    assert pos["trail_method"] == "atr"
+    assert pos["trail_param"] == 2.5
+
+
+def test_patch_trail_method_manual(client, tmp_path):
+    pos_file = tmp_path / "positions.json"
+    response = client.patch(
+        "/api/portfolio/positions/POS-001/trail-method",
+        json={"trail_method": "manual", "trail_param": None},
+    )
+    assert response.status_code == 200
+    stored = json.loads(pos_file.read_text())
+    assert stored["positions"][0]["trail_method"] == "manual"
+    assert stored["positions"][0]["trail_param"] is None
+
+
+def test_patch_trail_method_invalid_value(client):
+    response = client.patch(
+        "/api/portfolio/positions/POS-001/trail-method",
+        json={"trail_method": "unknown_method"},
+    )
+    assert response.status_code == 422
+
+
+def test_patch_trail_method_not_found(client):
+    response = client.patch(
+        "/api/portfolio/positions/DOES-NOT-EXIST/trail-method",
+        json={"trail_method": "sma20"},
+    )
+    assert response.status_code == 404
+
+
+def test_positions_list_returns_trail_method(client):
+    client.patch(
+        "/api/portfolio/positions/POS-001/trail-method",
+        json={"trail_method": "fixed_pct", "trail_param": 5.0},
+    )
+    response = client.get("/api/portfolio/positions?status=open")
+    assert response.status_code == 200
+    positions = response.json()["positions"]
+    pos = next(p for p in positions if p["position_id"] == "POS-001")
+    assert pos["trail_method"] == "fixed_pct"
+    assert pos["trail_param"] == 5.0

--- a/tests/test_trail_evaluate.py
+++ b/tests/test_trail_evaluate.py
@@ -54,7 +54,7 @@ def test_sma20_trail_triggers(ohlcv_above_entry):
     cfg = ManageConfig(trail_after_R=2.0, trail_sma=20, sma_buffer_pct=0.005, max_holding_days=0)
     updates, _ = evaluate_positions(ohlcv_above_entry, [pos], cfg)
     assert updates[0].action == "MOVE_STOP_UP"
-    assert "SMA20" in updates[0].reason
+    assert "SMA" in updates[0].reason and "trail" in updates[0].reason
 
 
 def test_atr_trail_stop_moves_up(ohlcv_above_entry):

--- a/tests/test_trail_evaluate.py
+++ b/tests/test_trail_evaluate.py
@@ -1,0 +1,87 @@
+"""Tests for F13: per-position trail method customization in evaluate_positions."""
+import math
+import pandas as pd
+import pytest
+from swing_screener.portfolio.state import ManageConfig, Position, evaluate_positions
+
+
+def _make_ohlcv(ticker: str, closes: list) -> pd.DataFrame:
+    n = len(closes)
+    dates = pd.date_range("2024-01-01", periods=n, freq="B")
+    highs = [c + 0.5 for c in closes]
+    lows = [c - 0.5 for c in closes]
+    tuples = (
+        [("High", ticker)] * n
+        + [("Low", ticker)] * n
+        + [("Close", ticker)] * n
+    )
+    idx = pd.MultiIndex.from_tuples(tuples)
+    values = highs + lows + closes
+    df = pd.DataFrame([values], columns=idx, index=dates[:1])
+    # Expand to n rows
+    rows = []
+    for i, d in enumerate(dates):
+        row = {("High", ticker): highs[i], ("Low", ticker): lows[i], ("Close", ticker): closes[i]}
+        rows.append(row)
+    df = pd.DataFrame(rows, index=dates)
+    df.columns = pd.MultiIndex.from_tuples(df.columns)
+    return df
+
+
+def _pos_at_3r(ticker: str, trail_method: str, trail_param=None) -> Position:
+    return Position(
+        ticker=ticker,
+        status="open",
+        entry_date="2024-01-01",
+        entry_price=100.0,
+        stop_price=90.0,  # 1R = 10
+        shares=10,
+        trail_method=trail_method,
+        trail_param=trail_param,
+    )
+
+
+@pytest.fixture
+def ohlcv_above_entry():
+    # 50 bars ending at 130 → R = (130-100)/10 = 3.0
+    closes = [101.0] * 30 + [120.0] * 10 + [130.0] * 10
+    return _make_ohlcv("AAPL", closes)
+
+
+def test_sma20_trail_triggers(ohlcv_above_entry):
+    pos = _pos_at_3r("AAPL", "sma20")
+    # max_holding_days=0 disables time-exit; entry_date far enough back for bars to count
+    cfg = ManageConfig(trail_after_R=2.0, trail_sma=20, sma_buffer_pct=0.005, max_holding_days=0)
+    updates, _ = evaluate_positions(ohlcv_above_entry, [pos], cfg)
+    assert updates[0].action == "MOVE_STOP_UP"
+    assert "SMA20" in updates[0].reason
+
+
+def test_atr_trail_stop_moves_up(ohlcv_above_entry):
+    pos = _pos_at_3r("AAPL", "atr", 2.0)
+    cfg = ManageConfig(trail_after_R=2.0, max_holding_days=0)
+    updates, _ = evaluate_positions(ohlcv_above_entry, [pos], cfg)
+    update = updates[0]
+    # ATR on constant 1.0-range bars ≈ 1.0; stop ≈ 130 - 2.0 = 128 > 90
+    assert update.stop_suggested >= pos.stop_price
+    assert "ATR" in update.reason
+
+
+def test_fixed_pct_trail_stop_correct(ohlcv_above_entry):
+    pos = _pos_at_3r("AAPL", "fixed_pct", 5.0)
+    cfg = ManageConfig(trail_after_R=2.0, max_holding_days=0)
+    updates, _ = evaluate_positions(ohlcv_above_entry, [pos], cfg)
+    update = updates[0]
+    # last=130; 5% trail → 130 * 0.95 = 123.5
+    assert abs(update.stop_suggested - 130.0 * 0.95) < 0.02
+    assert "Fixed" in update.reason
+
+
+def test_manual_trail_no_trail_beyond_breakeven(ohlcv_above_entry):
+    pos = _pos_at_3r("AAPL", "manual")
+    cfg = ManageConfig(trail_after_R=2.0, max_holding_days=0)
+    updates, _ = evaluate_positions(ohlcv_above_entry, [pos], cfg)
+    update = updates[0]
+    # manual: no trail; breakeven rule fires (stop moves to entry=100)
+    # stop_suggested must not exceed entry price (no trail beyond breakeven)
+    assert update.stop_suggested <= pos.entry_price + 0.01

--- a/web-ui/src/components/domain/positions/TrailMethodSelector.test.tsx
+++ b/web-ui/src/components/domain/positions/TrailMethodSelector.test.tsx
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import TrailMethodSelector from '@/components/domain/positions/TrailMethodSelector';
+import { t } from '@/i18n/t';
+
+describe('TrailMethodSelector', () => {
+  it('renders all four trail method options', () => {
+    render(<TrailMethodSelector value="sma20" param={null} onChange={vi.fn()} />);
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: t('positions.trailMethod.sma20') })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: t('positions.trailMethod.atr') })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: t('positions.trailMethod.fixedPct') })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: t('positions.trailMethod.manual') })).toBeInTheDocument();
+  });
+
+  it('shows param input for atr with default multiplier', () => {
+    render(<TrailMethodSelector value="atr" param={2.0} onChange={vi.fn()} />);
+    const input = screen.getByRole('spinbutton') as HTMLInputElement;
+    expect(input).toBeInTheDocument();
+    expect(input.value).toBe('2');
+  });
+
+  it('shows param input for fixed_pct', () => {
+    render(<TrailMethodSelector value="fixed_pct" param={5.0} onChange={vi.fn()} />);
+    expect(screen.getByRole('spinbutton')).toBeInTheDocument();
+  });
+
+  it('hides param input for sma20', () => {
+    render(<TrailMethodSelector value="sma20" param={null} onChange={vi.fn()} />);
+    expect(screen.queryByRole('spinbutton')).not.toBeInTheDocument();
+  });
+
+  it('hides param input for manual and shows note', () => {
+    render(<TrailMethodSelector value="manual" param={null} onChange={vi.fn()} />);
+    expect(screen.queryByRole('spinbutton')).not.toBeInTheDocument();
+    expect(screen.getByText(t('positions.trailMethod.manualNote'))).toBeInTheDocument();
+  });
+
+  it('calls onChange with default atr param when method changes to atr', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<TrailMethodSelector value="sma20" param={null} onChange={onChange} />);
+    await user.selectOptions(screen.getByRole('combobox'), 'atr');
+    expect(onChange).toHaveBeenCalledWith('atr', 2.0);
+  });
+
+  it('calls onChange with default fixed_pct param when method changes to fixed_pct', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<TrailMethodSelector value="sma20" param={null} onChange={onChange} />);
+    await user.selectOptions(screen.getByRole('combobox'), 'fixed_pct');
+    expect(onChange).toHaveBeenCalledWith('fixed_pct', 5.0);
+  });
+
+  it('calls onChange with null param when method changes to manual', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<TrailMethodSelector value="atr" param={2.0} onChange={onChange} />);
+    await user.selectOptions(screen.getByRole('combobox'), 'manual');
+    expect(onChange).toHaveBeenCalledWith('manual', null);
+  });
+});

--- a/web-ui/src/components/domain/positions/TrailMethodSelector.test.tsx
+++ b/web-ui/src/components/domain/positions/TrailMethodSelector.test.tsx
@@ -60,4 +60,10 @@ describe('TrailMethodSelector', () => {
     await user.selectOptions(screen.getByRole('combobox'), 'manual');
     expect(onChange).toHaveBeenCalledWith('manual', null);
   });
+
+  it('shows ATR default value when param is null', () => {
+    render(<TrailMethodSelector value="atr" param={null} onChange={vi.fn()} />);
+    const input = screen.getByRole('spinbutton') as HTMLInputElement;
+    expect(input.value).toBe('2');
+  });
 });

--- a/web-ui/src/components/domain/positions/TrailMethodSelector.tsx
+++ b/web-ui/src/components/domain/positions/TrailMethodSelector.tsx
@@ -1,0 +1,71 @@
+import type { TrailMethod } from '@/features/portfolio/types';
+import { t } from '@/i18n/t';
+
+interface TrailMethodSelectorProps {
+  value: TrailMethod;
+  param: number | null | undefined;
+  onChange: (method: TrailMethod, param: number | null) => void;
+}
+
+const ATR_DEFAULT = 2.0;
+const FIXED_PCT_DEFAULT = 5.0;
+
+export default function TrailMethodSelector({
+  value,
+  param,
+  onChange,
+}: TrailMethodSelectorProps) {
+  const showParam = value === 'atr' || value === 'fixed_pct';
+
+  const handleMethodChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const method = e.target.value as TrailMethod;
+    const defaultParam =
+      method === 'atr' ? ATR_DEFAULT : method === 'fixed_pct' ? FIXED_PCT_DEFAULT : null;
+    onChange(method, defaultParam);
+  };
+
+  const handleParamChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onChange(value, parseFloat(e.target.value) || null);
+  };
+
+  const paramLabel =
+    value === 'atr'
+      ? t('positions.trailMethod.atrMultiplierLabel')
+      : t('positions.trailMethod.fixedPctLabel');
+
+  return (
+    <div className="space-y-2">
+      <label className="block text-sm font-medium">{t('positions.trailMethod.label')}</label>
+      <select
+        value={value}
+        onChange={handleMethodChange}
+        className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-800 text-sm"
+      >
+        <option value="sma20">{t('positions.trailMethod.sma20')}</option>
+        <option value="atr">{t('positions.trailMethod.atr')}</option>
+        <option value="fixed_pct">{t('positions.trailMethod.fixedPct')}</option>
+        <option value="manual">{t('positions.trailMethod.manual')}</option>
+      </select>
+      {showParam && (
+        <div>
+          <label className="block text-xs text-gray-600 dark:text-gray-400 mb-1">
+            {paramLabel}
+          </label>
+          <input
+            type="number"
+            step={value === 'atr' ? '0.1' : '0.5'}
+            min="0.1"
+            value={param ?? (value === 'atr' ? ATR_DEFAULT : FIXED_PCT_DEFAULT)}
+            onChange={handleParamChange}
+            className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-800 text-sm"
+          />
+        </div>
+      )}
+      {value === 'manual' && (
+        <p className="text-xs text-gray-500 dark:text-gray-400">
+          {t('positions.trailMethod.manualNote')}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/web-ui/src/components/domain/positions/TrailMethodSelector.tsx
+++ b/web-ui/src/components/domain/positions/TrailMethodSelector.tsx
@@ -25,7 +25,8 @@ export default function TrailMethodSelector({
   };
 
   const handleParamChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    onChange(value, parseFloat(e.target.value) || null);
+    const parsed = parseFloat(e.target.value);
+    onChange(value, Number.isFinite(parsed) ? parsed : null);
   };
 
   const paramLabel =
@@ -35,8 +36,9 @@ export default function TrailMethodSelector({
 
   return (
     <div className="space-y-2">
-      <label className="block text-sm font-medium">{t('positions.trailMethod.label')}</label>
+      <label htmlFor="trail-method-select" className="block text-sm font-medium">{t('positions.trailMethod.label')}</label>
       <select
+        id="trail-method-select"
         value={value}
         onChange={handleMethodChange}
         className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-800 text-sm"
@@ -48,10 +50,11 @@ export default function TrailMethodSelector({
       </select>
       {showParam && (
         <div>
-          <label className="block text-xs text-gray-600 dark:text-gray-400 mb-1">
+          <label htmlFor="trail-param-input" className="block text-xs text-gray-600 dark:text-gray-400 mb-1">
             {paramLabel}
           </label>
           <input
+            id="trail-param-input"
             type="number"
             step={value === 'atr' ? '0.1' : '0.5'}
             min="0.1"

--- a/web-ui/src/components/domain/positions/UpdateStopModalForm.test.tsx
+++ b/web-ui/src/components/domain/positions/UpdateStopModalForm.test.tsx
@@ -2,14 +2,36 @@ import { describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import UpdateStopModalForm from '@/components/domain/positions/UpdateStopModalForm';
+import { t } from '@/i18n/t';
 
-const { usePositionStopSuggestionMock } = vi.hoisted(() => ({
+const { usePositionStopSuggestionMock, useUpdateTrailMethodMutationMock } = vi.hoisted(() => ({
   usePositionStopSuggestionMock: vi.fn(),
+  useUpdateTrailMethodMutationMock: vi.fn(),
+}));
+
+const { computePositionStopSuggestionMock } = vi.hoisted(() => ({
+  computePositionStopSuggestionMock: vi.fn(),
 }));
 
 vi.mock('@/features/portfolio/hooks', () => ({
   usePositionStopSuggestion: usePositionStopSuggestionMock,
+  useUpdateTrailMethodMutation: useUpdateTrailMethodMutationMock,
 }));
+
+vi.mock('@/features/portfolio/api', () => ({
+  computePositionStopSuggestion: computePositionStopSuggestionMock,
+}));
+
+const basePosition = {
+  ticker: 'REP.MC',
+  status: 'open' as const,
+  entryDate: '2026-03-03',
+  entryPrice: 17.32,
+  stopPrice: 17.7,
+  shares: 5,
+  positionId: 'POS-REP-1',
+  notes: '',
+};
 
 describe('UpdateStopModalForm', () => {
   it('rounds suggested stop to two decimals when applying suggestion', async () => {
@@ -31,19 +53,12 @@ describe('UpdateStopModalForm', () => {
       isLoading: false,
       error: null,
     });
+    useUpdateTrailMethodMutationMock.mockReturnValue({ mutateAsync: vi.fn() });
+    computePositionStopSuggestionMock.mockResolvedValue(null);
 
     render(
       <UpdateStopModalForm
-        position={{
-          ticker: 'REP.MC',
-          status: 'open',
-          entryDate: '2026-03-03',
-          entryPrice: 17.32,
-          stopPrice: 17.7,
-          shares: 5,
-          positionId: 'POS-REP-1',
-          notes: '',
-        }}
+        position={basePosition}
         isLoading={false}
         onClose={vi.fn()}
         onSubmit={vi.fn()}
@@ -57,6 +72,51 @@ describe('UpdateStopModalForm', () => {
 
     await waitFor(() => {
       expect(input.value).toBe('17.75');
+    });
+  });
+
+  it('shows TrailMethodSelector with position trail method', () => {
+    usePositionStopSuggestionMock.mockReturnValue({ data: null, isLoading: false, error: null });
+    useUpdateTrailMethodMutationMock.mockReturnValue({ mutateAsync: vi.fn() });
+    computePositionStopSuggestionMock.mockResolvedValue(null);
+
+    render(
+      <UpdateStopModalForm
+        position={{ ...basePosition, trailMethod: 'sma20' }}
+        isLoading={false}
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(t('positions.trailMethod.label'))).toBeInTheDocument();
+    const combobox = screen.getByRole('combobox') as HTMLSelectElement;
+    expect(combobox.value).toBe('sma20');
+  });
+
+  it('recomputes stop suggestion when trail method changes to atr', async () => {
+    const user = userEvent.setup();
+
+    usePositionStopSuggestionMock.mockReturnValue({ data: null, isLoading: false, error: null });
+    useUpdateTrailMethodMutationMock.mockReturnValue({ mutateAsync: vi.fn() });
+    computePositionStopSuggestionMock.mockResolvedValue(null);
+
+    render(
+      <UpdateStopModalForm
+        position={{ ...basePosition, trailMethod: 'sma20' }}
+        isLoading={false}
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    const combobox = screen.getByRole('combobox');
+    await user.selectOptions(combobox, 'atr');
+
+    await waitFor(() => {
+      expect(computePositionStopSuggestionMock).toHaveBeenCalledWith(
+        expect.objectContaining({ trailMethod: 'atr' }),
+      );
     });
   });
 });

--- a/web-ui/src/components/domain/positions/UpdateStopModalForm.test.tsx
+++ b/web-ui/src/components/domain/positions/UpdateStopModalForm.test.tsx
@@ -68,7 +68,7 @@ describe('UpdateStopModalForm', () => {
     const input = screen.getByRole('spinbutton') as HTMLInputElement;
     await user.clear(input);
     await user.type(input, '17.8');
-    await user.click(screen.getByRole('button', { name: 'Use Suggested' }));
+    await user.click(screen.getByRole('button', { name: t('positions.updateStopModal.useSuggested') }));
 
     await waitFor(() => {
       expect(input.value).toBe('17.75');

--- a/web-ui/src/components/domain/positions/UpdateStopModalForm.tsx
+++ b/web-ui/src/components/domain/positions/UpdateStopModalForm.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useState } from 'react';
 import Button from '@/components/common/Button';
 import ModalShell from '@/components/common/ModalShell';
-import { usePositionStopSuggestion } from '@/features/portfolio/hooks';
-import type { Position, UpdateStopRequest } from '@/features/portfolio/types';
+import TrailMethodSelector from '@/components/domain/positions/TrailMethodSelector';
+import { computePositionStopSuggestion } from '@/features/portfolio/api';
+import { usePositionStopSuggestion, useUpdateTrailMethodMutation } from '@/features/portfolio/hooks';
+import type { Position, PositionUpdate, TrailMethod, UpdateStopRequest } from '@/features/portfolio/types';
 import { formatCurrency } from '@/utils/formatters';
 import { t } from '@/i18n/t';
 
@@ -26,7 +28,14 @@ export default function UpdateStopModalForm({
   onSubmit,
 }: UpdateStopModalFormProps) {
   const suggestionQuery = usePositionStopSuggestion(position.positionId);
-  const suggestion = suggestionQuery.data;
+  const [liveSuggestion, setLiveSuggestion] = useState<PositionUpdate | null>(null);
+
+  const [trailMethod, setTrailMethod] = useState<TrailMethod>(position.trailMethod ?? 'sma20');
+  const [trailParam, setTrailParam] = useState<number | null>(position.trailParam ?? null);
+
+  const trailMethodMutation = useUpdateTrailMethodMutation();
+
+  const suggestion = liveSuggestion ?? suggestionQuery.data;
   const suggestionError = suggestionQuery.error instanceof Error ? suggestionQuery.error.message : '';
   const suggestedStop = suggestion?.stopSuggested;
   const suggestedStopRounded = suggestedStop != null ? roundToCents(suggestedStop) : null;
@@ -57,8 +66,35 @@ export default function UpdateStopModalForm({
     });
   }, [canApplySuggested, suggestedStopRounded, suggestion?.reason, initialStop, initialReason]);
 
-  const handleSubmit = (event: React.FormEvent) => {
+  const handleTrailChange = async (method: TrailMethod, param: number | null) => {
+    setTrailMethod(method);
+    setTrailParam(param);
+    try {
+      const computed = await computePositionStopSuggestion({
+        ...position,
+        trailMethod: method,
+        trailParam: param,
+      });
+      if (computed) {
+        setLiveSuggestion(computed);
+      }
+    } catch {
+      // Silently ignore — stale suggestion remains shown
+    }
+  };
+
+  const trailMethodChanged =
+    trailMethod !== (position.trailMethod ?? 'sma20') ||
+    trailParam !== (position.trailParam ?? null);
+
+  const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
+    if (trailMethodChanged && position.positionId) {
+      await trailMethodMutation.mutateAsync({
+        positionId: position.positionId,
+        request: { trailMethod, trailParam },
+      });
+    }
     onSubmit({
       ...formData,
       newStop: roundToCents(formData.newStop),
@@ -91,6 +127,8 @@ export default function UpdateStopModalForm({
             <strong>{t('positions.updateStopModal.sharesLabel')}</strong> {position.shares}
           </p>
         </div>
+
+        <TrailMethodSelector value={trailMethod} param={trailParam} onChange={handleTrailChange} />
 
         <div className="bg-blue-50 dark:bg-blue-900/20 p-3 rounded">
           <p className="text-sm text-blue-700 dark:text-blue-200 font-semibold">

--- a/web-ui/src/components/domain/positions/UpdateStopModalForm.tsx
+++ b/web-ui/src/components/domain/positions/UpdateStopModalForm.tsx
@@ -34,6 +34,7 @@ export default function UpdateStopModalForm({
   const [trailParam, setTrailParam] = useState<number | null>(position.trailParam ?? null);
 
   const trailMethodMutation = useUpdateTrailMethodMutation();
+  const [trailError, setTrailError] = useState<string>('');
 
   const suggestion = liveSuggestion ?? suggestionQuery.data;
   const suggestionError = suggestionQuery.error instanceof Error ? suggestionQuery.error.message : '';
@@ -79,7 +80,7 @@ export default function UpdateStopModalForm({
         setLiveSuggestion(computed);
       }
     } catch {
-      // Silently ignore — stale suggestion remains shown
+      setLiveSuggestion(null);
     }
   };
 
@@ -89,16 +90,19 @@ export default function UpdateStopModalForm({
 
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
+    setTrailError('');
     if (trailMethodChanged && position.positionId) {
-      await trailMethodMutation.mutateAsync({
-        positionId: position.positionId,
-        request: { trailMethod, trailParam },
-      });
+      try {
+        await trailMethodMutation.mutateAsync({
+          positionId: position.positionId,
+          request: { trailMethod, trailParam },
+        });
+      } catch (err) {
+        setTrailError(err instanceof Error ? err.message : 'Failed to update trail method');
+        return;
+      }
     }
-    onSubmit({
-      ...formData,
-      newStop: roundToCents(formData.newStop),
-    });
+    onSubmit({ ...formData, newStop: roundToCents(formData.newStop) });
   };
 
   const handleUseSuggested = () => {
@@ -207,6 +211,12 @@ export default function UpdateStopModalForm({
         {error ? (
           <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded p-3">
             <p className="text-sm text-red-800 dark:text-red-200">{error}</p>
+          </div>
+        ) : null}
+
+        {trailError ? (
+          <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded p-3">
+            <p className="text-sm text-red-800 dark:text-red-200">{trailError}</p>
           </div>
         ) : null}
 

--- a/web-ui/src/features/portfolio/api.ts
+++ b/web-ui/src/features/portfolio/api.ts
@@ -24,6 +24,7 @@ import {
   UpdateStopRequest,
   ClosePositionRequest,
   PartialCloseRequest,
+  UpdateTrailMethodRequest,
   transformCreateOrderRequest,
   transformOrder,
   transformPosition,
@@ -443,6 +444,60 @@ export async function fetchPositionStopSuggestion(positionId: string): Promise<P
   }
   const data = await response.json();
   return transformPositionUpdate(data);
+}
+
+export async function updatePositionTrailMethod(
+  positionId: string,
+  request: UpdateTrailMethodRequest,
+): Promise<void> {
+  const response = await fetch(apiUrl(API_ENDPOINTS.positionTrailMethod(positionId)), {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      trail_method: request.trailMethod,
+      trail_param: request.trailParam ?? null,
+    }),
+  });
+  if (!response.ok) {
+    const error = await response.json();
+    throw new Error(error.detail || 'Failed to update trail method');
+  }
+}
+
+export async function computePositionStopSuggestion(
+  position: Position,
+): Promise<PositionUpdate> {
+  const response = await fetch(apiUrl(API_ENDPOINTS.positionStopSuggestionCompute), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      position: {
+        ticker: position.ticker,
+        status: position.status,
+        entry_date: position.entryDate,
+        entry_price: position.entryPrice,
+        stop_price: position.stopPrice,
+        shares: position.shares,
+        position_id: position.positionId ?? null,
+        source_order_id: position.sourceOrderId ?? null,
+        initial_risk: position.initialRisk ?? null,
+        max_favorable_price: position.maxFavorablePrice ?? null,
+        exit_date: position.exitDate ?? null,
+        exit_price: position.exitPrice ?? null,
+        current_price: position.currentPrice ?? null,
+        notes: position.notes ?? '',
+        exit_order_ids: position.exitOrderIds ?? null,
+        trail_method: position.trailMethod ?? 'sma20',
+        trail_param: position.trailParam ?? null,
+      },
+    }),
+  });
+  if (!response.ok) {
+    const error = await response.json();
+    throw new Error(error.detail || 'Failed to compute stop suggestion');
+  }
+  const raw = await response.json();
+  return transformPositionUpdate(raw);
 }
 
 export async function closePosition(

--- a/web-ui/src/features/portfolio/api.ts
+++ b/web-ui/src/features/portfolio/api.ts
@@ -450,6 +450,9 @@ export async function updatePositionTrailMethod(
   positionId: string,
   request: UpdateTrailMethodRequest,
 ): Promise<void> {
+  if (isLocalPersistenceMode()) {
+    throw new Error('Trail method update is not supported in local persistence mode');
+  }
   const response = await fetch(apiUrl(API_ENDPOINTS.positionTrailMethod(positionId)), {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },

--- a/web-ui/src/features/portfolio/hooks.ts
+++ b/web-ui/src/features/portfolio/hooks.ts
@@ -17,6 +17,7 @@ import {
   fillOrderFromDegiro,
   syncDegiroOrders,
   updatePositionStop,
+  updatePositionTrailMethod,
   OrderFilterStatus,
   PositionFilterStatus,
   DegiroStatus,
@@ -27,6 +28,7 @@ import {
   UpdateStopRequest,
   ClosePositionRequest,
   PartialCloseRequest,
+  UpdateTrailMethodRequest,
 } from './types';
 import { queryKeys } from '@/lib/queryKeys';
 import { invalidateOrderQueries, invalidatePositionQueries } from '@/lib/queryInvalidation';
@@ -155,6 +157,23 @@ export function useUpdateStopMutation(onSuccess?: () => void) {
     onSuccess: async () => {
       await invalidatePositionQueries(queryClient);
       await invalidateOrderQueries(queryClient);
+      onSuccess?.();
+    },
+  });
+}
+
+export function useUpdateTrailMethodMutation(onSuccess?: () => void) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      positionId,
+      request,
+    }: {
+      positionId: string;
+      request: UpdateTrailMethodRequest;
+    }) => updatePositionTrailMethod(positionId, request),
+    onSuccess: async () => {
+      await invalidatePositionQueries(queryClient);
       onSuccess?.();
     },
   });

--- a/web-ui/src/features/portfolio/types.ts
+++ b/web-ui/src/features/portfolio/types.ts
@@ -24,6 +24,8 @@ export type {
   ClosePositionRequest,
   PartialCloseEvent,
   PartialCloseRequest,
+  TrailMethod,
+  UpdateTrailMethodRequest,
 } from '@/types/position';
 export {
   transformPosition,

--- a/web-ui/src/i18n/messages.en.ts
+++ b/web-ui/src/i18n/messages.en.ts
@@ -446,6 +446,16 @@ export const messagesEn = {
       suggested: 'Suggested',
       rNow: 'R now',
     },
+    trailMethod: {
+      label: 'Trail Method',
+      sma20: 'SMA20 (default)',
+      atr: 'ATR Multiple',
+      fixedPct: 'Fixed %',
+      manual: 'Manual only',
+      atrMultiplierLabel: 'ATR Multiplier (default: 2.0)',
+      fixedPctLabel: 'Trail % below current price',
+      manualNote: 'No automatic trail — stop suggestion uses current stop.',
+    },
     partialCloseModal: {
       title: 'Partial Close — {{ticker}}',
       sharesLabel: 'Shares to close',

--- a/web-ui/src/lib/api.ts
+++ b/web-ui/src/lib/api.ts
@@ -33,6 +33,7 @@ export const API_ENDPOINTS = {
   positionStopSuggestionCompute: '/api/portfolio/stop-suggestion/compute',
   positionClose: (id: string) => `/api/portfolio/positions/${id}/close`,
   positionPartialClose: (id: string) => `/api/portfolio/positions/${id}/partial-close`,
+  positionTrailMethod: (id: string) => `/api/portfolio/positions/${id}/trail-method`,
   portfolioSummary: '/api/portfolio/summary',
   earningsProximity: (ticker: string) => `/api/portfolio/earnings-proximity/${encodeURIComponent(ticker)}`,
   regimeBreakdown: '/api/portfolio/analytics/regime-breakdown',

--- a/web-ui/src/types/position.test.ts
+++ b/web-ui/src/types/position.test.ts
@@ -47,6 +47,8 @@ describe('Position Helper Functions', () => {
         thesis: null,
         lesson: null,
         tags: [],
+        trailMethod: 'sma20',
+        trailParam: null,
         partialCloses: [],
       })
     })

--- a/web-ui/src/types/position.ts
+++ b/web-ui/src/types/position.ts
@@ -142,7 +142,9 @@ export function transformPosition(apiPosition: PositionApiResponse): Position {
     thesis: apiPosition.thesis ?? null,
     lesson: apiPosition.lesson ?? null,
     tags: apiPosition.tags ?? [],
-    trailMethod: (apiPosition.trail_method as TrailMethod) ?? 'sma20',
+    trailMethod: (['sma20', 'atr', 'fixed_pct', 'manual'] as const).includes(apiPosition.trail_method as TrailMethod)
+      ? (apiPosition.trail_method as TrailMethod)
+      : 'sma20',
     trailParam: apiPosition.trail_param ?? null,
     partialCloses: (apiPosition.partial_closes ?? []).map((e) => ({
       date: e.date,

--- a/web-ui/src/types/position.ts
+++ b/web-ui/src/types/position.ts
@@ -2,6 +2,13 @@
 
 export type PositionStatus = 'open' | 'closed';
 
+export type TrailMethod = 'sma20' | 'atr' | 'fixed_pct' | 'manual';
+
+export interface UpdateTrailMethodRequest {
+  trailMethod: TrailMethod;
+  trailParam?: number | null;
+}
+
 export interface PartialCloseEvent {
   date: string;
   sharesClosed: number;
@@ -36,6 +43,8 @@ export interface Position {
   thesis?: string | null;
   lesson?: string | null;
   tags?: string[];
+  trailMethod?: TrailMethod;
+  trailParam?: number | null;
   partialCloses?: PartialCloseEvent[];
 }
 
@@ -101,6 +110,8 @@ export interface PositionApiResponse {
   thesis?: string | null;
   lesson?: string | null;
   tags?: string[] | null;
+  trail_method?: string | null;
+  trail_param?: number | null;
   partial_closes?: Array<{
     date: string;
     shares_closed: number;
@@ -131,6 +142,8 @@ export function transformPosition(apiPosition: PositionApiResponse): Position {
     thesis: apiPosition.thesis ?? null,
     lesson: apiPosition.lesson ?? null,
     tags: apiPosition.tags ?? [],
+    trailMethod: (apiPosition.trail_method as TrailMethod) ?? 'sma20',
+    trailParam: apiPosition.trail_param ?? null,
     partialCloses: (apiPosition.partial_closes ?? []).map((e) => ({
       date: e.date,
       sharesClosed: e.shares_closed,


### PR DESCRIPTION
## Summary
  - Adds `trail_method` (`sma20 | atr | fixed_pct | manual`) and `trail_param` to each position, defaulting to `sma20` for full backward compatibility
  - Backend: `evaluate_positions()` branches on `trail_method`; new PATCH `/api/portfolio/positions/{id}/trail-method` persists the choice
  - Frontend: `TrailMethodSelector` in the manage-stop modal with live stop recompute on method change; trail mutation sequenced before stop-price update on submit

  ## Test Plan
  - [ ] `pytest tests/test_trail_evaluate.py tests/api/test_trail_customization.py -v` — 10 tests
  - [ ] `cd web-ui && npx vitest run src/components/domain/positions/TrailMethodSelector.test.tsx` — 9 tests
  - [ ] `pytest -q` — 655 passed
  - [ ] `cd web-ui && npx vitest run` — 376 passed
  - [ ] `cd web-ui && npm run typecheck` — clean

  Worktree preserved at .worktrees/trail-customization for any PR feedback iteration.