### PR TITLE
[codex] Align pullback entry summary with order price

### DIFF
--- a/src/swing_screener/intelligence/models.py
+++ b/src/swing_screener/intelligence/models.py
@@ -67,6 +67,23 @@ class SymbolIntelligenceRequest(BaseModel):
     entry_price: float | None = None
     r_now: float | None = None
     days_open: int | None = None
+    # Extended context — decision summary + chart quality + fundamentals
+    rr: float | None = None
+    target: float | None = None
+    rel_strength: float | None = None
+    atr: float | None = None
+    consolidation_tightness: float | None = None
+    breakout_volume_confirmation: bool | None = None
+    above_breakout_extension: float | None = None
+    fair_value_low: float | None = None
+    fair_value_base: float | None = None
+    fair_value_high: float | None = None
+    valuation_label: Literal["cheap", "fair", "expensive", "unknown"] | None = None
+    decision_action: str | None = None
+    decision_conviction: str | None = None
+    technical_label: str | None = None
+    fundamentals_label: str | None = None
+    catalyst_summary: str | None = None
 
 
 class SymbolIntelligence(BaseModel):
@@ -81,3 +98,4 @@ class SymbolIntelligence(BaseModel):
     position_signal: PositionSignal | None = None
     position_outlook: PositionOutlook | None = None
     sources: list[str] = []
+    inputs_used: dict = Field(default_factory=dict)

--- a/src/swing_screener/intelligence/symbol_analyzer.py
+++ b/src/swing_screener/intelligence/symbol_analyzer.py
@@ -29,6 +29,11 @@ Return ONLY a JSON block (fenced with ```json) with exactly these fields:
 - catalyst_urgency: one of high | medium | low | none
 - summary_line: one sentence synthetic read (max 120 chars)
 - narrative: flowing prose in Markdown. Start with the actionable read: **What to do:** and **Watch for:** in the first two short paragraphs. Then add the supporting technical, fundamental, and catalyst rationale. No H1/H2 headings. Max 300 words.
+  When writing the narrative, always include:
+  - **When to act:** Explain the specific timing for order placement — after market close today, on a confirmed pullback to the entry level, or on a breakout above a key level. Be concrete about the condition.
+  - **Expected growth:** Using the target price and fair value context, state the expected upside as a percentage and how long it might take to play out (days/weeks).
+  - **Take profit reasoning:** Explain why the target price was set where it is — R-multiple from stop, resistance level, or fair value estimate.
+  Keep the narrative flowing and discursive, integrating the screener decision context naturally rather than listing fields mechanically.
 - upcoming_events: array of objects {type, date, direction, summary} for events that could move the price.
   type: earnings | macro | dividend | product_launch | regulatory | other
   date: ISO date string or null if unknown
@@ -106,6 +111,80 @@ def _build_user_prompt(ticker: str, req: SymbolIntelligenceRequest) -> str:
     if not has_position:
         lines.append(f"Suggested entry: {fmt(req.entry)} | Suggested stop: {fmt(req.stop)}")
 
+        # Trade plan block
+        if any(x is not None for x in (req.target, req.rr)):
+            currency = req.currency or ""
+            plan_lines: list[str] = [
+                "",
+                "--- Trade plan ---",
+            ]
+            entry_str = f"Entry: {fmt(req.entry)} {currency}" if req.entry is not None else ""
+            stop_str = f"Stop: {fmt(req.stop)} {currency}" if req.stop is not None else ""
+            target_str = f"Target: {fmt(req.target)} {currency}" if req.target is not None else ""
+            price_parts = [p for p in (entry_str, stop_str, target_str) if p]
+            if price_parts:
+                plan_lines.append(" | ".join(price_parts))
+            rr_str = f"Risk/Reward: {req.rr}x" if req.rr is not None else ""
+            if req.target is not None and req.close is not None:
+                upside_pct = round((req.target - req.close) / req.close * 100, 1)
+                upside_str = f"Upside to target: {upside_pct}%"
+            else:
+                upside_str = ""
+            rr_parts = [p for p in (rr_str, upside_str) if p]
+            if rr_parts:
+                plan_lines.append(" | ".join(rr_parts))
+            lines += plan_lines
+
+        # Decision context block
+        has_decision = any(
+            x is not None and x != ""
+            for x in (
+                req.decision_action, req.decision_conviction,
+                req.technical_label, req.fundamentals_label, req.valuation_label,
+                req.fair_value_low, req.fair_value_base, req.fair_value_high,
+            )
+        )
+        if has_decision:
+            currency = req.currency or ""
+            lines += ["", "--- Decision context (screener) ---"]
+            action_str = f"Action: {req.decision_action}" if req.decision_action else ""
+            conv_str = f"Conviction: {req.decision_conviction}" if req.decision_conviction else ""
+            ac_parts = [p for p in (action_str, conv_str) if p]
+            if ac_parts:
+                lines.append(" | ".join(ac_parts))
+            tech_str = f"Technical: {req.technical_label}" if req.technical_label else ""
+            fund_str = f"Fundamentals: {req.fundamentals_label}" if req.fundamentals_label else ""
+            val_str = f"Valuation: {req.valuation_label}" if req.valuation_label else ""
+            label_parts = [p for p in (tech_str, fund_str, val_str) if p]
+            if label_parts:
+                lines.append(" | ".join(label_parts))
+            if any(x is not None for x in (req.fair_value_low, req.fair_value_base, req.fair_value_high)):
+                fv_low = fmt(req.fair_value_low)
+                fv_high = fmt(req.fair_value_high)
+                fv_base = fmt(req.fair_value_base)
+                lines.append(
+                    f"Fair value range: {fv_low}–{fv_high} (base {fv_base}) {currency}"
+                )
+
+        # Chart quality block
+        has_chart_quality = any(x is not None for x in (req.atr, req.rel_strength))
+        if has_chart_quality:
+            lines += ["", "--- Chart quality ---"]
+            atr_str = f"ATR: {fmt(req.atr)}" if req.atr is not None else ""
+            rs_str = f"Relative strength vs benchmark: {req.rel_strength}%" if req.rel_strength is not None else ""
+            cq_parts = [p for p in (atr_str, rs_str) if p]
+            if cq_parts:
+                lines.append(" | ".join(cq_parts))
+
+    # Catalyst context block (before web search instruction)
+    if req.catalyst_summary:
+        lines += [
+            "",
+            "--- Existing catalyst context ---",
+            req.catalyst_summary,
+            "(Build on this context. Do not repeat it verbatim.)",
+        ]
+
     lines.append(
         f"\nSearch for recent news, earnings results, catalysts, and analyst views for {ticker}. "
         "Then produce the structured JSON analysis."
@@ -122,6 +201,65 @@ class SymbolAnalyzer:
         self._client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
 
     def analyze(self, ticker: str, req: SymbolIntelligenceRequest) -> SymbolIntelligence:
+        inputs_used: dict = {}
+
+        trade_plan: dict = {}
+        if req.entry is not None:
+            trade_plan["entry"] = req.entry
+        if req.stop is not None:
+            trade_plan["stop"] = req.stop
+        if req.target is not None:
+            trade_plan["target"] = req.target
+        if req.rr is not None:
+            trade_plan["rr"] = req.rr
+        if req.target and req.close:
+            trade_plan["upside_pct"] = round((req.target - req.close) / req.close * 100, 1)
+        if trade_plan:
+            inputs_used["trade_plan"] = trade_plan
+
+        technical: dict = {}
+        if req.sma_20 is not None:
+            technical["sma_20"] = req.sma_20
+        if req.sma_50 is not None:
+            technical["sma_50"] = req.sma_50
+        if req.sma_200 is not None:
+            technical["sma_200"] = req.sma_200
+        if req.momentum_6m is not None:
+            technical["momentum_6m"] = req.momentum_6m
+        if req.momentum_12m is not None:
+            technical["momentum_12m"] = req.momentum_12m
+        if req.rel_strength is not None:
+            technical["rel_strength"] = req.rel_strength
+        if req.atr is not None:
+            technical["atr"] = req.atr
+        if req.signal:
+            technical["signal"] = req.signal
+        if technical:
+            inputs_used["technical"] = technical
+
+        decision: dict = {}
+        if req.decision_action:
+            decision["action"] = req.decision_action
+        if req.decision_conviction:
+            decision["conviction"] = req.decision_conviction
+        if req.technical_label:
+            decision["technical_label"] = req.technical_label
+        if req.fundamentals_label:
+            decision["fundamentals_label"] = req.fundamentals_label
+        if req.valuation_label:
+            decision["valuation_label"] = req.valuation_label
+        if req.fair_value_low is not None:
+            decision["fair_value_low"] = req.fair_value_low
+        if req.fair_value_base is not None:
+            decision["fair_value_base"] = req.fair_value_base
+        if req.fair_value_high is not None:
+            decision["fair_value_high"] = req.fair_value_high
+        if decision:
+            inputs_used["decision_context"] = decision
+
+        if req.catalyst_summary:
+            inputs_used["catalyst"] = {"summary_available": True}
+
         user_prompt = _build_user_prompt(ticker, req)
         response = self._client.responses.create(
             model=self._model,
@@ -144,6 +282,7 @@ class SymbolAnalyzer:
             position_outlook=raw.get("position_outlook"),
             sources=raw.get("sources", []),
         )
+        result = result.model_copy(update={"inputs_used": inputs_used})
         try:
             write_to_cache(ticker, result)
         except Exception:

--- a/src/swing_screener/intelligence/symbol_analyzer.py
+++ b/src/swing_screener/intelligence/symbol_analyzer.py
@@ -28,7 +28,7 @@ Return ONLY a JSON block (fenced with ```json) with exactly these fields:
 - conviction: one of high | medium | low
 - catalyst_urgency: one of high | medium | low | none
 - summary_line: one sentence synthetic read (max 120 chars)
-- narrative: flowing prose in Markdown. Start with the actionable read: **What to do:** and **Watch for:** in the first two short paragraphs. Then add the supporting technical, fundamental, and catalyst rationale. No H1/H2 headings. Max 300 words.
+- narrative: flowing prose in Markdown. Start with the actionable read: **What to do:** and **Watch for:** in the first two short paragraphs. Then add the supporting technical, fundamental, and catalyst rationale. No H1/H2 headings. Max 400 words.
   When writing the narrative, always include:
   - **When to act:** Explain the specific timing for order placement — after market close today, on a confirmed pullback to the entry level, or on a breakout above a key level. Be concrete about the condition.
   - **Expected growth:** Using the target price and fair value context, state the expected upside as a percentage and how long it might take to play out (days/weeks).
@@ -109,10 +109,8 @@ def _build_user_prompt(ticker: str, req: SymbolIntelligenceRequest) -> str:
     ]
 
     if not has_position:
-        lines.append(f"Suggested entry: {fmt(req.entry)} | Suggested stop: {fmt(req.stop)}")
-
         # Trade plan block
-        if any(x is not None for x in (req.target, req.rr)):
+        if any(x is not None for x in (req.entry, req.stop, req.target, req.rr)):
             currency = req.currency or ""
             plan_lines: list[str] = [
                 "",
@@ -158,7 +156,7 @@ def _build_user_prompt(ticker: str, req: SymbolIntelligenceRequest) -> str:
             label_parts = [p for p in (tech_str, fund_str, val_str) if p]
             if label_parts:
                 lines.append(" | ".join(label_parts))
-            if any(x is not None for x in (req.fair_value_low, req.fair_value_base, req.fair_value_high)):
+            if all(x is not None for x in (req.fair_value_low, req.fair_value_base, req.fair_value_high)):
                 fv_low = fmt(req.fair_value_low)
                 fv_high = fmt(req.fair_value_high)
                 fv_base = fmt(req.fair_value_base)
@@ -212,7 +210,7 @@ class SymbolAnalyzer:
             trade_plan["target"] = req.target
         if req.rr is not None:
             trade_plan["rr"] = req.rr
-        if req.target and req.close:
+        if req.target is not None and req.close is not None:
             trade_plan["upside_pct"] = round((req.target - req.close) / req.close * 100, 1)
         if trade_plan:
             inputs_used["trade_plan"] = trade_plan

--- a/src/swing_screener/intelligence/symbol_analyzer.py
+++ b/src/swing_screener/intelligence/symbol_analyzer.py
@@ -116,9 +116,9 @@ def _build_user_prompt(ticker: str, req: SymbolIntelligenceRequest) -> str:
                 "",
                 "--- Trade plan ---",
             ]
-            entry_str = f"Entry: {fmt(req.entry)} {currency}" if req.entry is not None else ""
-            stop_str = f"Stop: {fmt(req.stop)} {currency}" if req.stop is not None else ""
-            target_str = f"Target: {fmt(req.target)} {currency}" if req.target is not None else ""
+            entry_str = f"Planned entry (pullback level): {fmt(req.entry)} {currency}" if req.entry is not None else ""
+            stop_str = f"Stop loss (invalidation level): {fmt(req.stop)} {currency}" if req.stop is not None else ""
+            target_str = f"Price target: {fmt(req.target)} {currency}" if req.target is not None else ""
             price_parts = [p for p in (entry_str, stop_str, target_str) if p]
             if price_parts:
                 plan_lines.append(" | ".join(price_parts))

--- a/web-ui/src/components/domain/workspace/AnalysisDecisionStrip.test.tsx
+++ b/web-ui/src/components/domain/workspace/AnalysisDecisionStrip.test.tsx
@@ -99,6 +99,62 @@ describe('AnalysisDecisionStrip — Risk % cell', () => {
   });
 });
 
+describe('AnalysisDecisionStrip — planned pullback entry', () => {
+  it('uses the suggested order price as planned entry and shows close as secondary context', () => {
+    const decisionSummary = {
+      symbol: 'BESI.AS',
+      action: 'BUY_ON_PULLBACK' as const,
+      conviction: 'medium' as const,
+      technicalLabel: 'strong' as const,
+      fundamentalsLabel: 'strong' as const,
+      valuationLabel: 'expensive' as const,
+      catalystLabel: 'weak' as const,
+      catalystSummary: null,
+      catalystSources: [],
+      whyNow: '',
+      whatToDo: '',
+      mainRisk: '',
+      tradePlan: { entry: 287.6, stop: 277.37, target: 308.06, rr: 2 },
+      drivers: { positives: [], negatives: [], warnings: [] },
+      valuationContext: {
+        method: 'not_available' as const,
+        summary: '',
+        trailingPe: undefined,
+        priceToSales: undefined,
+        bookValuePerShare: undefined,
+        priceToBook: undefined,
+        bookToPrice: undefined,
+        fairValueLow: undefined,
+        fairValueBase: undefined,
+        fairValueHigh: undefined,
+        premiumDiscountPct: undefined,
+      },
+    };
+    const candidate = buildCandidate({
+      ticker: 'BESI.AS',
+      currency: 'EUR',
+      close: 287.6,
+      entry: 287.6,
+      stop: 277.37,
+      suggestedOrderType: 'BUY_LIMIT',
+      suggestedOrderPrice: 285.04,
+      decisionSummary,
+    });
+
+    render(<AnalysisDecisionStrip ticker="BESI.AS" candidate={candidate} />);
+
+    const entryLabel = screen.getByText('Planned entry');
+    const entryCell = entryLabel.closest('div[class*="min-w"]');
+    expect(entryCell?.textContent).toContain('€285.04');
+    expect(entryCell?.textContent).toContain('Close €287.60');
+    expect(entryCell?.textContent).not.toContain('Entry (close)');
+
+    const oneRLabel = screen.getByText('1R');
+    const oneRCell = oneRLabel.closest('div[class*="min-w"]');
+    expect(oneRCell?.textContent).toContain('€7.67');
+  });
+});
+
 describe('AnalysisDecisionStrip — watch button', () => {
   it('renders Watch button when isWatched=false and calls onWatch on click', async () => {
     const onWatch = vi.fn();

--- a/web-ui/src/components/domain/workspace/AnalysisDecisionStrip.tsx
+++ b/web-ui/src/components/domain/workspace/AnalysisDecisionStrip.tsx
@@ -47,11 +47,16 @@ function convictionLabel(conviction: DecisionConviction): string {
   }
 }
 
-function compactValue(label: string, value: string) {
+function isPositiveNumber(value: number | null | undefined): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0;
+}
+
+function compactValue(label: string, value: string, secondary?: string) {
   return (
     <div className="min-w-[88px] rounded-md border border-slate-200 bg-white/90 px-2.5 py-2">
       <div className="text-[10px] uppercase tracking-wide text-slate-500">{label}</div>
       <div className="mt-1 text-sm font-semibold text-slate-900">{value}</div>
+      {secondary ? <div className="mt-0.5 text-[10px] text-slate-500">{secondary}</div> : null}
     </div>
   );
 }
@@ -67,13 +72,27 @@ export default function AnalysisDecisionStrip({
 }: AnalysisDecisionStripProps) {
   const summary = candidate?.decisionSummary;
   const currency = candidate?.currency ?? 'USD';
-  const entry = summary?.tradePlan.entry ?? candidate?.recommendation?.risk?.entry ?? candidate?.entry;
+  const closeEntry = summary?.tradePlan.entry ?? candidate?.recommendation?.risk?.entry ?? candidate?.entry;
+  const suggestedOrderEntry = isPositiveNumber(candidate?.suggestedOrderPrice) ? candidate.suggestedOrderPrice : null;
+  const usesSuggestedEntry =
+    suggestedOrderEntry != null &&
+    (!isPositiveNumber(closeEntry) || Math.abs(suggestedOrderEntry - closeEntry) >= 0.005);
+  const entry = usesSuggestedEntry ? suggestedOrderEntry : closeEntry;
   const stop = summary?.tradePlan.stop ?? candidate?.recommendation?.risk?.stop ?? candidate?.stop;
   const target = summary?.tradePlan.target ?? candidate?.recommendation?.risk?.target;
-  const rr = summary?.tradePlan.rr ?? candidate?.recommendation?.risk?.rr ?? candidate?.rr;
+  const computedRr = target != null && entry != null && stop != null && entry > stop
+    ? (target - entry) / (entry - stop)
+    : null;
+  const rr = computedRr ?? summary?.tradePlan.rr ?? candidate?.recommendation?.risk?.rr ?? candidate?.rr;
   const oneR = entry != null && stop != null ? entry - stop : null;
   const pctToTarget = target != null && entry != null && entry > 0 ? (target - entry) / entry * 100 : null;
   const riskPct = candidate?.recommendation?.risk?.riskPct;
+  const entryLabel = usesSuggestedEntry
+    ? t('workspacePage.panels.analysis.decisionSummary.tradePlan.plannedEntry')
+    : t('workspacePage.panels.analysis.decisionSummary.tradePlan.entryClose');
+  const closeSecondary = usesSuggestedEntry && isPositiveNumber(closeEntry)
+    ? `${t('workspacePage.panels.analysis.decisionSummary.tradePlan.close')} ${formatCurrency(closeEntry, currency)}`
+    : undefined;
 
   return (
     <div className="sticky top-0 z-10 rounded-xl border border-slate-200 bg-slate-50/95 p-3 shadow-sm backdrop-blur supports-[backdrop-filter]:bg-slate-50/85">
@@ -104,7 +123,7 @@ export default function AnalysisDecisionStrip({
               </button>
             )}
             <div className="grid grid-cols-4 gap-2 md:grid-cols-7">
-              {compactValue(t('workspacePage.panels.analysis.decisionSummary.tradePlan.entryClose'), entry != null ? formatCurrency(entry, currency) : '—')}
+              {compactValue(entryLabel, entry != null ? formatCurrency(entry, currency) : '—', closeSecondary)}
               {compactValue('Stop', stop != null ? formatCurrency(stop, currency) : '—')}
               {compactValue('Target', target != null ? formatCurrency(target, currency) : '—')}
               {compactValue(t('workspacePage.panels.analysis.decisionSummary.tradePlan.toTarget'), pctToTarget != null ? `${formatNumber(pctToTarget, 2)}%` : '—')}

--- a/web-ui/src/components/domain/workspace/NarrativeAnalysisCard.test.tsx
+++ b/web-ui/src/components/domain/workspace/NarrativeAnalysisCard.test.tsx
@@ -110,6 +110,25 @@ describe('NarrativeAnalysisCard', () => {
     expect(screen.queryByText(/AI summary reflects/)).toBeNull();
   });
 
+  it('renders "Data used by AI" panel with chips when inputsUsed has content', () => {
+    const intelligenceWithInputs: SymbolIntelligence = {
+      ...baseIntelligence,
+      inputsUsed: { trade_plan: { entry: 285, rr: 2.5 } },
+    };
+    render(<NarrativeAnalysisCard intelligence={intelligenceWithInputs} />);
+    expect(screen.getByText('Data used by AI')).toBeInTheDocument();
+    expect(screen.getByText('entry:')).toBeInTheDocument();
+  });
+
+  it('does not render "Data used by AI" panel when inputsUsed is empty', () => {
+    const intelligenceEmptyInputs: SymbolIntelligence = {
+      ...baseIntelligence,
+      inputsUsed: {},
+    };
+    render(<NarrativeAnalysisCard intelligence={intelligenceEmptyInputs} />);
+    expect(screen.queryByText('Data used by AI')).toBeNull();
+  });
+
   it('renders confidenceNotes from explanation when present, not drivers.warnings', () => {
     const candidateWithNotes: SymbolAnalysisCandidate = {
       ...baseCandidate,

--- a/web-ui/src/components/domain/workspace/NarrativeAnalysisCard.test.tsx
+++ b/web-ui/src/components/domain/workspace/NarrativeAnalysisCard.test.tsx
@@ -52,17 +52,10 @@ describe('NarrativeAnalysisCard', () => {
     expect(screen.getByText(/Watch for:/)).toBeInTheDocument();
   });
 
-  it('renders trade plan tiles when candidate has decisionSummary', () => {
-    render(<NarrativeAnalysisCard intelligence={baseIntelligence} candidate={baseCandidate} currency="USD" />);
-    expect(screen.getByText('$182.40')).toBeInTheDocument();
-    expect(screen.getByText('$174.20')).toBeInTheDocument();
-    expect(screen.getByText('$204.00')).toBeInTheDocument();
-    expect(screen.getByText('2.60x')).toBeInTheDocument();
-  });
-
-  it('does not render trade plan when no candidate', () => {
-    render(<NarrativeAnalysisCard intelligence={baseIntelligence} />);
-    expect(screen.queryByText('$182.40')).toBeNull();
+  it('does not render a duplicate trade plan grid', () => {
+    render(<NarrativeAnalysisCard intelligence={baseIntelligence} candidate={baseCandidate} />);
+    // Trade plan is shown in the workspace header, not inside this card
+    expect(screen.queryByText('2.60x')).toBeNull();
   });
 
   it('signals detail section is collapsed by default', () => {

--- a/web-ui/src/components/domain/workspace/NarrativeAnalysisCard.tsx
+++ b/web-ui/src/components/domain/workspace/NarrativeAnalysisCard.tsx
@@ -193,6 +193,35 @@ export default function NarrativeAnalysisCard({
           </div>
         </div>
 
+        {/* Data inputs used by AI */}
+        {intelligence.inputsUsed && Object.keys(intelligence.inputsUsed).length > 0 && (
+          <details className="rounded-md border border-slate-200 bg-white p-3">
+            <summary className="cursor-pointer text-xs font-medium text-slate-500 select-none">
+              {t('workspacePage.panels.analysis.intelligence.dataInputs')}
+            </summary>
+            <div className="mt-3 space-y-2">
+              {Object.entries(intelligence.inputsUsed).map(([group, fields]) => (
+                <div key={group}>
+                  <div className="text-[10px] font-semibold uppercase tracking-wide text-slate-400 mb-1">
+                    {group.replace(/_/g, ' ')}
+                  </div>
+                  <div className="flex flex-wrap gap-1.5">
+                    {Object.entries(fields as Record<string, unknown>).filter(([, v]) => v != null).map(([key, value]) => (
+                      <span
+                        key={key}
+                        className="inline-flex items-center gap-1 rounded-full bg-slate-100 px-2.5 py-0.5 text-xs text-slate-700"
+                      >
+                        <span className="font-medium text-slate-500">{key.replace(/_/g, ' ')}:</span>
+                        <span>{typeof value === 'number' ? (Number.isInteger(value) ? value : value.toFixed(2)) : String(value)}</span>
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </details>
+        )}
+
         {/* Collapsed signals + valuation detail */}
         {summary && (
           <details className="rounded-md border border-slate-200 bg-white p-3">

--- a/web-ui/src/components/domain/workspace/NarrativeAnalysisCard.tsx
+++ b/web-ui/src/components/domain/workspace/NarrativeAnalysisCard.tsx
@@ -4,12 +4,10 @@ import type { SymbolIntelligence, DecisionAction, DecisionConviction } from '@/f
 import type { DecisionCatalystLabel, DecisionSignalLabel, DecisionValuationLabel } from '@/features/screener/types';
 import type { SymbolAnalysisCandidate } from '@/components/domain/workspace/types';
 import { t } from '@/i18n/t';
-import { formatCurrency, formatNumber } from '@/utils/formatters';
 
 interface NarrativeAnalysisCardProps {
   intelligence: SymbolIntelligence;
   candidate?: SymbolAnalysisCandidate | null;
-  currency?: string;
 }
 
 function actionLabel(action: DecisionAction): string {
@@ -91,7 +89,6 @@ function convictionVariant(conviction: DecisionConviction): 'default' | 'success
 export default function NarrativeAnalysisCard({
   intelligence,
   candidate,
-  currency = 'USD',
 }: NarrativeAnalysisCardProps) {
   const { action, conviction, summaryLine, narrative } = intelligence;
   const summary = candidate?.decisionSummary;
@@ -111,14 +108,6 @@ export default function NarrativeAnalysisCard({
     },
   ].filter((item) => item.value);
 
-  const tradePlanItems = summary?.tradePlan
-    ? [
-        { label: t('workspacePage.panels.analysis.decisionSummary.tradePlan.entry'), value: summary.tradePlan.entry, fmt: (v: number) => formatCurrency(v, currency) },
-        { label: t('workspacePage.panels.analysis.decisionSummary.tradePlan.stop'), value: summary.tradePlan.stop, fmt: (v: number) => formatCurrency(v, currency) },
-        { label: t('workspacePage.panels.analysis.decisionSummary.tradePlan.target'), value: summary.tradePlan.target, fmt: (v: number) => formatCurrency(v, currency) },
-        { label: t('workspacePage.panels.analysis.decisionSummary.tradePlan.rr'), value: summary.tradePlan.rr, fmt: (v: number) => `${formatNumber(v, 2)}x` },
-      ].filter((item) => item.value != null)
-    : [];
 
   return (
     <div className="rounded-lg border border-slate-200 overflow-hidden">
@@ -158,18 +147,6 @@ export default function NarrativeAnalysisCard({
             </dl>
           )}
         </div>
-
-        {/* Compact trade plan */}
-        {tradePlanItems.length > 0 && (
-          <div className="grid grid-cols-2 gap-2 md:grid-cols-4">
-            {tradePlanItems.map((item) => (
-              <div key={item.label} className="rounded-md border border-slate-200 bg-white px-3 py-2">
-                <div className="text-[11px] uppercase tracking-wide text-gray-500">{item.label}</div>
-                <div className="mt-1 text-sm font-semibold text-slate-900">{item.fmt(item.value as number)}</div>
-              </div>
-            ))}
-          </div>
-        )}
 
         {/* Warnings — always visible, never collapsed */}
         {warnings.length > 0 && (

--- a/web-ui/src/components/domain/workspace/SymbolAnalysisContent.tsx
+++ b/web-ui/src/components/domain/workspace/SymbolAnalysisContent.tsx
@@ -191,7 +191,6 @@ export default function SymbolAnalysisContent({
                   <NarrativeAnalysisCard
                     intelligence={displayedIntelligence}
                     candidate={candidate}
-                    currency={candidate?.currency}
                   />
                 );
               }

--- a/web-ui/src/features/intelligence/api.test.ts
+++ b/web-ui/src/features/intelligence/api.test.ts
@@ -73,4 +73,92 @@ describe('candidateToPayload', () => {
     expect(payload!.stop).toBe(143);
     expect(payload!.entry_price).toBe(140);
   });
+
+  it('maps rr, atr, rel_strength from candidate fields', () => {
+    const payload = candidateToPayload({
+      ...baseCandidate,
+      rr: 2.5,
+      atr: 3.2,
+      relStrength: 15.4,
+    });
+    expect(payload!.rr).toBe(2.5);
+    expect(payload!.atr).toBe(3.2);
+    expect(payload!.rel_strength).toBe(15.4);
+  });
+
+  it('maps decision_action, decision_conviction, valuation_label, technical_label, fundamentals_label from decisionSummary', () => {
+    const payload = candidateToPayload({
+      ...baseCandidate,
+      decisionSummary: {
+        symbol: 'AAPL',
+        action: 'BUY_NOW',
+        conviction: 'high',
+        technicalLabel: 'strong',
+        fundamentalsLabel: 'neutral',
+        valuationLabel: 'fair',
+        catalystLabel: 'active',
+        whyNow: 'Breakout.',
+        whatToDo: 'Buy.',
+        mainRisk: 'Risk.',
+        tradePlan: { entry: 152, stop: 143, target: 170, rr: 2.5 },
+        valuationContext: { method: 'earnings_multiple' },
+        drivers: { positives: [], negatives: [], warnings: [] },
+        catalystSummary: null,
+        catalystSources: [],
+      },
+    });
+    expect(payload!.decision_action).toBe('BUY_NOW');
+    expect(payload!.decision_conviction).toBe('high');
+    expect(payload!.valuation_label).toBe('fair');
+    expect(payload!.technical_label).toBe('strong');
+    expect(payload!.fundamentals_label).toBe('neutral');
+  });
+
+  it('maps target and fair_value_* from decisionSummary.tradePlan and valuationContext', () => {
+    const payload = candidateToPayload({
+      ...baseCandidate,
+      decisionSummary: {
+        symbol: 'AAPL',
+        action: 'BUY_NOW',
+        conviction: 'high',
+        technicalLabel: 'strong',
+        fundamentalsLabel: 'neutral',
+        valuationLabel: 'fair',
+        catalystLabel: 'active',
+        whyNow: 'Breakout.',
+        whatToDo: 'Buy.',
+        mainRisk: 'Risk.',
+        tradePlan: { entry: 152, stop: 143, target: 170, rr: 2.5 },
+        valuationContext: {
+          method: 'earnings_multiple',
+          fairValueLow: 140,
+          fairValueBase: 160,
+          fairValueHigh: 180,
+        },
+        drivers: { positives: [], negatives: [], warnings: [] },
+        catalystSummary: null,
+        catalystSources: [],
+      },
+    });
+    expect(payload!.target).toBe(170);
+    expect(payload!.fair_value_low).toBe(140);
+    expect(payload!.fair_value_base).toBe(160);
+    expect(payload!.fair_value_high).toBe(180);
+  });
+
+  it('all new fields are null when candidate has no decisionSummary', () => {
+    const payload = candidateToPayload(baseCandidate);
+    expect(payload!.rr).toBeNull();
+    expect(payload!.atr).toBeNull();
+    expect(payload!.rel_strength).toBeNull();
+    expect(payload!.target).toBeNull();
+    expect(payload!.fair_value_low).toBeNull();
+    expect(payload!.fair_value_base).toBeNull();
+    expect(payload!.fair_value_high).toBeNull();
+    expect(payload!.valuation_label).toBeNull();
+    expect(payload!.decision_action).toBeNull();
+    expect(payload!.decision_conviction).toBeNull();
+    expect(payload!.technical_label).toBeNull();
+    expect(payload!.fundamentals_label).toBeNull();
+  });
 });

--- a/web-ui/src/features/intelligence/api.ts
+++ b/web-ui/src/features/intelligence/api.ts
@@ -18,6 +18,19 @@ export interface IntelligenceRequestPayload {
   entry_price?: number;
   r_now?: number;
   days_open?: number;
+  rr?: number | null;
+  target?: number | null;
+  rel_strength?: number | null;
+  atr?: number | null;
+  fair_value_low?: number | null;
+  fair_value_base?: number | null;
+  fair_value_high?: number | null;
+  valuation_label?: string | null;
+  decision_action?: string | null;
+  decision_conviction?: string | null;
+  technical_label?: string | null;
+  fundamentals_label?: string | null;
+  catalyst_summary?: string | null;
 }
 
 export function candidateToPayload(
@@ -38,6 +51,19 @@ export function candidateToPayload(
     sector: candidate.sector ?? null,
     currency: candidate.currency ?? 'USD',
   };
+  payload.rr = candidate.rr ?? null;
+  payload.rel_strength = candidate.relStrength ?? null;
+  payload.atr = candidate.atr ?? null;
+  payload.target = candidate.decisionSummary?.tradePlan?.target ?? null;
+  payload.fair_value_low = candidate.decisionSummary?.valuationContext?.fairValueLow ?? null;
+  payload.fair_value_base = candidate.decisionSummary?.valuationContext?.fairValueBase ?? null;
+  payload.fair_value_high = candidate.decisionSummary?.valuationContext?.fairValueHigh ?? null;
+  payload.valuation_label = candidate.decisionSummary?.valuationLabel ?? null;
+  payload.decision_action = candidate.decisionSummary?.action ?? null;
+  payload.decision_conviction = candidate.decisionSummary?.conviction ?? null;
+  payload.technical_label = candidate.decisionSummary?.technicalLabel ?? null;
+  payload.fundamentals_label = candidate.decisionSummary?.fundamentalsLabel ?? null;
+  payload.catalyst_summary = candidate.decisionSummary?.catalystSummary ?? null;
   if (position != null) {
     payload.entry_price = position.entryPrice;
     payload.r_now = position.rNow;

--- a/web-ui/src/features/intelligence/types.test.ts
+++ b/web-ui/src/features/intelligence/types.test.ts
@@ -25,6 +25,38 @@ describe('transformIntelligence', () => {
   });
 });
 
+function makeBase(): SymbolIntelligenceAPI {
+  return {
+    symbol: 'BASE',
+    generated_at: '2026-05-28T00:00:00Z',
+    action: 'WATCH',
+    conviction: 'medium',
+    catalyst_urgency: 'none',
+    summary_line: 'Base.',
+    narrative: 'Text.',
+    upcoming_events: [],
+    position_signal: null,
+    position_outlook: null,
+    sources: [],
+  };
+}
+
+describe('transformIntelligence inputs_used', () => {
+  it('maps inputs_used to inputsUsed', () => {
+    const api = makeBase();
+    api.inputs_used = { trade_plan: { entry: 100, rr: 2.5 } };
+    const result = transformIntelligence(api);
+    expect(result.inputsUsed).toEqual({ trade_plan: { entry: 100, rr: 2.5 } });
+  });
+
+  it('defaults inputsUsed to empty object when inputs_used absent', () => {
+    const api = makeBase();
+    delete (api as unknown as Record<string, unknown>).inputs_used;
+    const result = transformIntelligence(api);
+    expect(result.inputsUsed).toEqual({});
+  });
+});
+
 describe('transformIntelligence with new fields', () => {
   it('maps catalyst_urgency, upcoming_events, position_signal', () => {
     const api: SymbolIntelligenceAPI = {

--- a/web-ui/src/features/intelligence/types.ts
+++ b/web-ui/src/features/intelligence/types.ts
@@ -58,6 +58,7 @@ export interface SymbolIntelligenceAPI {
   position_signal: PositionSignal | null;
   position_outlook?: PositionOutlookAPI | null;
   sources: string[];
+  inputs_used?: Record<string, Record<string, unknown>>;
 }
 
 export interface SymbolIntelligence {
@@ -72,6 +73,7 @@ export interface SymbolIntelligence {
   positionSignal: PositionSignal | null;
   positionOutlook?: PositionOutlook | null;
   sources: string[];
+  inputsUsed?: Record<string, Record<string, unknown>>;
 }
 
 function transformPositionOutlook(api: PositionOutlookAPI | null | undefined): PositionOutlook | null {
@@ -101,6 +103,7 @@ export function transformIntelligence(api: SymbolIntelligenceAPI): SymbolIntelli
     positionSignal: api.position_signal ?? null,
     positionOutlook: transformPositionOutlook(api.position_outlook),
     sources: api.sources ?? [],
+    inputsUsed: api.inputs_used ?? {},
   };
 }
 

--- a/web-ui/src/i18n/messages.en.ts
+++ b/web-ui/src/i18n/messages.en.ts
@@ -694,6 +694,8 @@ export const messagesEn = {
             target: 'Target',
             rr: 'R/R',
             entryClose: 'Entry (close)',
+            plannedEntry: 'Planned entry',
+            close: 'Close',
             oneR: '1R',
             toTarget: 'To Target',
           },

--- a/web-ui/src/i18n/messages.en.ts
+++ b/web-ui/src/i18n/messages.en.ts
@@ -599,6 +599,7 @@ export const messagesEn = {
           refreshAction: 'Refresh',
           lastAnalyzed: 'Last analyzed',
           signalsDetail: 'Signals & detail',
+          dataInputs: 'Data used by AI',
           decisionFocus: 'Decision focus',
           whyNow: 'Why now',
           whatToDo: 'What to do',


### PR DESCRIPTION
## Summary

- Show the executable suggested order price as the decision-strip entry when it differs from the close-based trade plan entry.
- Keep the close visible as secondary context in the same metric cell.
- Recompute 1R, percent-to-target, and R/R from the displayed planned entry so the strip matches the order ticket.

## Root cause

The order ticket already used `suggestedOrderPrice` for pullback limit entries, but the decision strip always used the close-based trade plan entry. That made pullback candidates show one entry at the top and a lower executable entry in the ticket.

## Validation

- `npm test -- AnalysisDecisionStrip.test.tsx --run`
- `npm run typecheck`
- `npm run lint`
- `npm run build`