### PR TITLE
feat(analytics): add plain-language edge insight card and open how-to…

### DIFF
--- a/web-ui/src/features/analytics/edgeInsight.test.ts
+++ b/web-ui/src/features/analytics/edgeInsight.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { pickEdgeInsight } from './edgeInsight';
+
+describe('pickEdgeInsight', () => {
+  it('returns developing verdict when fewer than 5 trades', () => {
+    const insight = pickEdgeInsight({ totalTrades: 3, avgR: null, profitFactor: null, winRate: null });
+    expect(insight.verdict).toBe('developing');
+    expect(insight.message).toContain('3 trades');
+  });
+
+  it('returns developing verdict for exactly 4 trades regardless of stats', () => {
+    const insight = pickEdgeInsight({ totalTrades: 4, avgR: 1.5, profitFactor: 2.0, winRate: 80 });
+    expect(insight.verdict).toBe('developing');
+  });
+
+  it('returns positive verdict when avgR > 0 and profitFactor >= 1.0', () => {
+    const insight = pickEdgeInsight({ totalTrades: 20, avgR: 0.35, profitFactor: 1.8, winRate: 45 });
+    expect(insight.verdict).toBe('positive');
+    expect(insight.message).toContain('+0.35R');
+    expect(insight.message).toContain('1.80');
+  });
+
+  it('returns positive verdict when profitFactor is exactly 1.0', () => {
+    const insight = pickEdgeInsight({ totalTrades: 10, avgR: 0.05, profitFactor: 1.0, winRate: 50 });
+    expect(insight.verdict).toBe('positive');
+  });
+
+  it('returns developing verdict when avgR > 0 but profitFactor < 1.0', () => {
+    const insight = pickEdgeInsight({ totalTrades: 10, avgR: 0.1, profitFactor: 0.7, winRate: 60 });
+    expect(insight.verdict).toBe('developing');
+    expect(insight.message).toContain('+0.10R');
+    expect(insight.message).toContain('0.70');
+  });
+
+  it('returns negative verdict when avgR <= 0 and win rate < 40%', () => {
+    const insight = pickEdgeInsight({ totalTrades: 15, avgR: -0.5, profitFactor: 0.4, winRate: 30 });
+    expect(insight.verdict).toBe('negative');
+    expect(insight.message).toContain('30.0%');
+  });
+
+  it('returns negative verdict when avgR is 0', () => {
+    const insight = pickEdgeInsight({ totalTrades: 8, avgR: 0, profitFactor: 1.0, winRate: 50 });
+    expect(insight.verdict).toBe('negative');
+  });
+
+  it('returns negative verdict when avgR < 0 with win rate >= 40%', () => {
+    const insight = pickEdgeInsight({ totalTrades: 12, avgR: -0.2, profitFactor: 0.8, winRate: 50 });
+    expect(insight.verdict).toBe('negative');
+  });
+
+  it('message always contains a non-empty string', () => {
+    const cases = [
+      { totalTrades: 0, avgR: null, profitFactor: null, winRate: null },
+      { totalTrades: 20, avgR: 0.5, profitFactor: 2.0, winRate: 60 },
+      { totalTrades: 20, avgR: -0.3, profitFactor: 0.5, winRate: 35 },
+    ];
+    for (const c of cases) {
+      expect(pickEdgeInsight(c).message.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/web-ui/src/features/analytics/edgeInsight.ts
+++ b/web-ui/src/features/analytics/edgeInsight.ts
@@ -1,0 +1,51 @@
+import { formatNumber } from '@/utils/formatters';
+
+export type EdgeVerdict = 'positive' | 'developing' | 'negative';
+
+export interface EdgeInsight {
+  verdict: EdgeVerdict;
+  message: string;
+}
+
+interface EdgeInsightInput {
+  totalTrades: number;
+  avgR: number | null;
+  profitFactor: number | null;
+  winRate: number | null;
+}
+
+export function pickEdgeInsight({ totalTrades, avgR, profitFactor, winRate }: EdgeInsightInput): EdgeInsight {
+  if (totalTrades < 5) {
+    return {
+      verdict: 'developing',
+      message: `${totalTrades} trades recorded — build more history before drawing conclusions.`,
+    };
+  }
+
+  if (avgR != null && avgR > 0 && profitFactor != null && profitFactor >= 1.0) {
+    return {
+      verdict: 'positive',
+      message: `Positive edge: average +${formatNumber(avgR, 2)}R per trade with a ${formatNumber(profitFactor, 2)} profit factor. Keep executing the system.`,
+    };
+  }
+
+  if (avgR != null && avgR > 0) {
+    return {
+      verdict: 'developing',
+      message: `Average R is positive (+${formatNumber(avgR, 2)}R) but profit factor is ${profitFactor != null ? formatNumber(profitFactor, 2) : '—'} — a few large wins may be masking more frequent small losses.`,
+    };
+  }
+
+  // avgR <= 0 or null
+  if (winRate != null && winRate < 40) {
+    return {
+      verdict: 'negative',
+      message: `Win rate is ${formatNumber(winRate, 1)}% and average R is ${avgR != null ? formatNumber(avgR, 2) + 'R' : '—'}. Reduce full −1R losses by skipping low-conviction setups.`,
+    };
+  }
+
+  return {
+    verdict: 'negative',
+    message: `Closed trades average ${avgR != null ? formatNumber(avgR, 2) + 'R' : '—'} — exits may be cutting winners too short. Compare captured R vs. peak R on recent trades.`,
+  };
+}

--- a/web-ui/src/i18n/messages.en.ts
+++ b/web-ui/src/i18n/messages.en.ts
@@ -1904,6 +1904,14 @@ export const messagesEn = {
       losses: 'Losses',
       breakeven: 'Breakeven',
     },
+    insight: {
+      title: 'Performance Insight',
+      verdictLabel: {
+        positive: 'Positive Edge',
+        developing: 'Developing',
+        negative: 'Needs Work',
+      },
+    },
     table: {
       date: 'Date',
       ticker: 'Ticker',

--- a/web-ui/src/pages/Analytics.tsx
+++ b/web-ui/src/pages/Analytics.tsx
@@ -6,6 +6,7 @@ import { cn } from '@/utils/cn';
 import { formatNumber, formatCurrency } from '@/utils/formatters';
 import EdgeBreakdownTable from '@/components/domain/portfolio/EdgeBreakdownTable';
 import RegimeBreakdownTable from '@/components/domain/portfolio/RegimeBreakdownTable';
+import { pickEdgeInsight, type EdgeVerdict } from '@/features/analytics/edgeInsight';
 
 // ─── helpers ────────────────────────────────────────────────────────────────
 
@@ -254,9 +255,55 @@ function RDistributionChart({ values }: { values: number[] }) {
 
 // ─── how to read explainer ───────────────────────────────────────────────────
 
+const VERDICT_STYLES: Record<EdgeVerdict, { border: string; bg: string; label: string; labelClass: string }> = {
+  positive: {
+    border: 'border-green-200 dark:border-green-700',
+    bg: 'bg-green-50 dark:bg-green-900/20',
+    label: t('analyticsPage.insight.verdictLabel.positive'),
+    labelClass: 'text-green-700 dark:text-green-300',
+  },
+  developing: {
+    border: 'border-amber-200 dark:border-amber-700',
+    bg: 'bg-amber-50 dark:bg-amber-900/20',
+    label: t('analyticsPage.insight.verdictLabel.developing'),
+    labelClass: 'text-amber-700 dark:text-amber-300',
+  },
+  negative: {
+    border: 'border-red-200 dark:border-red-700',
+    bg: 'bg-red-50 dark:bg-red-900/20',
+    label: t('analyticsPage.insight.verdictLabel.negative'),
+    labelClass: 'text-red-700 dark:text-red-400',
+  },
+};
+
+interface EdgeInsightCardProps {
+  totalTrades: number;
+  avgR: number | null;
+  profitFactor: number | null;
+  winRate: number | null;
+}
+
+function EdgeInsightCard({ totalTrades, avgR, profitFactor, winRate }: EdgeInsightCardProps) {
+  const insight = pickEdgeInsight({ totalTrades, avgR, profitFactor, winRate });
+  const styles = VERDICT_STYLES[insight.verdict];
+  return (
+    <div className={cn('rounded-lg border px-4 py-3', styles.border, styles.bg)}>
+      <div className="flex items-baseline gap-2 mb-1">
+        <span className="text-[11px] font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+          {t('analyticsPage.insight.title')}
+        </span>
+        <span className={cn('text-xs font-bold uppercase tracking-wide', styles.labelClass)}>
+          {styles.label}
+        </span>
+      </div>
+      <p className="text-sm text-gray-700 dark:text-gray-300">{insight.message}</p>
+    </div>
+  );
+}
+
 function HowToReadBox() {
   return (
-    <details className="rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/50 px-4 py-3 text-sm">
+    <details open className="rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/50 px-4 py-3 text-sm">
       <summary className="cursor-pointer font-medium text-gray-700 dark:text-gray-300 select-none">
         How to read this page
       </summary>
@@ -382,6 +429,14 @@ export default function Analytics() {
         <p className="text-sm text-gray-500 dark:text-gray-400">{t('analyticsPage.empty')}</p>
       ) : (
         <>
+          {/* Edge insight — computed verdict above stat cards */}
+          <EdgeInsightCard
+            totalTrades={stats.totalTrades}
+            avgR={stats.avgR}
+            profitFactor={stats.profitFactor}
+            winRate={stats.winRate}
+          />
+
           {/* Stat cards */}
           <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
             <StatCard


### PR DESCRIPTION
… by default

Addresses UX finding #7: Performance Analytics showed expert metrics (Avg R, Profit Factor, etc.) with no plain-language interpretation for beginners.

- Extracts pickEdgeInsight() pure function to features/analytics/edgeInsight.ts — returns verdict (positive/developing/negative) + one-line message computed from actual trade stats (avgR, profitFactor, winRate, totalTrades)
- Adds EdgeInsightCard rendered above the stat grid with color-coded border (green/amber/red) matching the verdict
- Makes HowToReadBox open by default (was collapsed)
- Adds i18n keys: analyticsPage.insight.{title, verdictLabel.*}
- 9 unit tests for all verdict branches in edgeInsight.test.ts