### PR TITLE
Feat/analysis canvas ux fixes

### DIFF
--- a/web-ui/src/components/domain/screener/ScreenerCandidateReviewList.test.tsx
+++ b/web-ui/src/components/domain/screener/ScreenerCandidateReviewList.test.tsx
@@ -263,4 +263,24 @@ describe('ScreenerCandidateReviewList', () => {
 
     expect(screen.getByText(t('screener.guidedList.quality.fail'))).toBeInTheDocument();
   });
+
+  it('shows Passes quality badge when quality is pass and readiness is ready', () => {
+    const candidate = makeCandidate('NVDA', {
+      action: 'BUY_NOW',
+      verdict: 'RECOMMENDED',
+      warnings: [],
+      weeklyTrend: 'up',
+    });
+
+    renderWithProviders(
+      <ScreenerCandidateReviewList
+        candidates={[candidate]}
+        selectedTicker={null}
+        onReview={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText(t('screener.guidedList.quality.pass'))).toBeInTheDocument();
+    expect(screen.getByText(t('screener.guidedList.readiness.ready'))).toBeInTheDocument();
+  });
 });

--- a/web-ui/src/components/domain/screener/ScreenerCandidateReviewList.test.tsx
+++ b/web-ui/src/components/domain/screener/ScreenerCandidateReviewList.test.tsx
@@ -228,4 +228,39 @@ describe('ScreenerCandidateReviewList', () => {
 
     expect(screen.getByText(t('screener.guidedList.empty'))).toBeInTheDocument();
   });
+
+  it('suppresses Fails quality badge when orderReadiness is ready (BUY_NOW)', () => {
+    const candidate = makeCandidate('AMAT', {
+      action: 'BUY_NOW',
+      verdict: 'NOT_RECOMMENDED',
+    });
+
+    renderWithProviders(
+      <ScreenerCandidateReviewList
+        candidates={[candidate]}
+        selectedTicker={null}
+        onReview={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByText(t('screener.guidedList.quality.fail'))).not.toBeInTheDocument();
+    expect(screen.getByText(t('screener.guidedList.readiness.ready'))).toBeInTheDocument();
+  });
+
+  it('shows Fails quality badge when quality is fail and readiness is not ready (WATCH_ONLY)', () => {
+    const candidate = makeCandidate('AMAT', {
+      action: 'WATCH',
+      verdict: 'NOT_RECOMMENDED',
+    });
+
+    renderWithProviders(
+      <ScreenerCandidateReviewList
+        candidates={[candidate]}
+        selectedTicker={null}
+        onReview={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText(t('screener.guidedList.quality.fail'))).toBeInTheDocument();
+  });
 });

--- a/web-ui/src/components/domain/screener/ScreenerCandidateReviewList.tsx
+++ b/web-ui/src/components/domain/screener/ScreenerCandidateReviewList.tsx
@@ -93,11 +93,13 @@ export default function ScreenerCandidateReviewList({
                 >
                   {candidate.ticker}
                 </button>
-                <span
-                  className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${QUALITY_BADGE_CLASS[quality]}`}
-                >
-                  {t(QUALITY_LABEL_KEY[quality])}
-                </span>
+                {!(quality === 'fail' && decision.orderReadiness === 'ready') && (
+                  <span
+                    className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${QUALITY_BADGE_CLASS[quality]}`}
+                  >
+                    {t(QUALITY_LABEL_KEY[quality])}
+                  </span>
+                )}
                 <span
                   className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${READINESS_CHIP_CLASS[decision.orderReadiness]}`}
                 >

--- a/web-ui/src/components/domain/workspace/AnalysisCanvasPanel.test.tsx
+++ b/web-ui/src/components/domain/workspace/AnalysisCanvasPanel.test.tsx
@@ -11,6 +11,7 @@ import * as screenerHooks from '@/features/screener/hooks';
 import * as watchlistHooks from '@/features/watchlist/hooks';
 import { useScreenerStore } from '@/stores/screenerStore';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
+import { t } from '@/i18n/t';
 import { renderWithProviders } from '@/test/utils';
 
 vi.mock('@/features/fundamentals/hooks', () => ({
@@ -173,7 +174,7 @@ describe('AnalysisCanvasPanel', () => {
 
     const { user } = renderWithProviders(<AnalysisCanvasPanel />);
 
-    expect(screen.getByText('No fundamentals snapshot available yet.')).toBeInTheDocument();
+    expect(screen.getByText(t('workspacePage.panels.analysis.fundamentals.noSnapshot'))).toBeInTheDocument();
 
     await act(async () => {
       await user.click(screen.getByRole('button', { name: 'Run fundamentals analysis' }));

--- a/web-ui/src/components/domain/workspace/AnalysisCanvasPanel.test.tsx
+++ b/web-ui/src/components/domain/workspace/AnalysisCanvasPanel.test.tsx
@@ -560,6 +560,75 @@ describe('AnalysisCanvasPanel', () => {
     expect(screen.getByText(/AAPL Decision Summary/)).toBeInTheDocument();
   });
 
+  it('does not render BeginnerDecisionHeader in overview when decisionSummary is present', () => {
+    useWorkspaceStore.setState({
+      selectedTicker: 'AAPL',
+      selectedTickerSource: 'screener',
+      analysisTab: 'overview',
+    });
+    useScreenerStore.setState({
+      lastResult: {
+        asofDate: '2026-03-19',
+        totalScreened: 1,
+        dataFreshness: 'final_close',
+        candidates: [
+          {
+            ticker: 'AAPL',
+            currency: 'USD',
+            close: 180,
+            sma20: 175,
+            sma50: 170,
+            sma200: 160,
+            atr: 3,
+            momentum6m: 0.18,
+            momentum12m: 0.27,
+            relStrength: 0.09,
+            score: 0.82,
+            confidence: 79,
+            rank: 1,
+            decisionSummary: {
+              symbol: 'AAPL',
+              action: 'BUY_NOW',
+              conviction: 'high',
+              technicalLabel: 'strong',
+              fundamentalsLabel: 'strong',
+              valuationLabel: 'fair',
+              catalystLabel: 'active',
+              whyNow: 'Setup timing is ready and business quality supports conviction.',
+              whatToDo: 'Use the current trade plan and keep sizing disciplined.',
+              mainRisk: 'Valuation remains acceptable, but risk still matters.',
+              tradePlan: { entry: 180, stop: 171, target: 198, rr: 2 },
+              valuationContext: { method: 'not_available' },
+              drivers: {
+                positives: [],
+                negatives: [],
+                warnings: ['No cached catalyst snapshot is available yet.'],
+              },
+              catalystSummary: null,
+              catalystSources: [],
+            },
+          },
+        ],
+      },
+    });
+    vi.mocked(fundamentalsHooks.useFundamentalSnapshotQuery).mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: undefined,
+    } as never);
+    vi.mocked(fundamentalsHooks.useRefreshFundamentalSnapshotMutation).mockReturnValue({
+      mutate: vi.fn(),
+      data: undefined,
+      isPending: false,
+      isError: false,
+      error: null,
+    } as never);
+
+    renderWithProviders(<AnalysisCanvasPanel />);
+
+    expect(screen.queryByText('Should I place an order?')).not.toBeInTheDocument();
+  });
+
   it('renders a watch toggle for the selected symbol', () => {
     vi.mocked(fundamentalsHooks.useFundamentalSnapshotQuery).mockReturnValue({
       isLoading: false,

--- a/web-ui/src/components/domain/workspace/AnalysisCanvasPanel.tsx
+++ b/web-ui/src/components/domain/workspace/AnalysisCanvasPanel.tsx
@@ -62,7 +62,6 @@ export default function AnalysisCanvasPanel() {
           <SymbolAnalysisContent
             ticker={selectedTicker}
             candidate={selectedCandidate}
-            screenerCandidate={selectedCandidate}
             activeTab={activeTab}
             onTabChange={setAnalysisTab}
             orderPanel={<ActionPanel ticker={selectedTicker} />}

--- a/web-ui/src/components/domain/workspace/AnalysisDecisionStrip.test.tsx
+++ b/web-ui/src/components/domain/workspace/AnalysisDecisionStrip.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import AnalysisDecisionStrip from '@/components/domain/workspace/AnalysisDecisionStrip';
+import type { SymbolAnalysisCandidate } from '@/components/domain/workspace/types';
+
+function buildCandidate(overrides: Partial<SymbolAnalysisCandidate> = {}): SymbolAnalysisCandidate {
+  return {
+    ticker: 'AAPL',
+    currency: 'USD',
+    ...overrides,
+  };
+}
+
+describe('AnalysisDecisionStrip — Risk % cell', () => {
+  it('shows dash when riskPct is 0', () => {
+    const candidate = buildCandidate({
+      recommendation: {
+        verdict: 'RECOMMENDED',
+        reasonsShort: [],
+        reasonsDetailed: [],
+        risk: { entry: 180, riskAmount: 5, riskPct: 0, positionSize: 1000, shares: 10 },
+        costs: { commissionEstimate: 1, fxEstimate: 0, slippageEstimate: 0, totalCost: 1 },
+        checklist: [],
+        education: { commonBiasWarning: '', whatToLearn: '', whatWouldMakeValid: [] },
+      },
+    });
+
+    render(<AnalysisDecisionStrip ticker="AAPL" candidate={candidate} />);
+
+    const riskLabel = screen.getAllByText('Risk %')[0];
+    const cell = riskLabel.closest('div[class*="min-w"]');
+    expect(cell?.textContent).toContain('—');
+    expect(cell?.textContent).not.toContain('0.00%');
+  });
+
+  it('shows formatted percentage when riskPct is 0.025', () => {
+    const candidate = buildCandidate({
+      recommendation: {
+        verdict: 'RECOMMENDED',
+        reasonsShort: [],
+        reasonsDetailed: [],
+        risk: { entry: 180, riskAmount: 5, riskPct: 0.025, positionSize: 1000, shares: 10 },
+        costs: { commissionEstimate: 1, fxEstimate: 0, slippageEstimate: 0, totalCost: 1 },
+        checklist: [],
+        education: { commonBiasWarning: '', whatToLearn: '', whatWouldMakeValid: [] },
+      },
+    });
+
+    render(<AnalysisDecisionStrip ticker="AAPL" candidate={candidate} />);
+
+    expect(screen.getByText('2.50%')).toBeInTheDocument();
+  });
+});

--- a/web-ui/src/components/domain/workspace/AnalysisDecisionStrip.tsx
+++ b/web-ui/src/components/domain/workspace/AnalysisDecisionStrip.tsx
@@ -102,6 +102,7 @@ export default function AnalysisDecisionStrip({ ticker, candidate, onPrepareOrde
   const stop = summary?.tradePlan.stop ?? candidate?.recommendation?.risk?.stop ?? candidate?.stop;
   const target = summary?.tradePlan.target ?? candidate?.recommendation?.risk?.target;
   const rr = summary?.tradePlan.rr ?? candidate?.recommendation?.risk?.rr ?? candidate?.rr;
+  const oneR = entry != null && stop != null ? entry - stop : null;
   const riskPct = candidate?.recommendation?.risk?.riskPct;
   const badges = summary
     ? [
@@ -135,6 +136,7 @@ export default function AnalysisDecisionStrip({ ticker, candidate, onPrepareOrde
             {compactValue('Target', target != null ? formatCurrency(target, currency) : '—')}
             {compactValue('R/R', rr != null ? `${formatNumber(rr, 1)}x` : '—')}
             {compactValue('Risk %', riskPct != null && riskPct > 0 ? `${formatNumber(riskPct * 100, 2)}%` : '—')}
+            {compactValue(t('workspacePage.panels.analysis.decisionSummary.tradePlan.oneR'), oneR != null ? formatCurrency(oneR, currency) : '—')}
           </div>
         </div>
 

--- a/web-ui/src/components/domain/workspace/AnalysisDecisionStrip.tsx
+++ b/web-ui/src/components/domain/workspace/AnalysisDecisionStrip.tsx
@@ -13,6 +13,7 @@ import { formatCurrency, formatNumber } from '@/utils/formatters';
 interface AnalysisDecisionStripProps {
   ticker: string;
   candidate?: SymbolAnalysisCandidate | null;
+  onPrepareOrder?: () => void;
 }
 
 function actionLabel(action: DecisionAction): string {
@@ -94,7 +95,7 @@ function compactValue(label: string, value: string) {
   );
 }
 
-export default function AnalysisDecisionStrip({ ticker, candidate }: AnalysisDecisionStripProps) {
+export default function AnalysisDecisionStrip({ ticker, candidate, onPrepareOrder }: AnalysisDecisionStripProps) {
   const summary = candidate?.decisionSummary;
   const currency = candidate?.currency ?? 'USD';
   const entry = summary?.tradePlan.entry ?? candidate?.recommendation?.risk?.entry ?? candidate?.entry;
@@ -150,6 +151,17 @@ export default function AnalysisDecisionStrip({ ticker, candidate }: AnalysisDec
             </span>
           ))}
         </div>
+        {summary?.action === 'BUY_NOW' && onPrepareOrder && (
+          <div className="flex justify-end">
+            <button
+              type="button"
+              onClick={onPrepareOrder}
+              className="rounded-md bg-emerald-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-emerald-700"
+            >
+              {t('analysis.beginnerHeader.action.prepare_order')}
+            </button>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/web-ui/src/components/domain/workspace/AnalysisDecisionStrip.tsx
+++ b/web-ui/src/components/domain/workspace/AnalysisDecisionStrip.tsx
@@ -130,7 +130,7 @@ export default function AnalysisDecisionStrip({ ticker, candidate, onPrepareOrde
             </p>
           </div>
           <div className="flex flex-wrap gap-2">
-            {compactValue('Entry', entry != null ? formatCurrency(entry, currency) : '—')}
+            {compactValue(t('workspacePage.panels.analysis.decisionSummary.tradePlan.entryClose'), entry != null ? formatCurrency(entry, currency) : '—')}
             {compactValue('Stop', stop != null ? formatCurrency(stop, currency) : '—')}
             {compactValue('Target', target != null ? formatCurrency(target, currency) : '—')}
             {compactValue('R/R', rr != null ? `${formatNumber(rr, 1)}x` : '—')}

--- a/web-ui/src/components/domain/workspace/AnalysisDecisionStrip.tsx
+++ b/web-ui/src/components/domain/workspace/AnalysisDecisionStrip.tsx
@@ -134,7 +134,7 @@ export default function AnalysisDecisionStrip({ ticker, candidate, onPrepareOrde
             {compactValue('Stop', stop != null ? formatCurrency(stop, currency) : '—')}
             {compactValue('Target', target != null ? formatCurrency(target, currency) : '—')}
             {compactValue('R/R', rr != null ? `${formatNumber(rr, 1)}x` : '—')}
-            {compactValue('Risk %', riskPct != null ? `${formatNumber(riskPct * 100, 2)}%` : '—')}
+            {compactValue('Risk %', riskPct != null && riskPct > 0 ? `${formatNumber(riskPct * 100, 2)}%` : '—')}
           </div>
         </div>
 

--- a/web-ui/src/components/domain/workspace/BeginnerDecisionHeader.test.tsx
+++ b/web-ui/src/components/domain/workspace/BeginnerDecisionHeader.test.tsx
@@ -127,6 +127,42 @@ describe('BeginnerDecisionHeader', () => {
     expect(screen.getByText('Close below 171')).toBeInTheDocument();
   });
 
+  it('shows weak catalyst note when action is BUY_NOW and catalystLabel is weak', () => {
+    const candidate = buildCandidate({
+      decisionSummary: {
+        symbol: 'AAPL',
+        action: 'BUY_NOW',
+        conviction: 'high',
+        technicalLabel: 'strong',
+        fundamentalsLabel: 'strong',
+        valuationLabel: 'fair',
+        catalystLabel: 'weak',
+        whyNow: 'Setup timing is ready.',
+        whatToDo: 'Use the current trade plan.',
+        mainRisk: 'Valuation risk remains.',
+        tradePlan: { entry: 180, stop: 171, target: 198, rr: 2 },
+        valuationContext: { method: 'not_available' },
+        drivers: { positives: [], negatives: [], warnings: [] },
+        catalystSummary: null,
+        catalystSources: [],
+      },
+    });
+    renderWithProviders(
+      <BeginnerDecisionHeader candidate={candidate} onAction={vi.fn()} />
+    );
+
+    expect(screen.getByText(t('analysis.beginnerHeader.weakCatalystNote'))).toBeInTheDocument();
+  });
+
+  it('does not show weak catalyst note when catalystLabel is active', () => {
+    const candidate = buildBuyNowCandidate();
+    renderWithProviders(
+      <BeginnerDecisionHeader candidate={candidate} onAction={vi.fn()} />
+    );
+
+    expect(screen.queryByText(t('analysis.beginnerHeader.weakCatalystNote'))).not.toBeInTheDocument();
+  });
+
   it('calls onAction with the correct nextStepKind when action button is clicked', async () => {
     const onAction = vi.fn();
     const candidate = buildBuyNowCandidate();

--- a/web-ui/src/components/domain/workspace/BeginnerDecisionHeader.tsx
+++ b/web-ui/src/components/domain/workspace/BeginnerDecisionHeader.tsx
@@ -110,6 +110,12 @@ export default function BeginnerDecisionHeader({ candidate, onAction }: Beginner
           {decision.invalidation}
         </p>
       ) : null}
+      {decision.suggestedAction === 'BUY_NOW' &&
+        candidate.decisionSummary?.catalystLabel === 'weak' && (
+          <p className="text-sm text-blue-700 mb-1">
+            {t('analysis.beginnerHeader.weakCatalystNote')}
+          </p>
+        )}
       <Button
         type="button"
         variant="primary"

--- a/web-ui/src/components/domain/workspace/NarrativeAnalysisCard.test.tsx
+++ b/web-ui/src/components/domain/workspace/NarrativeAnalysisCard.test.tsx
@@ -89,6 +89,27 @@ describe('NarrativeAnalysisCard', () => {
     expect(screen.queryByText('Watch China exposure')).toBeNull();
   });
 
+  it('shows mismatch banner when intelligence action differs from candidate decisionSummary action', () => {
+    const watchIntelligence: SymbolIntelligence = {
+      ...baseIntelligence,
+      action: 'WATCH',
+    };
+    const buyNowCandidate: SymbolAnalysisCandidate = {
+      ...baseCandidate,
+      decisionSummary: {
+        ...baseCandidate.decisionSummary!,
+        action: 'BUY_NOW',
+      },
+    };
+    render(<NarrativeAnalysisCard intelligence={watchIntelligence} candidate={buyNowCandidate} />);
+    expect(screen.getByText(/AI summary reflects/)).toBeInTheDocument();
+  });
+
+  it('does not show mismatch banner when actions match', () => {
+    render(<NarrativeAnalysisCard intelligence={baseIntelligence} candidate={baseCandidate} />);
+    expect(screen.queryByText(/AI summary reflects/)).toBeNull();
+  });
+
   it('renders confidenceNotes from explanation when present, not drivers.warnings', () => {
     const candidateWithNotes: SymbolAnalysisCandidate = {
       ...baseCandidate,

--- a/web-ui/src/components/domain/workspace/NarrativeAnalysisCard.tsx
+++ b/web-ui/src/components/domain/workspace/NarrativeAnalysisCard.tsx
@@ -131,6 +131,14 @@ export default function NarrativeAnalysisCard({
       </div>
 
       <div className="bg-slate-50 p-3 space-y-3">
+        {candidate?.decisionSummary?.action && action !== candidate.decisionSummary.action && (
+          <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
+            {t('workspacePage.panels.analysis.intelligence.aiActionMismatch', {
+              aiAction: actionLabel(action),
+              screenerAction: actionLabel(candidate.decisionSummary.action),
+            })}
+          </div>
+        )}
         {/* Decision first, rationale after. */}
         <div className="rounded-md bg-white border border-slate-200 p-3">
           <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">

--- a/web-ui/src/components/domain/workspace/SymbolAnalysisContent.tsx
+++ b/web-ui/src/components/domain/workspace/SymbolAnalysisContent.tsx
@@ -9,7 +9,6 @@ import CachedSymbolPriceChart from '@/components/domain/market/CachedSymbolPrice
 import WatchToggleButton from '@/components/domain/watchlist/WatchToggleButton';
 import FundamentalsSnapshotCard from '@/components/domain/fundamentals/FundamentalsSnapshotCard';
 import AnalysisDecisionStrip from '@/components/domain/workspace/AnalysisDecisionStrip';
-import BeginnerDecisionHeader from '@/components/domain/workspace/BeginnerDecisionHeader';
 import DecisionSummaryCard from '@/components/domain/workspace/DecisionSummaryCard';
 import NarrativeAnalysisCard from '@/components/domain/workspace/NarrativeAnalysisCard';
 import TechnicalMetricsGrid from '@/components/domain/workspace/TechnicalMetricsGrid';
@@ -46,7 +45,6 @@ function provenanceLegendItems() {
 export default function SymbolAnalysisContent({
   ticker,
   candidate,
-  screenerCandidate,
   activeTab,
   onTabChange,
   orderPanel = null,
@@ -164,15 +162,11 @@ export default function SymbolAnalysisContent({
           />
         </div>
 
-        {screenerCandidate ? (
-          <BeginnerDecisionHeader
-            candidate={screenerCandidate}
-            onAction={(kind) => {
-              if (kind === 'prepare_order') onTabChange('order');
-            }}
-          />
-        ) : null}
-        <AnalysisDecisionStrip ticker={ticker} candidate={candidate} />
+        <AnalysisDecisionStrip
+          ticker={ticker}
+          candidate={candidate}
+          onPrepareOrder={() => onTabChange('order')}
+        />
 
         {activeTab === 'overview' && (
           <>

--- a/web-ui/src/components/domain/workspace/SymbolAnalysisContent.tsx
+++ b/web-ui/src/components/domain/workspace/SymbolAnalysisContent.tsx
@@ -13,7 +13,7 @@ import DecisionSummaryCard from '@/components/domain/workspace/DecisionSummaryCa
 import NarrativeAnalysisCard from '@/components/domain/workspace/NarrativeAnalysisCard';
 import TechnicalMetricsGrid from '@/components/domain/workspace/TechnicalMetricsGrid';
 import type { SymbolAnalysisCandidate, WorkspaceAnalysisTab } from '@/components/domain/workspace/types';
-import type { ScreenerCandidate, ScreenerResponse } from '@/features/screener/types';
+import type { ScreenerResponse } from '@/features/screener/types';
 import { useRunScreenerMutation } from '@/features/screener/hooks';
 import {
   useFundamentalSnapshotQuery,
@@ -28,7 +28,6 @@ import { formatDateTime } from '@/utils/formatters';
 interface SymbolAnalysisContentProps {
   ticker: string;
   candidate?: SymbolAnalysisCandidate | null;
-  screenerCandidate?: ScreenerCandidate | null;
   activeTab: WorkspaceAnalysisTab;
   onTabChange: (tab: WorkspaceAnalysisTab) => void;
   orderPanel?: ReactNode;

--- a/web-ui/src/e2e/beginnerFlow.test.tsx
+++ b/web-ui/src/e2e/beginnerFlow.test.tsx
@@ -367,7 +367,7 @@ describe('Scenario 5: View toggle — guided and advanced labels', () => {
     // isolation. Those integration concerns are covered by
     // ScreenerInboxPanel.test.tsx. Here we only confirm that the key values
     // are stable so renames surface as test failures.
-    expect(t('screener.viewToggle.guided')).toBe('Guided');
+    expect(t('screener.viewToggle.guided')).toBe('Cards');
     expect(t('screener.viewToggle.advanced')).toBe('Advanced table');
   });
 

--- a/web-ui/src/features/screener/beginnerDecision.test.ts
+++ b/web-ui/src/features/screener/beginnerDecision.test.ts
@@ -400,6 +400,19 @@ describe('toBeginnerDecision', () => {
     expect(decision.invalidation).toBe('Price closes below the 50-day MA.');
   });
 
+  it('formats long stop decimal in invalidation text', () => {
+    const candidate = makeCandidate('AAPL', {
+      action: 'BUY_NOW',
+      verdict: 'RECOMMENDED',
+      whatInvalidatesIt: ['Price closing below the stop at 396.9259 invalidates the setup.'],
+    });
+    candidate.decisionSummary!.tradePlan = { entry: 400, stop: 396.9259, target: 420, rr: 3 };
+    const decision = toBeginnerDecision(candidate);
+
+    expect(decision.invalidation).toContain('$396.93');
+    expect(decision.invalidation).not.toContain('396.9259');
+  });
+
   it('has no invalidation when whatInvalidatesIt is empty', () => {
     const candidate = makeCandidate('AAPL', {
       action: 'BUY_NOW',

--- a/web-ui/src/features/screener/beginnerDecision.ts
+++ b/web-ui/src/features/screener/beginnerDecision.ts
@@ -1,5 +1,6 @@
 import type { ScreenerCandidate, DecisionAction } from '@/features/screener/types';
 import { prioritizeCandidates } from '@/features/screener/prioritization';
+import { formatCurrency } from '@/utils/formatters';
 
 // ── Public types ────────────────────────────────────────────────────────────
 
@@ -230,7 +231,12 @@ export function toBeginnerDecision(candidate: ScreenerCandidate): BeginnerDecisi
 
   const mainRisk = deriveMainRisk(candidate);
 
-  const invalidation = candidate.decisionSummary?.explanation?.whatInvalidatesIt?.[0];
+  const rawInvalidation = candidate.decisionSummary?.explanation?.whatInvalidatesIt?.[0];
+  const stopValue = candidate.decisionSummary?.tradePlan?.stop;
+  const invalidation =
+    rawInvalidation && stopValue != null
+      ? rawInvalidation.replace(/\d+\.\d{4,}/g, formatCurrency(stopValue, candidate.currency ?? 'USD'))
+      : rawInvalidation;
 
   const { kind: nextStepKind, label: nextStepLabel } = nextStepForReadiness(readiness);
 

--- a/web-ui/src/i18n/messages.en.ts
+++ b/web-ui/src/i18n/messages.en.ts
@@ -1108,7 +1108,7 @@ export const messagesEn = {
       },
     },
     viewToggle: {
-      guided: 'Guided',
+      guided: 'Cards',
       advanced: 'Advanced table',
     },
     guidedList: {

--- a/web-ui/src/i18n/messages.en.ts
+++ b/web-ui/src/i18n/messages.en.ts
@@ -519,6 +519,7 @@ export const messagesEn = {
       },
       mainRisk: 'Main risk:',
       invalidation: 'What would change this:',
+      weakCatalystNote: 'Acting despite weak catalyst: technical and fundamental strength meet the entry threshold.',
       action: {
         prepare_order: 'Prepare order',
         wait: 'Review price plan',

--- a/web-ui/src/i18n/messages.en.ts
+++ b/web-ui/src/i18n/messages.en.ts
@@ -681,6 +681,7 @@ export const messagesEn = {
             stop: 'Stop',
             target: 'Target',
             rr: 'R/R',
+            entryClose: 'Entry (close)',
           },
           copy: {
             whyItQualified: 'Why It Qualified',

--- a/web-ui/src/i18n/messages.en.ts
+++ b/web-ui/src/i18n/messages.en.ts
@@ -569,7 +569,7 @@ export const messagesEn = {
         },
         fundamentals: {
           descriptionHasSnapshot: 'Refresh the cached fundamentals snapshot for this symbol.',
-          descriptionNoSnapshot: 'Run fundamentals analysis for this symbol and cache the snapshot.',
+          descriptionNoSnapshot: 'No cached snapshot yet — click below to fetch and store fundamentals for this symbol.',
           refreshingAction: 'Refreshing fundamentals...',
           runningAction: 'Running fundamentals...',
           refreshAction: 'Refresh fundamentals',
@@ -577,7 +577,7 @@ export const messagesEn = {
           refreshError: 'Failed to refresh fundamentals',
           loading: 'Loading fundamentals...',
           loadError: 'Failed to load fundamentals',
-          noSnapshot: 'No fundamentals snapshot available yet.',
+          noSnapshot: 'No fundamentals snapshot cached. Use the button above to run analysis for this symbol.',
         },
         computeAnalysis: {
           description: 'No screener analysis is cached for {{ticker}} yet.',

--- a/web-ui/src/i18n/messages.en.ts
+++ b/web-ui/src/i18n/messages.en.ts
@@ -608,6 +608,7 @@ export const messagesEn = {
             low: 'Low urgency',
             none: '',
           },
+          aiActionMismatch: 'AI summary reflects {{aiAction}} — screener decision is {{screenerAction}}. Context may differ.',
           upcomingEvents: 'Upcoming Events',
           positionSignal: {
             hold: 'Hold',

--- a/web-ui/src/i18n/messages.en.ts
+++ b/web-ui/src/i18n/messages.en.ts
@@ -682,6 +682,7 @@ export const messagesEn = {
             target: 'Target',
             rr: 'R/R',
             entryClose: 'Entry (close)',
+            oneR: '1R',
           },
           copy: {
             whyItQualified: 'Why It Qualified',

--- a/web-ui/src/i18n/messages.en.ts
+++ b/web-ui/src/i18n/messages.en.ts
@@ -559,7 +559,7 @@ export const messagesEn = {
         placeholder: 'Screener controls and candidates will appear here.',
       },
       analysis: {
-        title: 'Analysis Canvas',
+        title: 'Stock Analysis',
         description: 'Review the selected ticker before creating an order.',
         tabs: {
           overview: 'Overview',

--- a/web-ui/src/i18n/messages.en.ts
+++ b/web-ui/src/i18n/messages.en.ts
@@ -86,7 +86,7 @@ export const messagesEn = {
       UNKNOWN: 'Setup incomplete',
       INCOMPLETE: 'Setup incomplete',
     },
-    setupQualityExplanation: 'Setup quality: whether the trade passes checklist rules. Suggested action: what to do next.',
+    setupQualityExplanation: 'Setup quality · Suggested action',
     details: {
       title: 'Recommendation — {{ticker}}',
     },


### PR DESCRIPTION
## What changed

  Twelve targeted UX fixes to the Today screener and Stock Analysis canvas, focused on trader execution clarity.

  ### High priority

  - **Collapsed triple summary** — removed `BeginnerDecisionHeader` from the Overview tab; the decision context was repeating three times. The "Prepare order" CTA now lives in the sticky `AnalysisDecisionStrip` instead.
  - **Suppressed contradictory Fails badge** — when `decisionSummary.action` is `BUY_NOW`, the red "Fails" quality badge is hidden. The screener was simultaneously saying "buy now" and "fails quality", which erodes trust.
  - **Risk % dash** — displays `—` instead of `0.00%` when `riskPct` is zero or missing (no stop set = no meaningful risk figure to show).
  - **AI action mismatch banner** — when the AI narrative recommends a different action than the screener decision, an amber banner surfaces the discrepancy inline. Prevents silent contradictions the trader would otherwise miss.

  ### Medium priority

  - **Stop decimal formatting** — raw stop values like `396.9259` in the invalidation text are now formatted as `$396.93`.
  - **Weak catalyst note** — when `action === BUY_NOW` and `catalystLabel === 'weak'`, a blue inline note makes the override explicit.
  - **Fundamentals empty state** — copy now guides the user to run analysis rather than just saying "no data".

  ### Low priority (copy and labelling)

  - Renamed "Analysis Canvas" → "Stock Analysis" throughout.
  - Renamed "Guided" view toggle → "Cards".
  - Shortened the `setupQualityExplanation` footnote.
  - Annotated Entry price as "(close)" in the decision strip.
  - Added 1R = entry − stop value to the decision strip.

  ## Test plan

  - [ ] 567/567 Vitest tests pass (`npm test` in `web-ui/`)
  - [ ] Open Today screener, select a BUY_NOW candidate — confirm no triple summary, Prepare Order button visible in strip
  - [ ] Select a BUY_NOW candidate with `fail` quality — confirm "Fails" badge hidden, green "Ready" chip only
  - [ ] Select any candidate with `riskPct = 0` — confirm Risk % shows `—`
  - [ ] Select a candidate where AI action ≠ screener action — confirm amber mismatch banner appears
  - [ ] Check invalidation text for a candidate with a stop — confirm formatted price (e.g. `$396.93` not `396.9259`)
  - [ ] Confirm title bar reads "Stock Analysis" and view toggle reads "Cards"
  - [ ] Entry label reads "Entry (close)" and 1R value appears next to entry/stop

  🤖 Generated with [Claude Code](https://claude.ai/claude-code)