### PR TITLE
fix(today): correct section order and i18n filter labels

### DIFF
--- a/web-ui/src/pages/Today.test.tsx
+++ b/web-ui/src/pages/Today.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { screen } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { server } from '@/test/mocks/server';
 import { renderWithProviders } from '@/test/utils';
@@ -51,6 +51,95 @@ describe('Today page — pending orders badge', () => {
     expect(
       screen.queryByText(t('todayPage.pendingBadge.singular', { count: '1' }))
     ).not.toBeInTheDocument();
+  });
+
+  it('renders "Requires Action" section before "Watchlist nearing trigger" section when both are present', async () => {
+    server.use(
+      http.get('*/api/portfolio/orders/local', () =>
+        HttpResponse.json({ orders: [], asof: '2026-05-04' })
+      ),
+      http.get('*/api/daily-review', () =>
+        HttpResponse.json({
+          watchlist_near_trigger: [
+            {
+              ticker: 'ASML',
+              watched_at: '2026-05-01T10:00:00Z',
+              watch_price: 660,
+              currency: 'EUR',
+              source: 'screener',
+              current_price: 671,
+              signal_trigger_price: 680,
+              distance_to_trigger_pct: -1.3,
+              price_history: [],
+            },
+          ],
+          new_candidates: [],
+          positions_add_on_candidates: [],
+          positions_hold: [],
+          positions_update_stop: [],
+          positions_close: [
+            {
+              position_id: 'pos-NVDA-001',
+              ticker: 'NVDA',
+              entry_price: 150,
+              stop_price: 140,
+              current_price: 138,
+              r_now: -1.2,
+              days_open: 5,
+              time_stop_warning: false,
+              reason: 'Price broke below stop',
+            },
+          ],
+          summary: {
+            total_positions: 1,
+            no_action: 0,
+            update_stop: 0,
+            close_positions: 1,
+            new_candidates: 0,
+            add_on_candidates: 0,
+            watchlist_near_trigger: 1,
+            review_date: '2026-05-04',
+          },
+        })
+      )
+    );
+
+    renderWithProviders(<Today />);
+
+    // Wait for both sections to appear
+    const requiresActionEl = await screen.findByText(new RegExp(t('todayPage.actionList.requiresAction'), 'i'));
+    const watchlistEl = screen.getByText(new RegExp(t('watchlist.pipeline.dailyReviewTitle'), 'i'));
+
+    // "Requires Action" must come before "Watchlist nearing trigger" in the DOM
+    expect(
+      requiresActionEl.compareDocumentPosition(watchlistEl) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it('action filter dropdown shows human-readable labels, not raw enum strings', async () => {
+    server.use(
+      http.get('*/api/portfolio/orders/local', () =>
+        HttpResponse.json({ orders: [], asof: '2026-05-04' })
+      ),
+    );
+
+    renderWithProviders(<Today />);
+
+    // Wait for the filter bar to render (it renders once daily-review responds)
+    await screen.findByRole('combobox');
+    const select = screen.getByRole('combobox');
+    const options = within(select).getAllByRole('option');
+    const labels = options.map((o) => o.textContent ?? '');
+
+    // Should use readable labels from i18n
+    expect(labels).toContain(t('screener.guidedList.action.BUY_NOW'));
+    expect(labels).toContain(t('screener.guidedList.action.BUY_ON_PULLBACK'));
+    expect(labels).toContain(t('screener.guidedList.action.WATCH'));
+
+    // Must NOT leak raw enum strings
+    expect(labels).not.toContain('BUY_NOW');
+    expect(labels).not.toContain('BUY_ON_PULLBACK');
+    expect(labels).not.toContain('WATCH');
   });
 
   it('shows watchlist near-trigger section when daily review returns matches', async () => {

--- a/web-ui/src/pages/Today.tsx
+++ b/web-ui/src/pages/Today.tsx
@@ -559,8 +559,17 @@ function TodayActionList({ onTickerSelect }: TodayActionListProps) {
           onChange={(e) => setActionFilter(e.target.value)}
           className="text-xs border border-border rounded px-1.5 py-1 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300"
         >
-          {['all', 'BUY_NOW', 'BUY_ON_PULLBACK', 'WAIT_FOR_BREAKOUT', 'WATCH', 'TACTICAL_ONLY', 'AVOID', 'MANAGE_ONLY'].map((v) => (
-            <option key={v} value={v}>{v === 'all' ? t('dailyReview.filter.all') : v}</option>
+          {([
+            ['all',               t('dailyReview.filter.all')],
+            ['BUY_NOW',          t('screener.guidedList.action.BUY_NOW')],
+            ['BUY_ON_PULLBACK',  t('screener.guidedList.action.BUY_ON_PULLBACK')],
+            ['WAIT_FOR_BREAKOUT',t('screener.guidedList.action.WAIT_FOR_BREAKOUT')],
+            ['WATCH',            t('screener.guidedList.action.WATCH')],
+            ['TACTICAL_ONLY',    t('screener.guidedList.action.TACTICAL_ONLY')],
+            ['AVOID',            t('screener.guidedList.action.AVOID')],
+            ['MANAGE_ONLY',      t('screener.guidedList.action.MANAGE_ONLY')],
+          ] as [string, string][]).map(([value, label]) => (
+            <option key={value} value={value}>{label}</option>
           ))}
         </select>
       </div>
@@ -573,32 +582,7 @@ function TodayActionList({ onTickerSelect }: TodayActionListProps) {
           </p>
         )}
 
-        {/* Requires Action section */}
-        {watchlistNearTriggerCount > 0 && (
-          <div className="space-y-1">
-            <div className="px-3 py-1 text-xs font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-300 bg-amber-50 dark:bg-amber-900/20 rounded">
-              {t('watchlist.pipeline.dailyReviewTitle')} · {watchlistNearTriggerCount}
-            </div>
-            <p className="px-3 text-[11px] text-gray-500 dark:text-gray-400">
-              {t('watchlist.pipeline.dailyReviewSubtitle', { count: String(watchlistNearTriggerCount) })}
-            </p>
-            <div className="space-y-0.5">
-              {review?.watchlistNearTrigger.map((item) => {
-                const idx = flatItems.findIndex((fi) => fi.id === `watch-${item.ticker}`);
-                return (
-                  <WatchlistNearTriggerItem
-                    key={item.ticker}
-                    item={item}
-                    onClick={onTickerSelect}
-                    isFocused={focusedIndex === idx}
-                  />
-                );
-              })}
-            </div>
-          </div>
-        )}
-
-        {/* Requires Action section */}
+        {/* Requires Action section — close and update-stop before watchlist triggers */}
         {requiresActionCount > 0 && (
           <div className="space-y-1">
             <div className="px-3 py-1 text-xs font-semibold uppercase tracking-wide text-red-700 dark:text-red-400 bg-red-50 dark:bg-red-900/20 rounded">
@@ -629,6 +613,31 @@ function TodayActionList({ onTickerSelect }: TodayActionListProps) {
                     onClick={onTickerSelect}
                     onAction={position ? () => setUpdateStopTarget(position) : undefined}
                     isDone={doneIds.has(item.positionId)}
+                    isFocused={focusedIndex === idx}
+                  />
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        {/* Watchlist near-trigger section — below required position actions */}
+        {watchlistNearTriggerCount > 0 && (
+          <div className="space-y-1">
+            <div className="px-3 py-1 text-xs font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-300 bg-amber-50 dark:bg-amber-900/20 rounded">
+              {t('watchlist.pipeline.dailyReviewTitle')} · {watchlistNearTriggerCount}
+            </div>
+            <p className="px-3 text-[11px] text-gray-500 dark:text-gray-400">
+              {t('watchlist.pipeline.dailyReviewSubtitle', { count: String(watchlistNearTriggerCount) })}
+            </p>
+            <div className="space-y-0.5">
+              {review?.watchlistNearTrigger.map((item) => {
+                const idx = flatItems.findIndex((fi) => fi.id === `watch-${item.ticker}`);
+                return (
+                  <WatchlistNearTriggerItem
+                    key={item.ticker}
+                    item={item}
+                    onClick={onTickerSelect}
                     isFocused={focusedIndex === idx}
                   />
                 );


### PR DESCRIPTION
Requires-Action (close/update-stop) now renders before Watchlist near-trigger — open position risk management takes priority over upcoming opportunities.

Action filter dropdown replaces raw enum strings (BUY_NOW, WATCH, etc.) with their i18n labels (Buy now, Watch, etc.).

Two regression tests added to Today.test.tsx covering both fixes.