### PR TITLE
Surface data source quality and confidence

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,15 @@ OPENAI_API_KEY=your_openai_api_key
 # SEC_CONTACT_EMAIL=your@email.com
 
 # ---------------------------------------------------------------------------
+# Paid data providers — roadmap only, not active runtime providers yet
+#
+# These keys are documented for future EODHD / Twelve Data implementation work.
+# Setting them today does not enable fundamentals, calendar, or news providers.
+# ---------------------------------------------------------------------------
+# EODHD_API_KEY=
+# TWELVE_DATA_API_KEY=
+
+# ---------------------------------------------------------------------------
 # LangSmith tracing — optional, for debugging LLM calls
 # ---------------------------------------------------------------------------
 # LANGSMITH_TRACING=true

--- a/api/models/calendar.py
+++ b/api/models/calendar.py
@@ -1,7 +1,7 @@
 # api/models/calendar.py
 from __future__ import annotations
 from typing import Literal, Optional
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class CalendarEvent(BaseModel):
@@ -10,6 +10,9 @@ class CalendarEvent(BaseModel):
     event_type: Literal["earnings", "economic", "ipo", "dividend"]
     title: str
     source_tag: Literal["position", "screener", "economic", "ipo"]
+    provider: Optional[str] = None
+    confidence: float = Field(default=0.5, ge=0.0, le=1.0)
+    source_url: Optional[str] = None
     eps_estimate: Optional[float] = None
     eps_actual: Optional[float] = None
 

--- a/api/models/screener.py
+++ b/api/models/screener.py
@@ -1,7 +1,7 @@
 """Screener models."""
 from __future__ import annotations
 
-from typing import Literal, Optional
+from typing import Any, Literal, Optional
 from pydantic import BaseModel, Field, field_validator
 from api.models.recommendation import Recommendation
 from swing_screener.fundamentals.models import FundamentalSnapshot
@@ -55,6 +55,7 @@ class ScreenerCandidate(BaseModel):
     fundamentals_summary: Optional[str] = None
     fundamentals_asof: Optional[str] = None
     intelligence_asof: Optional[str] = None
+    data_source_summary: dict[str, Any] = Field(default_factory=dict)
     # Plan + recommendation fields (education-first)
     signal: Optional[str] = None
     entry: Optional[float] = None

--- a/api/services/calendar_service.py
+++ b/api/services/calendar_service.py
@@ -15,6 +15,11 @@ from api.repositories.positions_repo import PositionsRepository
 
 logger = logging.getLogger(__name__)
 
+FINNHUB_EARNINGS_URL = "https://finnhub.io/api/v1/calendar/earnings"
+FINNHUB_ECONOMIC_URL = "https://finnhub.io/api/v1/calendar/economic"
+FINNHUB_IPO_URL = "https://finnhub.io/api/v1/calendar/ipo"
+FINNHUB_DIVIDEND_URL = "https://finnhub.io/api/v1/calendar/dividend"
+
 
 class CalendarService:
     def __init__(
@@ -102,6 +107,9 @@ class CalendarService:
                             event_type="earnings",
                             title=f"{ticker} Earnings",
                             source_tag=source_tag,
+                            provider="finnhub",
+                            confidence=0.85,
+                            source_url=FINNHUB_EARNINGS_URL,
                             eps_estimate=eps_estimate,
                             eps_actual=eps_actual,
                         ))
@@ -119,7 +127,7 @@ class CalendarService:
         end: dt.date,
     ) -> Optional[tuple[dt.date, Optional[float], Optional[float]]]:
         resp = httpx.get(
-            "https://finnhub.io/api/v1/calendar/earnings",
+            FINNHUB_EARNINGS_URL,
             params={
                 "symbol": ticker,
                 "from": start.isoformat(),
@@ -166,6 +174,9 @@ class CalendarService:
                             event_type="earnings",
                             title=f"{ticker} Earnings",
                             source_tag=source_tag,
+                            provider="yfinance",
+                            confidence=0.55,
+                            source_url=f"https://finance.yahoo.com/quote/{ticker}/calendar",
                         ))
                 except Exception as exc:
                     logger.debug("Earnings fetch failed for %s: %s", ticker, exc)
@@ -191,7 +202,7 @@ class CalendarService:
             return []
         try:
             resp = httpx.get(
-                "https://finnhub.io/api/v1/calendar/economic",
+                FINNHUB_ECONOMIC_URL,
                 params={
                     "from": start.isoformat(),
                     "to": end.isoformat(),
@@ -208,6 +219,9 @@ class CalendarService:
                     event_type="economic",
                     title=item.get("event", "Economic event"),
                     source_tag="economic",
+                    provider="finnhub",
+                    confidence=0.8,
+                    source_url=FINNHUB_ECONOMIC_URL,
                 )
                 for item in items
                 if item.get("time") and item.get("impact") == "high"
@@ -221,7 +235,7 @@ class CalendarService:
             return []
         try:
             resp = httpx.get(
-                "https://finnhub.io/api/v1/calendar/ipo",
+                FINNHUB_IPO_URL,
                 params={
                     "from": start.isoformat(),
                     "to": end.isoformat(),
@@ -238,6 +252,9 @@ class CalendarService:
                     event_type="ipo",
                     title=f"{item.get('name', item.get('symbol', 'IPO'))} IPO",
                     source_tag="ipo",
+                    provider="finnhub",
+                    confidence=0.8,
+                    source_url=FINNHUB_IPO_URL,
                 )
                 for item in items
                 if item.get("date") and item.get("status") in {"priced", "filed"}
@@ -275,7 +292,7 @@ class CalendarService:
         end: dt.date,
     ) -> list[CalendarEvent]:
         resp = httpx.get(
-            "https://finnhub.io/api/v1/calendar/dividend",
+            FINNHUB_DIVIDEND_URL,
             params={
                 "symbol": ticker,
                 "from": start.isoformat(),
@@ -293,6 +310,9 @@ class CalendarService:
                 event_type="dividend",
                 title=f"{ticker} Dividend",
                 source_tag="position",
+                provider="finnhub",
+                confidence=0.8,
+                source_url=FINNHUB_DIVIDEND_URL,
             )
             for item in items
             if item.get("date")

--- a/api/services/screener_service.py
+++ b/api/services/screener_service.py
@@ -754,6 +754,7 @@ class ScreenerService:
                     f"Universe filters reduced the working list from {len(tickers)} to {len(filtered_tickers)} tickers."
                 )
             tickers = filtered_tickers
+            market_health = self._provider.get_source_health().to_dict()
 
             screening_tickers = [ticker for ticker in tickers if ticker != benchmark]
             active_currencies = _resolve_screening_currencies(
@@ -1021,6 +1022,7 @@ class ScreenerService:
                         avg_daily_volume_eur=_safe_optional_float(row.get("avg_daily_volume_eur")),
                         symbol_change_pct=symbol_change_pct,
                         benchmark_outperformance_pct=benchmark_outperformance_pct,
+                        data_source_summary={"market_data": market_health},
                         signal=str(signal) if not _is_na_scalar(signal) else None,
                         entry=rec_risk.entry,
                         stop=rec_risk.stop if stop_val is not None else None,
@@ -1150,4 +1152,3 @@ class ScreenerService:
             created_at=job.created_at,
             updated_at=job.updated_at,
         )
-

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -389,3 +389,34 @@ low_level:
       rate_limit_window_seconds: 60
       max_retries: 3
       retry_delay_base_seconds: 1.0
+
+# ---------------------------------------------------------------------------
+# Paid provider roadmap only. These entries document intended future gates and
+# must not be treated as active runtime providers until provider implementations
+# and validation tests exist.
+# ---------------------------------------------------------------------------
+data_provider_roadmap:
+  eodhd:
+    status: planned
+    runtime_enabled: false
+    activation_gates:
+      - provider_module_implemented
+      - config_validation_added
+      - contract_tests_passing
+      - explicit_user_config
+    domains:
+      - eu_fundamentals
+      - global_calendar
+      - financial_news
+  twelve_data:
+    status: planned
+    runtime_enabled: false
+    activation_gates:
+      - provider_module_implemented
+      - config_validation_added
+      - contract_tests_passing
+      - explicit_user_config
+    domains:
+      - global_fundamentals
+      - earnings_calendar
+      - dividends_calendar

--- a/docs/engineering/DATA_SOURCE_AUDIT_AND_PROVIDER_STRATEGY.md
+++ b/docs/engineering/DATA_SOURCE_AUDIT_AND_PROVIDER_STRATEGY.md
@@ -1,6 +1,6 @@
 # Data Source Audit And Provider Strategy
 
-Last updated: 2026-03-20
+Last updated: 2026-05-29
 
 ## Scope
 
@@ -20,6 +20,13 @@ Last updated: 2026-03-20
 | **Tier 3** — Best Quality / Production | Not started | — |
 
 ---
+
+## Current Code Reality As Of 2026-05-29
+
+- Default fundamentals are `sec_edgar -> yfinance` unless the DeGiro integration modules are installed.
+- Explicit `degiro` config is still accepted because the optional provider exists behind lazy imports and credential checks.
+- `EODHD` and `Twelve Data` are roadmap providers only; no runtime config should pretend they are available.
+- Paid providers must land behind provider modules, config validation, contract tests, and explicit user config before contributing to ranking.
 
 ---
 

--- a/docs/superpowers/plans/2026-05-28-data-source-improvement.md
+++ b/docs/superpowers/plans/2026-05-28-data-source-improvement.md
@@ -1,0 +1,958 @@
+# Data Source Improvement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Improve symbol prediction and evaluation by surfacing data provenance, tightening provider reliability, enriching fundamentals/events, and feeding the improved signals into combined ranking.
+
+**Architecture:** Add a lightweight provider capability and provenance layer that all market, fundamentals, calendar, and intelligence paths can report into. Improve data in small increments: first make source quality visible, then add richer fields, then wire only validated fields into scoring.
+
+**Tech Stack:** Python 3, FastAPI, Pydantic, pytest, existing `swing_screener` provider modules, React/Vite/TypeScript for UI display.
+
+---
+
+## File Structure
+
+- Create `src/swing_screener/data/source_health.py`: shared data-source health/provenance models and helpers.
+- Modify `src/swing_screener/data/providers/base.py`: expose optional provider capability metadata.
+- Modify `src/swing_screener/data/providers/yfinance_provider.py`, `stooq_provider.py`, `alpaca_provider.py`: return explicit source health metadata.
+- Modify `src/swing_screener/fundamentals/config.py`: remove broken DeGiro default unless integration imports are available.
+- Modify `src/swing_screener/fundamentals/providers/sec_edgar.py`: add richer filing/fundamental fields.
+- Modify `src/swing_screener/fundamentals/models.py`: add source health and richer metric fields.
+- Modify `src/swing_screener/fundamentals/scoring.py`: score only validated new fields and expose data confidence.
+- Modify `api/models/screener.py`: surface data source summaries per candidate.
+- Modify `api/services/screener_service.py`: attach source summaries and use new confidence modifiers.
+- Modify `api/services/calendar_service.py`: add provider/source metadata to calendar events and capture event confidence.
+- Modify `api/models/calendar.py`: expose calendar provider and confidence fields.
+- Modify `web-ui/src/features/screener/types.ts`: mirror new candidate fields.
+- Modify `web-ui/src/components/domain/workspace/KeyMetrics.tsx` or `AnalysisDecisionStrip.tsx`: add compact data-source visibility.
+- Test files:
+  - `tests/data/test_source_health.py`
+  - `tests/test_tier1_stack_smoke.py`
+  - `tests/test_fundamentals_scoring.py`
+  - `tests/api/test_screener_endpoints.py`
+  - `tests/test_calendar_service.py`
+  - `web-ui/src/features/screener/types.test.ts`
+
+---
+
+### Task 1: Add Shared Source Health And Provenance Models
+
+**Files:**
+- Create: `src/swing_screener/data/source_health.py`
+- Modify: `src/swing_screener/data/providers/base.py`
+- Test: `tests/data/test_source_health.py`
+
+- [ ] **Step 1: Write failing source health tests**
+
+```python
+# tests/data/test_source_health.py
+from swing_screener.data.source_health import (
+    DataSourceHealth,
+    DataSourceProvenance,
+    merge_source_health,
+)
+
+
+def test_source_health_defaults_are_conservative():
+    health = DataSourceHealth(provider="yfinance", domain="market_data")
+
+    assert health.status == "unknown"
+    assert health.quality_score == 0.5
+    assert health.delay_policy == "unknown"
+    assert health.warnings == []
+
+
+def test_provenance_serializes_provider_domain_and_asof():
+    provenance = DataSourceProvenance(
+        provider="sec_edgar",
+        domain="fundamentals",
+        asof_date="2026-05-28",
+        fetched_at="2026-05-28T12:00:00+00:00",
+        fields=["revenue_growth_yoy", "operating_margin"],
+    )
+
+    payload = provenance.to_dict()
+
+    assert payload["provider"] == "sec_edgar"
+    assert payload["domain"] == "fundamentals"
+    assert payload["fields"] == ["revenue_growth_yoy", "operating_margin"]
+
+
+def test_merge_source_health_penalizes_warnings_and_failures():
+    merged = merge_source_health(
+        [
+            DataSourceHealth(provider="sec_edgar", domain="fundamentals", status="ok", quality_score=0.9),
+            DataSourceHealth(provider="yfinance", domain="metadata", status="degraded", quality_score=0.6, warnings=["unofficial"]),
+        ]
+    )
+
+    assert merged.provider == "combined"
+    assert merged.domain == "aggregate"
+    assert 0.6 <= merged.quality_score < 0.9
+    assert merged.status == "degraded"
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `pytest tests/data/test_source_health.py -v`
+
+Expected: FAIL with `ModuleNotFoundError: No module named 'swing_screener.data.source_health'`.
+
+- [ ] **Step 3: Implement source health models**
+
+```python
+# src/swing_screener/data/source_health.py
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Literal
+
+SourceDomain = Literal["market_data", "metadata", "fundamentals", "calendar", "intelligence", "aggregate"]
+SourceStatus = Literal["ok", "degraded", "failed", "unknown"]
+
+
+@dataclass(frozen=True)
+class DataSourceHealth:
+    provider: str
+    domain: SourceDomain
+    status: SourceStatus = "unknown"
+    quality_score: float = 0.5
+    delay_policy: str = "unknown"
+    warnings: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        payload = asdict(self)
+        payload["quality_score"] = max(0.0, min(1.0, float(self.quality_score)))
+        return payload
+
+
+@dataclass(frozen=True)
+class DataSourceProvenance:
+    provider: str
+    domain: SourceDomain
+    asof_date: str | None = None
+    fetched_at: str | None = None
+    fields: list[str] = field(default_factory=list)
+    source_url: str | None = None
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def merge_source_health(items: list[DataSourceHealth]) -> DataSourceHealth:
+    if not items:
+        return DataSourceHealth(provider="combined", domain="aggregate")
+
+    statuses = {item.status for item in items}
+    if "failed" in statuses:
+        status: SourceStatus = "failed"
+    elif "degraded" in statuses:
+        status = "degraded"
+    elif statuses == {"ok"}:
+        status = "ok"
+    else:
+        status = "unknown"
+
+    warnings: list[str] = []
+    for item in items:
+        for warning in item.warnings:
+            if warning not in warnings:
+                warnings.append(warning)
+
+    base_score = sum(max(0.0, min(1.0, float(item.quality_score))) for item in items) / len(items)
+    warning_penalty = min(0.25, 0.05 * len(warnings))
+    failure_penalty = 0.35 if status == "failed" else 0.15 if status == "degraded" else 0.0
+
+    return DataSourceHealth(
+        provider="combined",
+        domain="aggregate",
+        status=status,
+        quality_score=max(0.0, round(base_score - warning_penalty - failure_penalty, 4)),
+        warnings=warnings,
+    )
+```
+
+- [ ] **Step 4: Add optional provider health API**
+
+```python
+# src/swing_screener/data/providers/base.py
+from swing_screener.data.source_health import DataSourceHealth
+
+# Add to MarketDataProvider:
+def get_source_health(self) -> DataSourceHealth:
+    return DataSourceHealth(provider=self.get_provider_name(), domain="market_data")
+```
+
+- [ ] **Step 5: Run test**
+
+Run: `pytest tests/data/test_source_health.py -v`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/swing_screener/data/source_health.py src/swing_screener/data/providers/base.py tests/data/test_source_health.py
+git commit -m "feat: add data source health models"
+```
+
+---
+
+### Task 2: Make Market Data Provider Quality Visible
+
+**Files:**
+- Modify: `src/swing_screener/data/providers/yfinance_provider.py`
+- Modify: `src/swing_screener/data/providers/stooq_provider.py`
+- Modify: `src/swing_screener/data/providers/alpaca_provider.py`
+- Modify: `api/models/screener.py`
+- Modify: `api/services/screener_service.py`
+- Test: `tests/api/test_screener_endpoints.py`
+
+- [ ] **Step 1: Write failing API test for candidate source summaries**
+
+```python
+# tests/api/test_screener_endpoints.py
+def test_screener_response_includes_market_data_source_summary(client, monkeypatch):
+    response = client.post(
+        "/api/screener",
+        json={"tickers": ["AAPL", "MSFT"], "top": 1, "asof_date": "2026-05-01"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    if data["candidates"]:
+        source_summary = data["candidates"][0]["data_source_summary"]
+        assert source_summary["market_data"]["provider"]
+        assert source_summary["market_data"]["status"] in {"ok", "degraded", "failed", "unknown"}
+        assert 0 <= source_summary["market_data"]["quality_score"] <= 1
+```
+
+- [ ] **Step 2: Run targeted test to verify failure**
+
+Run: `pytest tests/api/test_screener_endpoints.py::test_screener_response_includes_market_data_source_summary -v`
+
+Expected: FAIL because `data_source_summary` is missing.
+
+- [ ] **Step 3: Add provider-specific health**
+
+```python
+# yfinance provider
+def get_source_health(self) -> DataSourceHealth:
+    warnings = ["unofficial_provider"]
+    return DataSourceHealth(
+        provider="yfinance",
+        domain="market_data",
+        status="ok",
+        quality_score=0.65,
+        delay_policy="delayed_or_eod",
+        warnings=warnings,
+    )
+
+# stooq provider
+def get_source_health(self) -> DataSourceHealth:
+    return DataSourceHealth(
+        provider="stooq",
+        domain="market_data",
+        status="ok",
+        quality_score=0.6,
+        delay_policy="daily_eod",
+        warnings=["daily_only"],
+    )
+
+# alpaca provider
+def get_source_health(self) -> DataSourceHealth:
+    return DataSourceHealth(
+        provider=self.get_provider_name(),
+        domain="market_data",
+        status="ok",
+        quality_score=0.85 if not self.paper else 0.75,
+        delay_policy="provider_plan_dependent",
+        warnings=[] if not self.paper else ["paper_or_basic_plan_may_be_limited"],
+    )
+```
+
+- [ ] **Step 4: Extend screener model**
+
+```python
+# api/models/screener.py
+from typing import Any
+
+# Add this field to the existing ScreenerCandidate class, near the other source/asof fields.
+data_source_summary: dict[str, Any] = Field(default_factory=dict)
+```
+
+- [ ] **Step 5: Attach market data source summary in screener service**
+
+```python
+# api/services/screener_service.py
+market_health = self._provider.get_source_health().to_dict()
+
+# When building each ScreenerCandidate:
+data_source_summary={
+    "market_data": market_health,
+}
+```
+
+- [ ] **Step 6: Run targeted test**
+
+Run: `pytest tests/api/test_screener_endpoints.py::test_screener_response_includes_market_data_source_summary -v`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/swing_screener/data/providers api/models/screener.py api/services/screener_service.py tests/api/test_screener_endpoints.py
+git commit -m "feat: surface market data source quality"
+```
+
+---
+
+### Task 3: Fix Fundamentals Provider Chain And Add Data Confidence
+
+**Files:**
+- Modify: `src/swing_screener/fundamentals/config.py`
+- Modify: `src/swing_screener/fundamentals/service.py`
+- Modify: `src/swing_screener/fundamentals/models.py`
+- Modify: `src/swing_screener/fundamentals/scoring.py`
+- Test: `tests/test_fundamentals_service.py`
+- Test: `tests/test_fundamentals_scoring.py`
+
+- [ ] **Step 1: Write failing test for DeGiro default behavior**
+
+```python
+# tests/test_fundamentals_service.py
+from swing_screener.fundamentals.config import build_fundamentals_config
+
+
+def test_default_fundamentals_provider_chain_excludes_unavailable_degiro():
+    cfg = build_fundamentals_config({})
+
+    assert cfg.providers == ("sec_edgar", "yfinance")
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `pytest tests/test_fundamentals_service.py::test_default_fundamentals_provider_chain_excludes_unavailable_degiro -v`
+
+Expected: FAIL while default chain still includes `degiro`.
+
+- [ ] **Step 3: Make DeGiro opt-in unless integration exists**
+
+```python
+# src/swing_screener/fundamentals/config.py
+BASE_TIER1_PROVIDERS: tuple[str, ...] = ("sec_edgar", "yfinance")
+
+
+def _degiro_available() -> bool:
+    try:
+        import swing_screener.integrations.degiro.client  # noqa: F401
+        import swing_screener.integrations.degiro.credentials  # noqa: F401
+    except ModuleNotFoundError:
+        return False
+    return True
+
+
+def default_fundamentals_providers() -> tuple[str, ...]:
+    if _degiro_available():
+        return ("sec_edgar", "degiro", "yfinance")
+    return BASE_TIER1_PROVIDERS
+
+
+TIER1_PROVIDERS: tuple[str, ...] = default_fundamentals_providers()
+```
+
+- [ ] **Step 4: Add fundamentals confidence fields**
+
+```python
+# src/swing_screener/fundamentals/models.py
+# Add these fields to FundamentalSnapshot after data_quality_flags.
+data_confidence_score: float = 0.5
+source_health: dict[str, Any] = field(default_factory=dict)
+```
+
+- [ ] **Step 5: Score fundamentals confidence**
+
+```python
+# src/swing_screener/fundamentals/scoring.py
+def _data_confidence_score(coverage_status: str, freshness_status: str, quality_status: str) -> float:
+    coverage = {"supported": 0.9, "partial": 0.6, "insufficient": 0.3, "unsupported": 0.1}.get(coverage_status, 0.3)
+    freshness = {"current": 1.0, "stale": 0.55, "unknown": 0.45}.get(freshness_status, 0.45)
+    quality = {"high": 1.0, "medium": 0.75, "low": 0.45}.get(quality_status, 0.45)
+    return round(max(0.0, min(1.0, coverage * freshness * quality)), 4)
+```
+
+Then set `data_confidence_score` on `FundamentalSnapshot` inside `build_snapshot`.
+
+- [ ] **Step 6: Add scoring test**
+
+```python
+# tests/test_fundamentals_scoring.py
+def test_snapshot_data_confidence_penalizes_stale_partial_data(sample_provider_record):
+    from dataclasses import replace
+    from swing_screener.fundamentals.config import FundamentalsConfig
+    from swing_screener.fundamentals.scoring import build_snapshot
+
+    record = replace(sample_provider_record, most_recent_quarter="2020-01-01")
+    snapshot = build_snapshot(record, FundamentalsConfig(stale_after_days=120))
+
+    assert 0 <= snapshot.data_confidence_score <= 1
+    assert snapshot.data_confidence_score < 0.8
+```
+
+- [ ] **Step 7: Run fundamentals tests**
+
+Run: `pytest tests/test_fundamentals_service.py tests/test_fundamentals_scoring.py -v`
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/swing_screener/fundamentals tests/test_fundamentals_service.py tests/test_fundamentals_scoring.py
+git commit -m "feat: add fundamentals source confidence"
+```
+
+---
+
+### Task 4: Enrich SEC EDGAR Fundamentals With Filing Metadata And More Balance Sheet Fields
+
+**Files:**
+- Modify: `src/swing_screener/fundamentals/models.py`
+- Modify: `src/swing_screener/fundamentals/providers/sec_edgar.py`
+- Modify: `src/swing_screener/fundamentals/scoring.py`
+- Test: `tests/test_sec_edgar_fundamentals_provider.py`
+
+- [ ] **Step 1: Write failing SEC provider test**
+
+```python
+# tests/test_sec_edgar_fundamentals_provider.py
+def test_sec_edgar_record_includes_balance_sheet_and_filing_metadata(mock_sec_companyfacts):
+    provider = SecEdgarFundamentalsProvider()
+    record = provider.fetch_record("AAPL")
+
+    assert record.total_assets is not None
+    assert record.total_liabilities is not None
+    assert record.cash_and_equivalents is not None
+    assert record.latest_filing_form in {"10-Q", "10-K", "10-Q/A", "10-K/A"}
+    assert record.latest_filing_date is not None
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `pytest tests/test_sec_edgar_fundamentals_provider.py::test_sec_edgar_record_includes_balance_sheet_and_filing_metadata -v`
+
+Expected: FAIL because fields do not exist.
+
+- [ ] **Step 3: Add model fields**
+
+```python
+# src/swing_screener/fundamentals/models.py
+# Add these fields to ProviderFundamentalsRecord after total_equity.
+total_assets: float | None = None
+total_liabilities: float | None = None
+cash_and_equivalents: float | None = None
+latest_filing_form: str | None = None
+latest_filing_date: str | None = None
+
+# Add these fields to FundamentalSnapshot after total_equity.
+total_assets: float | None = None
+total_liabilities: float | None = None
+cash_and_equivalents: float | None = None
+latest_filing_form: str | None = None
+latest_filing_date: str | None = None
+```
+
+- [ ] **Step 4: Extract fields from SEC facts**
+
+```python
+# src/swing_screener/fundamentals/providers/sec_edgar.py
+total_assets, total_assets_period, total_assets_source = _latest_instant_value(
+    payload,
+    taxonomies=("us-gaap",),
+    concepts=("Assets",),
+    unit_candidates=("USD",),
+)
+total_liabilities, total_liabilities_period, total_liabilities_source = _latest_instant_value(
+    payload,
+    taxonomies=("us-gaap",),
+    concepts=("Liabilities",),
+    unit_candidates=("USD",),
+)
+cash_and_equivalents, cash_period, cash_source = _latest_instant_value(
+    payload,
+    taxonomies=("us-gaap",),
+    concepts=("CashAndCashEquivalentsAtCarryingValue", "CashCashEquivalentsRestrictedCashAndRestrictedCashEquivalents"),
+    unit_candidates=("USD",),
+)
+latest_filing_form, latest_filing_date = _latest_filing_metadata(payload)
+```
+
+Add helper:
+
+```python
+def _latest_filing_metadata(payload: dict[str, Any]) -> tuple[str | None, str | None]:
+    latest: tuple[str, str] | None = None
+    facts = payload.get("facts")
+    if not isinstance(facts, dict):
+        return (None, None)
+    for taxonomy in facts.values():
+        if not isinstance(taxonomy, dict):
+            continue
+        for node in taxonomy.values():
+            if not isinstance(node, dict):
+                continue
+            for items in (node.get("units") or {}).values():
+                if not isinstance(items, list):
+                    continue
+                for item in items:
+                    if not isinstance(item, dict):
+                        continue
+                    form = str(item.get("form", "")).strip()
+                    filed = str(item.get("filed", "")).strip()
+                    if form in _ALLOWED_FORMS and filed and (latest is None or filed > latest[1]):
+                        latest = (form, filed)
+    return latest if latest else (None, None)
+```
+
+- [ ] **Step 5: Pass fields through snapshot**
+
+Update `build_snapshot` to copy the new fields from `resolved_record`.
+
+- [ ] **Step 6: Run SEC tests**
+
+Run: `pytest tests/test_sec_edgar_fundamentals_provider.py tests/test_fundamentals_scoring.py -v`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/swing_screener/fundamentals tests/test_sec_edgar_fundamentals_provider.py
+git commit -m "feat: enrich SEC fundamentals metadata"
+```
+
+---
+
+### Task 5: Add Calendar Event Provenance And Confidence
+
+**Files:**
+- Modify: `api/models/calendar.py`
+- Modify: `api/services/calendar_service.py`
+- Test: `tests/test_calendar_service.py`
+
+- [ ] **Step 1: Write failing calendar test**
+
+```python
+# tests/test_calendar_service.py
+def test_calendar_events_include_provider_and_confidence(calendar_service_with_finnhub_key):
+    events = calendar_service_with_finnhub_key.get_events(days_ahead=30)
+
+    for event in events:
+        assert event.provider in {"finnhub", "yfinance"}
+        assert 0 <= event.confidence <= 1
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `pytest tests/test_calendar_service.py::test_calendar_events_include_provider_and_confidence -v`
+
+Expected: FAIL because fields are missing.
+
+- [ ] **Step 3: Extend calendar event model**
+
+```python
+# api/models/calendar.py
+# Add these fields to CalendarEvent after source_tag.
+provider: Optional[str] = None
+confidence: float = 0.5
+source_url: Optional[str] = None
+```
+
+- [ ] **Step 4: Populate provider metadata**
+
+```python
+# Finnhub earnings event
+CalendarEvent(
+    date=earnings_date.isoformat(),
+    ticker=ticker,
+    event_type="earnings",
+    title=f"{ticker} Earnings",
+    source_tag=source_tag,
+    eps_estimate=eps_estimate,
+    eps_actual=eps_actual,
+    provider="finnhub",
+    confidence=0.85,
+    source_url="https://finnhub.io/api/v1/calendar/earnings",
+)
+
+# yfinance fallback event
+CalendarEvent(
+    date=earnings_date.isoformat(),
+    ticker=ticker,
+    event_type="earnings",
+    title=f"{ticker} Earnings",
+    source_tag=source_tag,
+    provider="yfinance",
+    confidence=0.55,
+)
+```
+
+- [ ] **Step 5: Run calendar tests**
+
+Run: `pytest tests/test_calendar_service.py -v`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add api/models/calendar.py api/services/calendar_service.py tests/test_calendar_service.py
+git commit -m "feat: add calendar event provenance"
+```
+
+---
+
+### Task 6: Wire Data Confidence Into Combined Ranking
+
+**Files:**
+- Modify: `src/swing_screener/recommendation/priority.py`
+- Modify: `api/services/screener_service.py`
+- Test: `tests/test_combined_priority.py`
+
+- [ ] **Step 1: Write failing ranking test**
+
+```python
+# tests/test_combined_priority.py
+def test_combined_priority_penalizes_low_fundamentals_data_confidence(candidate_factory, fundamentals_snapshot_factory):
+    high_conf = candidate_factory(
+        ticker="HIGH",
+        confidence=80,
+        fundamentals_snapshot=fundamentals_snapshot_factory(
+            business_quality_score=0.8,
+            valuation_attractiveness=0.7,
+            data_confidence_score=0.95,
+        ),
+    )
+    low_conf = candidate_factory(
+        ticker="LOW",
+        confidence=80,
+        fundamentals_snapshot=fundamentals_snapshot_factory(
+            business_quality_score=0.8,
+            valuation_attractiveness=0.7,
+            data_confidence_score=0.25,
+        ),
+    )
+
+    ranked = compute_combined_priority([low_conf, high_conf])
+
+    assert ranked[0].ticker == "HIGH"
+    assert ranked[0].combined_priority_score > ranked[1].combined_priority_score
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `pytest tests/test_combined_priority.py::test_combined_priority_penalizes_low_fundamentals_data_confidence -v`
+
+Expected: FAIL because confidence is not considered.
+
+- [ ] **Step 3: Apply data confidence multiplier**
+
+```python
+# src/swing_screener/recommendation/priority.py
+def _fundamentals_score(candidate: ScreenerCandidate) -> float:
+    ds = candidate.decision_summary
+    score = _label_score(
+        _FUNDAMENTALS_SCORE,
+        getattr(ds, "fundamentals_label", None) if ds else None,
+    )
+    snapshot = getattr(candidate, "fundamentals_snapshot", None)
+    if snapshot is None:
+        return score
+
+    business_quality = _safe_float(getattr(snapshot, "business_quality_score", None))
+    if business_quality is not None:
+        score = business_quality
+
+    freshness_penalty = _safe_float(getattr(snapshot, "freshness_penalty", None)) or 0.0
+    coverage_penalty = _safe_float(getattr(snapshot, "coverage_penalty", None)) or 0.0
+    penalty_multiplier = max(0.0, 1.0 - freshness_penalty - (coverage_penalty * 0.5))
+    data_confidence = _safe_float(getattr(snapshot, "data_confidence_score", None))
+    if data_confidence is not None:
+        score *= max(0.25, min(1.0, data_confidence))
+    return max(0.0, score * penalty_multiplier)
+
+
+def _valuation_score(candidate: ScreenerCandidate) -> float:
+    ds = candidate.decision_summary
+    score = _label_score(
+        _VALUATION_SCORE,
+        getattr(ds, "valuation_label", None) if ds else None,
+    )
+    snapshot = getattr(candidate, "fundamentals_snapshot", None)
+    if snapshot is None:
+        return score
+
+    valuation = _safe_float(getattr(snapshot, "valuation_attractiveness", None))
+    score = valuation if valuation is not None else score
+    data_confidence = _safe_float(getattr(snapshot, "data_confidence_score", None))
+    if data_confidence is not None:
+        return score * max(0.4, min(1.0, data_confidence))
+    return score
+```
+
+- [ ] **Step 4: Run ranking tests**
+
+Run: `pytest tests/test_combined_priority.py -v`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/swing_screener/recommendation/priority.py tests/test_combined_priority.py
+git commit -m "feat: weight ranking by data confidence"
+```
+
+---
+
+### Task 7: Surface Data Sources In The UI
+
+**Files:**
+- Modify: `web-ui/src/features/screener/types.ts`
+- Modify: `web-ui/src/features/screener/types.test.ts`
+- Modify: `web-ui/src/components/domain/workspace/KeyMetrics.tsx`
+- Modify: `web-ui/src/components/domain/workspace/AnalysisDecisionStrip.tsx`
+- Test: `web-ui/src/components/domain/workspace/AnalysisDecisionStrip.test.tsx`
+
+- [ ] **Step 1: Write failing type test**
+
+```ts
+// web-ui/src/features/screener/types.test.ts
+it('maps data source summary from screener candidate payload', () => {
+  const candidate = mapScreenerCandidate({
+    ticker: 'AAPL',
+    close: 100,
+    sma_20: 95,
+    sma_50: 90,
+    sma_200: 80,
+    atr: 2,
+    momentum_6m: 10,
+    momentum_12m: 20,
+    rel_strength: 5,
+    score: 0.8,
+    confidence: 75,
+    rank: 1,
+    data_source_summary: {
+      market_data: { provider: 'yfinance', status: 'ok', quality_score: 0.65 },
+      fundamentals: { provider: 'sec_edgar', status: 'ok', quality_score: 0.9 },
+    },
+  });
+
+  expect(candidate.dataSourceSummary.marketData.provider).toBe('yfinance');
+  expect(candidate.dataSourceSummary.fundamentals.provider).toBe('sec_edgar');
+});
+```
+
+- [ ] **Step 2: Run UI test to verify failure**
+
+Run: `cd web-ui && npm test -- src/features/screener/types.test.ts --run`
+
+Expected: FAIL because mapping field is missing.
+
+- [ ] **Step 3: Add TypeScript types and mapping**
+
+```ts
+// web-ui/src/features/screener/types.ts
+export interface DataSourceHealth {
+  provider: string;
+  status: 'ok' | 'degraded' | 'failed' | 'unknown';
+  qualityScore: number;
+  delayPolicy?: string;
+  warnings: string[];
+}
+
+export interface CandidateDataSourceSummary {
+  marketData?: DataSourceHealth;
+  fundamentals?: DataSourceHealth;
+  calendar?: DataSourceHealth;
+  intelligence?: DataSourceHealth;
+}
+```
+
+Add this helper next to the existing candidate mapping helpers:
+
+```ts
+const mapDataSourceHealth = (value: unknown): DataSourceHealth | undefined => {
+  if (!value || typeof value !== 'object') return undefined;
+  const payload = value as Record<string, unknown>;
+  return {
+    provider: String(payload.provider ?? ''),
+    status: ['ok', 'degraded', 'failed', 'unknown'].includes(String(payload.status))
+      ? (payload.status as DataSourceHealth['status'])
+      : 'unknown',
+    qualityScore: Number(payload.quality_score ?? payload.qualityScore ?? 0.5),
+    delayPolicy: payload.delay_policy ? String(payload.delay_policy) : undefined,
+    warnings: Array.isArray(payload.warnings) ? payload.warnings.map(String) : [],
+  };
+};
+
+const mapDataSourceSummary = (value: unknown): CandidateDataSourceSummary => {
+  if (!value || typeof value !== 'object') return {};
+  const payload = value as Record<string, unknown>;
+  return {
+    marketData: mapDataSourceHealth(payload.market_data ?? payload.marketData),
+    fundamentals: mapDataSourceHealth(payload.fundamentals),
+    calendar: mapDataSourceHealth(payload.calendar),
+    intelligence: mapDataSourceHealth(payload.intelligence),
+  };
+};
+```
+
+- [ ] **Step 4: Render compact source chips**
+
+```tsx
+// web-ui/src/components/domain/workspace/AnalysisDecisionStrip.tsx
+const sourceItems = [
+  ['Market', candidate.dataSourceSummary.marketData],
+  ['Fundamentals', candidate.dataSourceSummary.fundamentals],
+  ['Events', candidate.dataSourceSummary.calendar],
+].filter(([, value]) => Boolean(value));
+```
+
+Render the chips inside the existing decision strip metrics area:
+
+```tsx
+{sourceItems.map(([label, source]) => (
+  <Badge key={label} variant={source?.status === 'ok' ? 'success' : 'warning'}>
+    {label}: {source?.provider || 'unknown'} ({source?.status || 'unknown'})
+  </Badge>
+))}
+```
+
+- [ ] **Step 5: Run UI tests**
+
+Run: `cd web-ui && npm test -- src/features/screener/types.test.ts src/components/domain/workspace/AnalysisDecisionStrip.test.tsx --run`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web-ui/src/features/screener/types.ts web-ui/src/features/screener/types.test.ts web-ui/src/components/domain/workspace/AnalysisDecisionStrip.tsx web-ui/src/components/domain/workspace/AnalysisDecisionStrip.test.tsx
+git commit -m "feat: surface candidate data sources"
+```
+
+---
+
+### Task 8: Add Provider Roadmap Switches For EODHD/Twelve Data Without Enabling By Default
+
+**Files:**
+- Modify: `docs/engineering/DATA_SOURCE_AUDIT_AND_PROVIDER_STRATEGY.md`
+- Modify: `config/defaults.yaml`
+- Modify: `.env.example`
+- Create: `src/swing_screener/fundamentals/providers/vendor_placeholder.py`
+- Test: `tests/test_fundamentals_service.py`
+
+- [ ] **Step 1: Write provider config validation test**
+
+```python
+# tests/test_fundamentals_service.py
+def test_paid_vendor_provider_names_are_rejected_until_implemented():
+    from swing_screener.fundamentals.config import build_fundamentals_config
+
+    cfg = build_fundamentals_config({"providers": ["eodhd", "sec_edgar"]})
+
+    assert cfg.providers == ("sec_edgar",)
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `pytest tests/test_fundamentals_service.py::test_paid_vendor_provider_names_are_rejected_until_implemented -v`
+
+Expected: PASS after current validation keeps unsupported providers out.
+
+- [ ] **Step 3: Document future provider config without activating it**
+
+```yaml
+# config/defaults.yaml
+data_provider_roadmap:
+  eodhd:
+    status: planned
+    domains:
+      - eu_fundamentals
+      - global_calendar
+      - financial_news
+  twelve_data:
+    status: planned
+    domains:
+      - global_fundamentals
+      - earnings_calendar
+      - dividends_calendar
+```
+
+- [ ] **Step 4: Add env documentation**
+
+```bash
+# .env.example
+# EODHD_API_KEY=
+# TWELVE_DATA_API_KEY=
+```
+
+- [ ] **Step 5: Update engineering audit**
+
+Add a current-state correction:
+
+```markdown
+## Current Code Reality As Of 2026-05-28
+
+- Default fundamentals should be `sec_edgar -> yfinance` unless DeGiro integration modules are installed.
+- EODHD/Twelve Data are roadmap providers only; no runtime code should pretend they are available.
+- Paid providers must land behind tests and explicit config before contributing to ranking.
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/engineering/DATA_SOURCE_AUDIT_AND_PROVIDER_STRATEGY.md config/defaults.yaml .env.example tests/test_fundamentals_service.py
+git commit -m "docs: define paid data provider roadmap"
+```
+
+---
+
+## Execution Order
+
+1. Task 1 first: all later work depends on shared health/provenance types.
+2. Task 2 next: market data is the most-used path and simplest to surface.
+3. Task 3 before Task 4: fix the provider chain before adding richer fundamentals.
+4. Task 4 then Task 6: richer fundamentals should exist before scoring changes depend on them.
+5. Task 5 can run in parallel with Task 4 after Task 1.
+6. Task 7 after Tasks 2, 3, and 5: UI needs stable API fields.
+7. Task 8 last: documentation and config roadmap should reflect implemented behavior.
+
+## Verification
+
+Run backend targeted tests:
+
+```bash
+pytest tests/data/test_source_health.py tests/test_fundamentals_service.py tests/test_fundamentals_scoring.py tests/test_sec_edgar_fundamentals_provider.py tests/test_calendar_service.py tests/test_combined_priority.py tests/api/test_screener_endpoints.py -v
+```
+
+Run frontend targeted tests:
+
+```bash
+cd web-ui && npm test -- src/features/screener/types.test.ts src/components/domain/workspace/AnalysisDecisionStrip.test.tsx --run
+```
+
+Run smoke test:
+
+```bash
+pytest tests/test_tier1_stack_smoke.py -v
+```
+
+## Self-Review Notes
+
+- The plan starts with source visibility before adding vendors, because invisible source quality makes prediction regressions hard to debug.
+- The plan does not implement paid EODHD/Twelve Data providers yet. It adds a clean roadmap gate so runtime behavior stays honest.
+- DeGiro is treated as opt-in until its integration package exists in this tree.
+- Combined ranking only consumes data-confidence fields after they are tested and surfaced.

--- a/src/swing_screener/data/providers/alpaca_provider.py
+++ b/src/swing_screener/data/providers/alpaca_provider.py
@@ -13,6 +13,7 @@ from alpaca.data.requests import StockBarsRequest
 from alpaca.data.timeframe import TimeFrame
 
 from .base import MarketDataProvider
+from swing_screener.data.source_health import DataSourceHealth
 
 
 class AlpacaDataProvider(MarketDataProvider):
@@ -65,6 +66,16 @@ class AlpacaDataProvider(MarketDataProvider):
         # Create cache directory
         if self.use_cache:
             self.cache_dir.mkdir(parents=True, exist_ok=True)
+
+    def get_source_health(self) -> DataSourceHealth:
+        return DataSourceHealth(
+            provider=self.get_provider_name(),
+            domain="market_data",
+            status="ok",
+            quality_score=0.75 if self.paper else 0.85,
+            delay_policy="provider_plan_dependent",
+            warnings=["paper_or_basic_plan_may_be_limited"] if self.paper else [],
+        )
     
     def _wait_for_rate_limit(self):
         """Enforce rate limiting (200 requests/minute)."""

--- a/src/swing_screener/data/providers/base.py
+++ b/src/swing_screener/data/providers/base.py
@@ -5,6 +5,8 @@ from abc import ABC, abstractmethod
 from typing import Optional
 import pandas as pd
 
+from swing_screener.data.source_health import DataSourceHealth
+
 
 class MarketDataProvider(ABC):
     """
@@ -115,3 +117,7 @@ class MarketDataProvider(ABC):
             Provider name (e.g., "yfinance", "alpaca", "ib")
         """
         pass
+
+    def get_source_health(self) -> DataSourceHealth:
+        """Return conservative source health metadata for this provider."""
+        return DataSourceHealth(provider=self.get_provider_name(), domain="market_data")

--- a/src/swing_screener/data/providers/stooq_provider.py
+++ b/src/swing_screener/data/providers/stooq_provider.py
@@ -11,6 +11,7 @@ import httpx
 import pandas as pd
 
 from .base import MarketDataProvider
+from swing_screener.data.source_health import DataSourceHealth
 from swing_screener.utils import normalize_tickers
 
 _INSTRUMENT_MASTER_PATH = Path("data/intelligence/instrument_master.json")
@@ -93,6 +94,16 @@ class StooqDataProvider(MarketDataProvider):
         return httpx.Client(
             timeout=self._timeout_sec,
             headers={"User-Agent": "swing-screener/1.0 (stooq fallback)"},
+        )
+
+    def get_source_health(self) -> DataSourceHealth:
+        return DataSourceHealth(
+            provider="stooq",
+            domain="market_data",
+            status="ok",
+            quality_score=0.6,
+            delay_policy="daily_eod",
+            warnings=["daily_only"],
         )
 
     def _load_stooq_symbol_map(self) -> dict[str, str]:

--- a/src/swing_screener/data/providers/yfinance_provider.py
+++ b/src/swing_screener/data/providers/yfinance_provider.py
@@ -13,6 +13,7 @@ import yfinance as yf
 from .base import MarketDataProvider
 from .stooq_provider import StooqDataProvider
 from ..market_data import fetch_ticker_metadata
+from swing_screener.data.source_health import DataSourceHealth
 from swing_screener.utils import normalize_tickers
 
 logger = logging.getLogger(__name__)
@@ -84,6 +85,16 @@ class YfinanceProvider(MarketDataProvider):
             yf.set_tz_cache_location(str(tz_cache_dir))
         except Exception as exc:  # pragma: no cover - defensive, depends on host FS perms
             logger.warning("Failed to configure yfinance tz cache at %s: %s", tz_cache_dir, exc)
+
+    def get_source_health(self) -> DataSourceHealth:
+        return DataSourceHealth(
+            provider="yfinance",
+            domain="market_data",
+            status="ok",
+            quality_score=0.65,
+            delay_policy="delayed_or_eod",
+            warnings=["unofficial_provider"],
+        )
 
     def _read_cached_ohlcv(self, cache_file: Path, tickers: list[str]) -> pd.DataFrame | None:
         """

--- a/src/swing_screener/data/source_health.py
+++ b/src/swing_screener/data/source_health.py
@@ -1,0 +1,79 @@
+"""Shared data source health and provenance models."""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Literal
+
+SourceDomain = Literal[
+    "market_data",
+    "metadata",
+    "fundamentals",
+    "calendar",
+    "intelligence",
+    "aggregate",
+]
+SourceStatus = Literal["ok", "degraded", "failed", "unknown"]
+
+
+@dataclass(frozen=True)
+class DataSourceHealth:
+    provider: str
+    domain: SourceDomain
+    status: SourceStatus = "unknown"
+    quality_score: float = 0.5
+    delay_policy: str = "unknown"
+    warnings: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        payload = asdict(self)
+        payload["quality_score"] = max(0.0, min(1.0, float(self.quality_score)))
+        return payload
+
+
+@dataclass(frozen=True)
+class DataSourceProvenance:
+    provider: str
+    domain: SourceDomain
+    asof_date: str | None = None
+    fetched_at: str | None = None
+    fields: list[str] = field(default_factory=list)
+    source_url: str | None = None
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def merge_source_health(items: list[DataSourceHealth]) -> DataSourceHealth:
+    if not items:
+        return DataSourceHealth(provider="combined", domain="aggregate")
+
+    statuses = {item.status for item in items}
+    if "failed" in statuses:
+        status: SourceStatus = "failed"
+    elif "degraded" in statuses:
+        status = "degraded"
+    elif statuses == {"ok"}:
+        status = "ok"
+    else:
+        status = "unknown"
+
+    warnings: list[str] = []
+    for item in items:
+        for warning in item.warnings:
+            if warning not in warnings:
+                warnings.append(warning)
+
+    base_score = sum(
+        max(0.0, min(1.0, float(item.quality_score)))
+        for item in items
+    ) / len(items)
+    warning_penalty = min(0.25, 0.05 * len(warnings))
+    failure_penalty = 0.35 if status == "failed" else 0.10 if status == "degraded" else 0.0
+
+    return DataSourceHealth(
+        provider="combined",
+        domain="aggregate",
+        status=status,
+        quality_score=max(0.0, round(base_score - warning_penalty - failure_penalty, 4)),
+        warnings=warnings,
+    )

--- a/src/swing_screener/fundamentals/config.py
+++ b/src/swing_screener/fundamentals/config.py
@@ -1,16 +1,34 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from importlib.util import find_spec
 from typing import Any
 
 SUPPORTED_FUNDAMENTAL_PROVIDERS = {"sec_edgar", "yfinance", "degiro"}
 
 # Ordered provider chain for the Tier 1 free-first stack.
-# SEC EDGAR is tried first (US equities only); degiro covers EU equities with
-# analyst estimates and ratios; yfinance is the global fallback.
+# SEC EDGAR is tried first (US equities only); yfinance is the global fallback.
+# DeGiro is included in the default chain only when its integration package is
+# available in this checkout.
 # Add new providers here when graduating to Tier 2 — this is the single source
 # of truth referenced by both the domain config and the API validation layer.
-TIER1_PROVIDERS: tuple[str, ...] = ("sec_edgar", "degiro", "yfinance")
+
+
+def _degiro_integration_available() -> bool:
+    try:
+        return (
+            find_spec("swing_screener.integrations.degiro.credentials") is not None
+            and find_spec("swing_screener.integrations.degiro.client") is not None
+        )
+    except ModuleNotFoundError:
+        return False
+
+
+TIER1_PROVIDERS: tuple[str, ...] = (
+    ("sec_edgar", "degiro", "yfinance")
+    if _degiro_integration_available()
+    else ("sec_edgar", "yfinance")
+)
 
 
 @dataclass(frozen=True)

--- a/src/swing_screener/fundamentals/models.py
+++ b/src/swing_screener/fundamentals/models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field
+import math
 from typing import Any
 
 VALID_METRIC_UNITS = {"number", "currency", "percent", "ratio"}
@@ -65,6 +66,25 @@ def _sanitize_trend_claims(
     return sanitized
 
 
+def _optional_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(parsed):
+        return None
+    return parsed
+
+
+def _bounded_float(value: Any, fallback: float) -> float:
+    parsed = _optional_float(value)
+    if parsed is None:
+        return fallback
+    return max(0.0, min(1.0, parsed))
+
+
 @dataclass(frozen=True)
 class FundamentalPillarScore:
     score: float | None = None
@@ -125,6 +145,11 @@ class ProviderFundamentalsRecord:
     book_value_per_share: float | None = None
     price_to_book: float | None = None
     book_to_price: float | None = None
+    total_assets: float | None = None
+    total_liabilities: float | None = None
+    cash_and_equivalents: float | None = None
+    latest_filing_form: str | None = None
+    latest_filing_date: str | None = None
     net_margin: float | None = None
     analyst_recommendation_score: float | None = None
     analyst_price_target: float | None = None
@@ -173,6 +198,8 @@ class FundamentalSnapshot:
     metric_context: dict[str, FundamentalMetricContext] = field(default_factory=dict)
     data_quality_status: str = "low"
     data_quality_flags: list[str] = field(default_factory=list)
+    data_confidence_score: float = 0.5
+    source_health: dict[str, Any] = field(default_factory=dict)
     red_flags: list[str] = field(default_factory=list)
     highlights: list[str] = field(default_factory=list)
     metric_sources: dict[str, str] = field(default_factory=dict)
@@ -192,6 +219,11 @@ class FundamentalSnapshot:
     analyst_recommendation_score: float | None = None
     analyst_price_target: float | None = None
     earnings_beat_streak: int | None = None
+    total_assets: float | None = None
+    total_liabilities: float | None = None
+    cash_and_equivalents: float | None = None
+    latest_filing_form: str | None = None
+    latest_filing_date: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -310,6 +342,11 @@ class FundamentalSnapshot:
             book_value_per_share=payload.get("book_value_per_share"),
             price_to_book=payload.get("price_to_book"),
             book_to_price=payload.get("book_to_price"),
+            total_assets=_optional_float(payload.get("total_assets")),
+            total_liabilities=_optional_float(payload.get("total_liabilities")),
+            cash_and_equivalents=_optional_float(payload.get("cash_and_equivalents")),
+            latest_filing_form=(str(payload.get("latest_filing_form")).strip() if payload.get("latest_filing_form") else None),
+            latest_filing_date=(str(payload.get("latest_filing_date")).strip() if payload.get("latest_filing_date") else None),
             most_recent_quarter=payload.get("most_recent_quarter"),
             data_region=(str(payload.get("data_region")).strip().upper() if payload.get("data_region") else None),
             pillars=pillars,
@@ -317,6 +354,12 @@ class FundamentalSnapshot:
             metric_context=metric_context,
             data_quality_status=data_quality_status,
             data_quality_flags=data_quality_flags,
+            data_confidence_score=_bounded_float(payload.get("data_confidence_score"), 0.5),
+            source_health=(
+                dict(payload.get("source_health"))
+                if isinstance(payload.get("source_health"), dict)
+                else {}
+            ),
             red_flags=_sanitize_trend_claims(payload.get("red_flags", []), historical_series),
             highlights=_sanitize_trend_claims(payload.get("highlights", []), historical_series),
             metric_sources={

--- a/src/swing_screener/fundamentals/providers/sec_edgar.py
+++ b/src/swing_screener/fundamentals/providers/sec_edgar.py
@@ -234,6 +234,39 @@ def _latest_instant_value(
     return (best[2], best[0], source)
 
 
+def _latest_filing_metadata(payload: dict[str, Any]) -> tuple[str | None, str | None]:
+    facts = payload.get("facts")
+    if not isinstance(facts, dict):
+        return (None, None)
+
+    best: tuple[str, str] | None = None
+    for section in facts.values():
+        if not isinstance(section, dict):
+            continue
+        for node in section.values():
+            if not isinstance(node, dict):
+                continue
+            units = node.get("units")
+            if not isinstance(units, dict):
+                continue
+            for items in units.values():
+                if not isinstance(items, list):
+                    continue
+                for item in items:
+                    if not isinstance(item, dict):
+                        continue
+                    form = str(item.get("form", "")).strip().upper()
+                    filed_at = str(item.get("filed", "")).strip()
+                    if not filed_at or form not in _ALLOWED_FORMS:
+                        continue
+                    candidate = (filed_at, form)
+                    if best is None or candidate > best:
+                        best = candidate
+    if best is None:
+        return (None, None)
+    return (best[1], best[0])
+
+
 def _latest_series_value(series: FundamentalMetricSeries | None) -> float | None:
     if series is None or not series.points:
         return None
@@ -523,6 +556,29 @@ class SecEdgarFundamentalsProvider:
             concepts=("StockholdersEquityIncludingPortionAttributableToNoncontrollingInterest", "StockholdersEquity"),
             unit_candidates=("USD",),
         )
+        total_assets, total_assets_period, total_assets_source = _latest_instant_value(
+            payload,
+            taxonomies=("us-gaap",),
+            concepts=("Assets",),
+            unit_candidates=("USD",),
+        )
+        total_liabilities, total_liabilities_period, total_liabilities_source = _latest_instant_value(
+            payload,
+            taxonomies=("us-gaap",),
+            concepts=("Liabilities",),
+            unit_candidates=("USD",),
+        )
+        cash_and_equivalents, cash_period, cash_source = _latest_instant_value(
+            payload,
+            taxonomies=("us-gaap",),
+            concepts=(
+                "CashAndCashEquivalentsAtCarryingValue",
+                "CashCashEquivalentsRestrictedCashAndRestrictedCashEquivalents",
+                "Cash",
+            ),
+            unit_candidates=("USD",),
+        )
+        latest_filing_form, latest_filing_date = _latest_filing_metadata(payload)
         shares_outstanding, shares_period, shares_source = _latest_instant_value(
             payload,
             taxonomies=("dei", "us-gaap"),
@@ -648,6 +704,27 @@ class SecEdgarFundamentalsProvider:
                 cadence="quarterly",
                 period_end=total_equity_period,
             )
+        if total_assets is not None and total_assets_source:
+            metric_sources["total_assets"] = total_assets_source
+            metric_context["total_assets"] = _latest_context(
+                source=total_assets_source,
+                cadence="quarterly",
+                period_end=total_assets_period,
+            )
+        if total_liabilities is not None and total_liabilities_source:
+            metric_sources["total_liabilities"] = total_liabilities_source
+            metric_context["total_liabilities"] = _latest_context(
+                source=total_liabilities_source,
+                cadence="quarterly",
+                period_end=total_liabilities_period,
+            )
+        if cash_and_equivalents is not None and cash_source:
+            metric_sources["cash_and_equivalents"] = cash_source
+            metric_context["cash_and_equivalents"] = _latest_context(
+                source=cash_source,
+                cadence="quarterly",
+                period_end=cash_period,
+            )
         if shares_outstanding is not None and shares_source:
             metric_sources["shares_outstanding"] = shares_source
             metric_context["shares_outstanding"] = _latest_context(
@@ -686,6 +763,11 @@ class SecEdgarFundamentalsProvider:
             current_ratio=current_ratio,
             shares_outstanding=shares_outstanding,
             total_equity=total_equity,
+            total_assets=total_assets,
+            total_liabilities=total_liabilities,
+            cash_and_equivalents=cash_and_equivalents,
+            latest_filing_form=latest_filing_form,
+            latest_filing_date=latest_filing_date,
             historical_series=historical_series,
             metric_context=metric_context,
             metric_sources={key: value for key, value in metric_sources.items() if value},

--- a/src/swing_screener/fundamentals/providers/vendor_placeholder.py
+++ b/src/swing_screener/fundamentals/providers/vendor_placeholder.py
@@ -1,0 +1,25 @@
+"""Roadmap metadata for paid fundamentals providers.
+
+EODHD and Twelve Data are planned Tier 2 candidates for broader fundamentals,
+calendar, and news coverage. This module intentionally exposes metadata only:
+it does not define provider classes, mutate provider registries, read
+environment variables, or make network calls.
+
+Runtime support must be added in a future implementation by creating tested
+provider modules and explicitly adding their names to fundamentals config
+validation.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+PLANNED_VENDOR_PROVIDER_NAMES: Final[tuple[str, ...]] = ("eodhd", "twelve_data")
+
+PLANNED_VENDOR_PROVIDER_DOMAINS: Final[dict[str, tuple[str, ...]]] = {
+    "eodhd": ("eu_fundamentals", "global_calendar", "financial_news"),
+    "twelve_data": ("global_fundamentals", "earnings_calendar", "dividends_calendar"),
+}
+
+RUNTIME_PROVIDER_REGISTRATION_ENABLED: Final[bool] = False
+

--- a/src/swing_screener/fundamentals/scoring.py
+++ b/src/swing_screener/fundamentals/scoring.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import replace
 from datetime import date, datetime
 
+from swing_screener.data.source_health import DataSourceHealth
 from swing_screener.fundamentals.config import FundamentalsConfig
 from swing_screener.fundamentals.models import (
     FundamentalMetricContext,
@@ -36,6 +37,9 @@ _METRIC_LABELS = {
     "book_value_per_share": "Book value / share",
     "price_to_book": "Price / book",
     "book_to_price": "Book / price",
+    "total_assets": "Total assets",
+    "total_liabilities": "Total liabilities",
+    "cash_and_equivalents": "Cash and equivalents",
 }
 
 
@@ -114,6 +118,9 @@ def _coverage_status(record: ProviderFundamentalsRecord, supported: bool) -> str
         record.price_to_sales,
         record.book_value_per_share,
         record.price_to_book,
+        record.total_assets,
+        record.total_liabilities,
+        record.cash_and_equivalents,
     ]
     count = sum(1 for value in available if value is not None)
     if count >= 7:
@@ -738,6 +745,46 @@ def _valuation_attractiveness_score(pillars: dict[str, FundamentalPillarScore]) 
     return valuation.score
 
 
+def _data_confidence_score(
+    *,
+    coverage_status: str,
+    freshness_status: str,
+    data_quality_status: str,
+) -> float:
+    coverage = {
+        "supported": 0.9,
+        "partial": 0.6,
+        "insufficient": 0.3,
+        "unsupported": 0.1,
+    }.get(coverage_status, 0.3)
+    freshness = {
+        "current": 1.0,
+        "stale": 0.55,
+        "unknown": 0.45,
+    }.get(freshness_status, 0.45)
+    quality = {
+        "high": 1.0,
+        "medium": 0.75,
+        "low": 0.45,
+    }.get(data_quality_status, 0.45)
+    return round(max(0.0, min(1.0, coverage * freshness * quality)), 4)
+
+
+def _source_health_status(
+    *,
+    coverage_status: str,
+    freshness_status: str,
+    data_quality_status: str,
+) -> str:
+    if (
+        coverage_status != "supported"
+        or freshness_status != "current"
+        or data_quality_status == "low"
+    ):
+        return "degraded"
+    return "ok"
+
+
 def build_snapshot(record: ProviderFundamentalsRecord, cfg: FundamentalsConfig) -> FundamentalSnapshot:
     resolved_record = _resolved_record(record)
     supported = _is_supported_equity(resolved_record.instrument_type)
@@ -748,6 +795,23 @@ def build_snapshot(record: ProviderFundamentalsRecord, cfg: FundamentalsConfig) 
     red_flags = _build_red_flags(resolved_record, freshness_status, historical_series)
     highlights = _build_highlights(resolved_record, pillars, coverage_status, historical_series)
     data_quality_status, data_quality_flags = _build_data_quality(resolved_record, historical_series)
+    data_confidence_score = _data_confidence_score(
+        coverage_status=coverage_status,
+        freshness_status=freshness_status,
+        data_quality_status=data_quality_status,
+    )
+    source_health = DataSourceHealth(
+        provider=resolved_record.provider,
+        domain="fundamentals",
+        status=_source_health_status(
+            coverage_status=coverage_status,
+            freshness_status=freshness_status,
+            data_quality_status=data_quality_status,
+        ),
+        quality_score=data_confidence_score,
+        delay_policy=freshness_status,
+        warnings=data_quality_flags,
+    ).to_dict()
 
     # Compute trend acceleration signals
     rev_accel = _revenue_acceleration(historical_series)
@@ -803,6 +867,11 @@ def build_snapshot(record: ProviderFundamentalsRecord, cfg: FundamentalsConfig) 
         book_value_per_share=resolved_record.book_value_per_share,
         price_to_book=resolved_record.price_to_book,
         book_to_price=resolved_record.book_to_price,
+        total_assets=resolved_record.total_assets,
+        total_liabilities=resolved_record.total_liabilities,
+        cash_and_equivalents=resolved_record.cash_and_equivalents,
+        latest_filing_form=resolved_record.latest_filing_form,
+        latest_filing_date=resolved_record.latest_filing_date,
         most_recent_quarter=resolved_record.most_recent_quarter,
         data_region=resolved_record.data_region,
         pillars=pillars,
@@ -810,6 +879,8 @@ def build_snapshot(record: ProviderFundamentalsRecord, cfg: FundamentalsConfig) 
         metric_context=resolved_record.metric_context,
         data_quality_status=data_quality_status,
         data_quality_flags=data_quality_flags,
+        data_confidence_score=data_confidence_score,
+        source_health=source_health,
         red_flags=red_flags,
         highlights=highlights,
         metric_sources=resolved_record.metric_sources,
@@ -842,6 +913,15 @@ def build_provider_error_snapshot(symbol: str, provider: str, error: str) -> Fun
         metric_context={},
         data_quality_status="low",
         data_quality_flags=["Provider reported an error; snapshot may be incomplete."],
+        data_confidence_score=0.0,
+        source_health=DataSourceHealth(
+            provider=provider,
+            domain="fundamentals",
+            status="failed",
+            quality_score=0.0,
+            delay_policy="unknown",
+            warnings=["Provider reported an error; snapshot may be incomplete."],
+        ).to_dict(),
         red_flags=[error],
         highlights=["Provider call failed; no fresh fundamental snapshot is available."],
         error=error,

--- a/src/swing_screener/recommendation/priority.py
+++ b/src/swing_screener/recommendation/priority.py
@@ -74,6 +74,13 @@ def _label_score(mapping: dict[str, float], label: str | None, default: float = 
     return mapping.get((label or "").lower(), default)
 
 
+def _data_confidence_multiplier(snapshot: Any, floor: float) -> float:
+    data_confidence = _safe_float(getattr(snapshot, "data_confidence_score", None))
+    if data_confidence is None:
+        return 1.0
+    return max(floor, max(0.0, min(1.0, data_confidence)))
+
+
 def _fundamentals_score(candidate: ScreenerCandidate) -> float:
     """Fundamentals sub-score: uses business_quality_score from snapshot when available,
     falls back to decision_summary label. Applies freshness and coverage penalties."""
@@ -93,6 +100,7 @@ def _fundamentals_score(candidate: ScreenerCandidate) -> float:
     freshness_penalty = _safe_float(getattr(snapshot, "freshness_penalty", None)) or 0.0
     coverage_penalty = _safe_float(getattr(snapshot, "coverage_penalty", None)) or 0.0
     penalty_multiplier = max(0.0, 1.0 - freshness_penalty - (coverage_penalty * 0.5))
+    score *= _data_confidence_multiplier(snapshot, floor=0.25)
     return max(0.0, score * penalty_multiplier)
 
 
@@ -109,7 +117,8 @@ def _valuation_score(candidate: ScreenerCandidate) -> float:
         return score
 
     valuation = _safe_float(getattr(snapshot, "valuation_attractiveness", None))
-    return valuation if valuation is not None else score
+    score = valuation if valuation is not None else score
+    return max(0.0, score * _data_confidence_multiplier(snapshot, floor=0.4))
 
 
 def compute_combined_priority(

--- a/tests/api/test_screener_endpoints.py
+++ b/tests/api/test_screener_endpoints.py
@@ -10,6 +10,7 @@ from api.main import app
 from api.dependencies import get_portfolio_service
 import api.services.screener_service as screener_service
 from api.models.screener import ScreenerResponse
+from swing_screener.data.source_health import DataSourceHealth
 from swing_screener.data.providers import MarketDataProvider
 from swing_screener.recommendation.models import DecisionSummary
 
@@ -86,6 +87,13 @@ def _create_mock_provider(ohlcv_data: pd.DataFrame) -> MarketDataProvider:
     mock_provider = MagicMock(spec=MarketDataProvider)
     mock_provider.fetch_ohlcv.return_value = ohlcv_data
     mock_provider.get_provider_name.return_value = "mock"
+    mock_provider.get_source_health.return_value = DataSourceHealth(
+        provider="mock",
+        domain="market_data",
+        status="ok",
+        quality_score=0.7,
+        delay_policy="test_fixture",
+    )
     return mock_provider
 
 
@@ -207,6 +215,43 @@ def test_screener_recommendation_payload_shape(monkeypatch):
     }
     assert isinstance(rec["checklist"][0]["gate_name"], str)
     assert isinstance(rec["education"]["what_would_make_valid"], list)
+
+
+def test_screener_response_includes_market_data_source_summary(monkeypatch):
+    ohlcv = _ohlcv_with_spy()
+    mock_provider = _create_mock_provider(ohlcv)
+
+    def fake_build_daily_report(ohlcv, cfg, exclude_tickers=None):
+        return pd.DataFrame(
+            {
+                "atr14": [1.2],
+                "mom_6m": [0.1],
+                "mom_12m": [0.2],
+                "rs_6m": [0.05],
+                "score": [0.55],
+                "confidence": [60.0],
+                "last": [50.0],
+                "ma20_level": [48.0],
+                "dist_sma50_pct": [5.0],
+                "dist_sma200_pct": [10.0],
+                "rank": [1],
+            },
+            index=["AAA"],
+        )
+
+    monkeypatch.setattr(screener_service, "get_default_provider", lambda **kwargs: mock_provider)
+    monkeypatch.setattr(screener_service, "build_daily_report", fake_build_daily_report)
+    monkeypatch.setattr(screener_service, "get_multiple_ticker_info", lambda tickers: {})
+
+    client = TestClient(app)
+    res = client.post("/api/screener/run", json={"universe": "broad_market_stocks", "top": 1})
+    assert res.status_code == 200
+
+    candidate = res.json()["candidates"][0]
+    market_data = candidate["data_source_summary"]["market_data"]
+    assert market_data["provider"] == "mock"
+    assert market_data["status"] in {"ok", "degraded", "failed", "unknown"}
+    assert 0 <= market_data["quality_score"] <= 1
 
 
 def test_screener_attaches_benchmark_comparison(monkeypatch):

--- a/tests/data/test_source_health.py
+++ b/tests/data/test_source_health.py
@@ -1,0 +1,120 @@
+from swing_screener.data.source_health import (
+    DataSourceHealth,
+    DataSourceProvenance,
+    merge_source_health,
+)
+from swing_screener.data.providers.alpaca_provider import AlpacaDataProvider
+from swing_screener.data.providers.base import MarketDataProvider
+from swing_screener.data.providers.stooq_provider import StooqDataProvider
+from swing_screener.data.providers.yfinance_provider import YfinanceProvider
+
+
+class DummyProvider(MarketDataProvider):
+    def fetch_ohlcv(self, tickers, start_date, end_date, interval="1d"):
+        raise NotImplementedError
+
+    def fetch_latest_price(self, ticker):
+        raise NotImplementedError
+
+    def get_ticker_info(self, ticker):
+        raise NotImplementedError
+
+    def is_market_open(self):
+        return False
+
+    def get_provider_name(self):
+        return "dummy"
+
+
+def test_source_health_defaults_are_conservative():
+    health = DataSourceHealth(provider="yfinance", domain="market_data")
+
+    assert health.status == "unknown"
+    assert health.quality_score == 0.5
+    assert health.delay_policy == "unknown"
+    assert health.warnings == []
+
+
+def test_provenance_serializes_provider_domain_and_asof():
+    provenance = DataSourceProvenance(
+        provider="sec_edgar",
+        domain="fundamentals",
+        asof_date="2026-05-28",
+        fetched_at="2026-05-28T12:00:00+00:00",
+        fields=["revenue_growth_yoy", "operating_margin"],
+    )
+
+    payload = provenance.to_dict()
+
+    assert payload["provider"] == "sec_edgar"
+    assert payload["domain"] == "fundamentals"
+    assert payload["fields"] == ["revenue_growth_yoy", "operating_margin"]
+
+
+def test_merge_source_health_penalizes_warnings_and_failures():
+    merged = merge_source_health(
+        [
+            DataSourceHealth(
+                provider="sec_edgar",
+                domain="fundamentals",
+                status="ok",
+                quality_score=0.9,
+            ),
+            DataSourceHealth(
+                provider="yfinance",
+                domain="metadata",
+                status="degraded",
+                quality_score=0.6,
+                warnings=["unofficial"],
+            ),
+        ]
+    )
+
+    assert merged.provider == "combined"
+    assert merged.domain == "aggregate"
+    assert 0.6 <= merged.quality_score < 0.9
+    assert merged.status == "degraded"
+
+
+def test_market_data_provider_default_health_is_unknown_and_neutral():
+    health = DummyProvider().get_source_health()
+
+    assert health.to_dict() == {
+        "provider": "dummy",
+        "domain": "market_data",
+        "status": "unknown",
+        "quality_score": 0.5,
+        "delay_policy": "unknown",
+        "warnings": [],
+    }
+
+
+def test_market_data_provider_quality_defaults_are_explicit(tmp_path):
+    yfinance = YfinanceProvider(cache_dir=str(tmp_path / "yf"))
+    stooq = StooqDataProvider()
+    alpaca_paper = AlpacaDataProvider(
+        api_key="paper-key",
+        secret_key="paper-secret",
+        paper=True,
+        cache_dir=str(tmp_path / "alpaca"),
+    )
+
+    yfinance_health = yfinance.get_source_health().to_dict()
+    stooq_health = stooq.get_source_health().to_dict()
+    alpaca_health = alpaca_paper.get_source_health().to_dict()
+
+    assert yfinance_health["provider"] == "yfinance"
+    assert yfinance_health["status"] == "ok"
+    assert yfinance_health["quality_score"] == 0.65
+    assert yfinance_health["delay_policy"] == "delayed_or_eod"
+    assert yfinance_health["warnings"] == ["unofficial_provider"]
+
+    assert stooq_health["provider"] == "stooq"
+    assert stooq_health["quality_score"] == 0.6
+    assert stooq_health["delay_policy"] == "daily_eod"
+    assert stooq_health["warnings"] == ["daily_only"]
+
+    assert alpaca_health["provider"] == "alpaca-paper"
+    assert alpaca_health["quality_score"] == 0.75
+    assert alpaca_health["delay_policy"] == "provider_plan_dependent"
+    assert alpaca_health["warnings"] == ["paper_or_basic_plan_may_be_limited"]

--- a/tests/test_calendar_service.py
+++ b/tests/test_calendar_service.py
@@ -207,6 +207,10 @@ def test_earnings_from_finnhub_includes_eps_estimate(tmp_path):
     assert len(earnings) == 1
     assert earnings[0].eps_estimate == pytest.approx(1.72)
     assert earnings[0].ticker == "AAPL"
+    assert earnings[0].provider == "finnhub"
+    assert 0.0 <= earnings[0].confidence <= 1.0
+    assert earnings[0].confidence == pytest.approx(0.85)
+    assert earnings[0].source_url == "https://finnhub.io/api/v1/calendar/earnings"
 
 
 def test_earnings_falls_back_to_yfinance_when_no_finnhub_key(tmp_path):
@@ -224,6 +228,9 @@ def test_earnings_falls_back_to_yfinance_when_no_finnhub_key(tmp_path):
     mock_yf.assert_called()
     earnings = [e for e in events if e.event_type == "earnings"]
     assert len(earnings) == 1
+    assert earnings[0].provider == "yfinance"
+    assert 0.0 <= earnings[0].confidence <= 1.0
+    assert earnings[0].confidence == pytest.approx(0.55)
 
 
 def test_earnings_finnhub_per_ticker_failure_is_skipped(tmp_path):
@@ -278,6 +285,10 @@ def test_ipo_events_returned_when_finnhub_key_set(tmp_path):
     assert len(ipos) == 1
     assert ipos[0].ticker == "ACME"
     assert ipos[0].source_tag == "ipo"
+    assert ipos[0].provider == "finnhub"
+    assert 0.0 <= ipos[0].confidence <= 1.0
+    assert ipos[0].confidence == pytest.approx(0.8)
+    assert ipos[0].source_url == "https://finnhub.io/api/v1/calendar/ipo"
 
 
 def test_ipo_events_skipped_when_no_finnhub_key(tmp_path):
@@ -345,6 +356,45 @@ def test_dividend_events_only_for_position_tickers(tmp_path):
     assert len(divs) == 1
     assert divs[0].ticker == "AAPL"
     assert divs[0].source_tag == "position"
+    assert divs[0].provider == "finnhub"
+    assert 0.0 <= divs[0].confidence <= 1.0
+    assert divs[0].confidence == pytest.approx(0.8)
+    assert divs[0].source_url == "https://finnhub.io/api/v1/calendar/dividend"
+
+
+def test_economic_events_include_finnhub_provenance_and_confidence(tmp_path):
+    import datetime as dt
+    from unittest.mock import MagicMock, patch
+    from api.services.calendar_service import CalendarService
+
+    repo = _make_positions_repo([])
+    svc = CalendarService(positions_repo=repo, data_dir=tmp_path, finnhub_api_key="test_key")
+
+    event_date = dt.date.today() + dt.timedelta(days=3)
+    resp = MagicMock()
+    resp.json.return_value = {
+        "economicCalendar": [
+            {
+                "time": f"{event_date.isoformat()} 08:30:00",
+                "event": "CPI",
+                "impact": "high",
+            }
+        ]
+    }
+    resp.raise_for_status = MagicMock()
+
+    with patch("api.services.calendar_service.httpx.get", return_value=resp):
+        with patch.object(svc, "_batch_fetch_earnings", return_value=[]):
+            with patch.object(svc, "_fetch_ipo_events", return_value=[]):
+                with patch.object(svc, "_fetch_dividend_events", return_value=[]):
+                    events = svc.get_events(days_ahead=30)
+
+    economic = [e for e in events if e.event_type == "economic"]
+    assert len(economic) == 1
+    assert economic[0].provider == "finnhub"
+    assert 0.0 <= economic[0].confidence <= 1.0
+    assert economic[0].confidence == pytest.approx(0.8)
+    assert economic[0].source_url == "https://finnhub.io/api/v1/calendar/economic"
 
 
 def test_dividend_events_skipped_when_no_finnhub_key(tmp_path):

--- a/tests/test_combined_priority.py
+++ b/tests/test_combined_priority.py
@@ -147,6 +147,7 @@ def test_fundamentals_snapshot_penalties_and_quality_shape_priority() -> None:
             valuation_attractiveness=0.4,
             freshness_penalty=0.4,
             coverage_penalty=0.6,
+            data_confidence_score=1.0,
         ),
     )
     resilient = _candidate(
@@ -165,6 +166,7 @@ def test_fundamentals_snapshot_penalties_and_quality_shape_priority() -> None:
             valuation_attractiveness=0.75,
             freshness_penalty=0.0,
             coverage_penalty=0.0,
+            data_confidence_score=1.0,
         ),
     )
     anchor = _candidate("ANCHOR", confidence=20, rank=3)
@@ -176,3 +178,72 @@ def test_fundamentals_snapshot_penalties_and_quality_shape_priority() -> None:
     assert scores["PENALIZED"] is not None
     assert scores["RESILIENT"] is not None
     assert scores["PENALIZED"] < scores["RESILIENT"]
+
+
+def test_data_confidence_penalizes_equivalent_fundamental_and_valuation_scores() -> None:
+    high_confidence = _candidate(
+        "HIGHCONF",
+        confidence=80,
+        rank=2,
+        fundamentals_label="strong",
+        catalyst_label="neutral",
+        valuation_label="cheap",
+        fundamentals_snapshot=FundamentalSnapshot(
+            symbol="HIGHCONF",
+            asof_date="2026-03-31",
+            provider="test",
+            updated_at="2026-03-31T00:00:00",
+            business_quality_score=0.8,
+            valuation_attractiveness=0.7,
+            data_confidence_score=0.95,
+        ),
+    )
+    low_confidence = _candidate(
+        "LOWCONF",
+        confidence=80,
+        rank=1,
+        fundamentals_label="strong",
+        catalyst_label="neutral",
+        valuation_label="cheap",
+        fundamentals_snapshot=FundamentalSnapshot(
+            symbol="LOWCONF",
+            asof_date="2026-03-31",
+            provider="test",
+            updated_at="2026-03-31T00:00:00",
+            business_quality_score=0.8,
+            valuation_attractiveness=0.7,
+            data_confidence_score=0.25,
+        ),
+    )
+
+    result = compute_combined_priority([low_confidence, high_confidence], cfg=_CFG)
+
+    assert result[0].ticker == "HIGHCONF"
+    assert result[0].combined_priority_score is not None
+    assert result[1].combined_priority_score is not None
+    assert result[0].combined_priority_score > result[1].combined_priority_score
+
+
+def test_zero_confidence_error_snapshot_uses_configured_confidence_floors() -> None:
+    candidate = _candidate(
+        "ERRFLOOR",
+        confidence=80,
+        rank=1,
+        fundamentals_label="strong",
+        catalyst_label="neutral",
+        valuation_label="cheap",
+        fundamentals_snapshot=FundamentalSnapshot(
+            symbol="ERRFLOOR",
+            asof_date="2026-03-31",
+            provider="test",
+            updated_at="2026-03-31T00:00:00",
+            business_quality_score=0.8,
+            valuation_attractiveness=0.7,
+            data_confidence_score=0.0,
+            error="provider failed",
+        ),
+    )
+
+    result = compute_combined_priority([candidate], cfg=_CFG)
+
+    assert result[0].combined_priority_score == pytest.approx(0.403)

--- a/tests/test_fundamentals_scoring.py
+++ b/tests/test_fundamentals_scoring.py
@@ -8,14 +8,20 @@ from pytest import approx
 
 from swing_screener.fundamentals.scoring import (
     _coverage_penalty_from_pillars,
+    _data_confidence_score,
     _freshness_penalty_from_date,
     _revenue_acceleration,
     _linear_slope,
+    build_provider_error_snapshot,
+    build_snapshot,
 )
 from swing_screener.fundamentals.models import (
+    FundamentalSnapshot,
     FundamentalMetricSeries,
     FundamentalSeriesPoint,
+    ProviderFundamentalsRecord,
 )
+from swing_screener.fundamentals.config import FundamentalsConfig
 
 
 # ---------------------------------------------------------------------------
@@ -115,3 +121,145 @@ def test_linear_slope_increasing():
 
 def test_linear_slope_insufficient_data():
     assert _linear_slope([5.0]) is None
+
+
+def test_data_confidence_score_uses_multiplicative_plan_formula():
+    strong = _data_confidence_score(
+        coverage_status="supported",
+        freshness_status="current",
+        data_quality_status="high",
+    )
+    partial_stale = _data_confidence_score(
+        coverage_status="partial",
+        freshness_status="stale",
+        data_quality_status="medium",
+    )
+    weak = _data_confidence_score(
+        coverage_status="insufficient",
+        freshness_status="unknown",
+        data_quality_status="low",
+    )
+
+    assert strong == 0.9
+    assert partial_stale == 0.2475
+    assert weak == 0.0608
+    assert 0.0 <= weak <= 1.0
+    assert 0.0 <= strong <= 1.0
+    assert strong > weak
+
+
+def test_snapshot_from_dict_missing_confidence_defaults_to_neutral():
+    snapshot = FundamentalSnapshot.from_dict(
+        {
+            "symbol": "AAPL",
+            "asof_date": "2026-05-28",
+            "provider": "yfinance",
+            "updated_at": "2026-05-28T10:00:00",
+        }
+    )
+
+    assert snapshot.data_confidence_score == 0.5
+
+
+def test_snapshot_from_dict_malformed_confidence_and_balance_sheet_fields_are_defensive():
+    cases = [
+        ("bad-assets", {}, [], "bad-score"),
+        ("NaN", "Infinity", "-Infinity", "NaN"),
+        ("Infinity", "-Infinity", "NaN", "Infinity"),
+        ("-Infinity", "NaN", "Infinity", "-Infinity"),
+    ]
+    for total_assets, total_liabilities, cash_and_equivalents, data_confidence_score in cases:
+        snapshot = FundamentalSnapshot.from_dict(
+            {
+                "symbol": "AAPL",
+                "asof_date": "2026-05-28",
+                "provider": "yfinance",
+                "updated_at": "2026-05-28T10:00:00",
+                "total_assets": total_assets,
+                "total_liabilities": total_liabilities,
+                "cash_and_equivalents": cash_and_equivalents,
+                "data_confidence_score": data_confidence_score,
+            }
+        )
+
+        assert snapshot.total_assets is None
+        assert snapshot.total_liabilities is None
+        assert snapshot.cash_and_equivalents is None
+        assert snapshot.data_confidence_score == 0.5
+
+
+def test_stale_high_quality_snapshot_marks_source_health_degraded():
+    record = ProviderFundamentalsRecord(
+        symbol="AAPL",
+        asof_date="2026-05-28",
+        provider="sec_edgar",
+        instrument_type="equity",
+        most_recent_quarter="2024-12-31",
+        revenue_growth_yoy=0.12,
+        earnings_growth_yoy=0.16,
+        gross_margin=0.45,
+        operating_margin=0.25,
+        free_cash_flow_margin=0.18,
+        debt_to_equity=40.0,
+        current_ratio=1.6,
+        return_on_equity=0.22,
+        trailing_pe=22.0,
+        price_to_sales=5.0,
+    )
+
+    snapshot = build_snapshot(
+        record,
+        FundamentalsConfig(providers=("sec_edgar", "yfinance"), stale_after_days=30),
+    )
+
+    assert snapshot.coverage_status == "supported"
+    assert snapshot.data_quality_status == "high"
+    assert snapshot.freshness_status == "stale"
+    assert snapshot.source_health["status"] == "degraded"
+
+
+def test_provider_error_snapshot_has_zero_confidence_for_failed_source_health():
+    snapshot = build_provider_error_snapshot("AAPL", "sec_edgar", "boom")
+
+    assert snapshot.source_health["status"] == "failed"
+    assert snapshot.source_health["quality_score"] == 0.0
+    assert snapshot.data_confidence_score == 0.0
+
+
+def test_build_snapshot_propagates_confidence_health_and_sec_balance_sheet_fields():
+    record = ProviderFundamentalsRecord(
+        symbol="AAPL",
+        asof_date="2026-05-28",
+        provider="sec_edgar",
+        instrument_type="equity",
+        most_recent_quarter="2026-03-31",
+        revenue_growth_yoy=0.12,
+        earnings_growth_yoy=0.16,
+        gross_margin=0.45,
+        operating_margin=0.25,
+        free_cash_flow_margin=0.18,
+        debt_to_equity=40.0,
+        current_ratio=1.6,
+        return_on_equity=0.22,
+        trailing_pe=22.0,
+        price_to_sales=5.0,
+        total_assets=350_000_000_000.0,
+        total_liabilities=275_000_000_000.0,
+        cash_and_equivalents=55_000_000_000.0,
+        latest_filing_form="10-Q",
+        latest_filing_date="2026-05-01",
+    )
+
+    snapshot = build_snapshot(
+        record,
+        FundamentalsConfig(providers=("sec_edgar", "yfinance"), stale_after_days=120),
+    )
+
+    assert snapshot.total_assets == 350_000_000_000.0
+    assert snapshot.total_liabilities == 275_000_000_000.0
+    assert snapshot.cash_and_equivalents == 55_000_000_000.0
+    assert snapshot.latest_filing_form == "10-Q"
+    assert snapshot.latest_filing_date == "2026-05-01"
+    assert 0.0 <= snapshot.data_confidence_score <= 1.0
+    assert snapshot.source_health["provider"] == "sec_edgar"
+    assert snapshot.source_health["quality_score"] == snapshot.data_confidence_score

--- a/tests/test_fundamentals_service.py
+++ b/tests/test_fundamentals_service.py
@@ -4,7 +4,7 @@ from dataclasses import replace
 
 import pytest
 
-from swing_screener.fundamentals.config import FundamentalsConfig
+from swing_screener.fundamentals.config import FundamentalsConfig, build_fundamentals_config
 from swing_screener.fundamentals.models import (
     FundamentalMetricContext,
     FundamentalMetricSeries,
@@ -395,7 +395,24 @@ def test_fundamentals_service_builds_supported_quarterly_snapshot_with_high_trus
     assert snapshot.metric_context["revenue_growth_yoy"].cadence == "quarterly"
     assert snapshot.data_quality_status == "high"
     assert snapshot.data_quality_flags == []
+    assert 0.0 <= snapshot.data_confidence_score <= 1.0
+    assert snapshot.data_confidence_score == pytest.approx(0.9)
+    assert snapshot.source_health["provider"] == "yfinance"
+    assert snapshot.source_health["domain"] == "fundamentals"
+    assert snapshot.source_health["status"] == "ok"
     assert "Quarterly revenue trend is improving." in snapshot.highlights
+
+
+def test_default_fundamentals_config_excludes_degiro_when_integration_unavailable():
+    cfg = build_fundamentals_config({})
+
+    assert cfg.providers == ("sec_edgar", "yfinance")
+
+
+def test_explicit_fundamentals_config_still_allows_degiro_provider_name():
+    cfg = build_fundamentals_config({"providers": ["degiro", "yfinance"]})
+
+    assert cfg.providers == ("degiro", "yfinance")
 
 
 def test_fundamentals_service_marks_etf_as_unsupported(tmp_path):

--- a/tests/test_fundamentals_service.py
+++ b/tests/test_fundamentals_service.py
@@ -415,6 +415,19 @@ def test_explicit_fundamentals_config_still_allows_degiro_provider_name():
     assert cfg.providers == ("degiro", "yfinance")
 
 
+def test_paid_vendor_provider_names_are_rejected_until_implemented():
+    from swing_screener.fundamentals import config
+    from swing_screener.fundamentals.providers import vendor_placeholder
+
+    cfg = build_fundamentals_config({"providers": ["eodhd", "twelve_data", "sec_edgar"]})
+
+    assert cfg.providers == ("sec_edgar",)
+    assert vendor_placeholder.PLANNED_VENDOR_PROVIDER_NAMES == ("eodhd", "twelve_data")
+    assert set(vendor_placeholder.PLANNED_VENDOR_PROVIDER_NAMES).isdisjoint(
+        config.SUPPORTED_FUNDAMENTAL_PROVIDERS
+    )
+
+
 def test_fundamentals_service_marks_etf_as_unsupported(tmp_path):
     service = FundamentalsAnalysisService(
         storage=FundamentalsStorage(tmp_path / "fundamentals"),

--- a/tests/test_fundamentals_snapshot_roundtrip.py
+++ b/tests/test_fundamentals_snapshot_roundtrip.py
@@ -181,3 +181,32 @@ def test_snapshot_from_dict_new_fields_default_to_none_when_absent():
     assert snapshot.analyst_recommendation_score is None
     assert snapshot.analyst_price_target is None
     assert snapshot.earnings_beat_streak is None
+
+
+def test_snapshot_from_dict_handles_malformed_new_numeric_fields():
+    from swing_screener.fundamentals.models import FundamentalSnapshot
+    cases = [
+        ("not-a-number", {}, [], "bad-score"),
+        ("NaN", "Infinity", "-Infinity", "NaN"),
+        ("Infinity", "-Infinity", "NaN", "Infinity"),
+        ("-Infinity", "NaN", "Infinity", "-Infinity"),
+    ]
+
+    for total_assets, total_liabilities, cash_and_equivalents, data_confidence_score in cases:
+        payload = {
+            "symbol": "AAPL",
+            "asof_date": "2026-05-27",
+            "provider": "yfinance",
+            "updated_at": "2026-05-27T10:00:00",
+            "total_assets": total_assets,
+            "total_liabilities": total_liabilities,
+            "cash_and_equivalents": cash_and_equivalents,
+            "data_confidence_score": data_confidence_score,
+        }
+
+        snapshot = FundamentalSnapshot.from_dict(payload)
+
+        assert snapshot.total_assets is None
+        assert snapshot.total_liabilities is None
+        assert snapshot.cash_and_equivalents is None
+        assert snapshot.data_confidence_score == 0.5

--- a/tests/test_sec_edgar_fundamentals_provider.py
+++ b/tests/test_sec_edgar_fundamentals_provider.py
@@ -169,6 +169,42 @@ def test_sec_edgar_provider_builds_quarterly_record(monkeypatch):
                         ]
                     }
                 },
+                "Assets": {
+                    "units": {
+                        "USD": [
+                            {
+                                "end": "2026-03-31",
+                                "val": 3500.0,
+                                "form": "10-Q",
+                                "filed": "2026-05-01",
+                            }
+                        ]
+                    }
+                },
+                "Liabilities": {
+                    "units": {
+                        "USD": [
+                            {
+                                "end": "2026-03-31",
+                                "val": 2700.0,
+                                "form": "10-Q",
+                                "filed": "2026-05-01",
+                            }
+                        ]
+                    }
+                },
+                "CashAndCashEquivalentsAtCarryingValue": {
+                    "units": {
+                        "USD": [
+                            {
+                                "end": "2026-03-31",
+                                "val": 600.0,
+                                "form": "10-Q",
+                                "filed": "2026-05-01",
+                            }
+                        ]
+                    }
+                },
                 "AssetsCurrent": {
                     "units": {
                         "USD": [
@@ -242,7 +278,18 @@ def test_sec_edgar_provider_builds_quarterly_record(monkeypatch):
     assert record.current_ratio == 2.0
     assert record.shares_outstanding == 100.0
     assert record.total_equity == 800.0
+    assert record.total_assets == 3500.0
+    assert record.total_liabilities == 2700.0
+    assert record.cash_and_equivalents == 600.0
+    assert record.latest_filing_form == "10-Q"
+    assert record.latest_filing_date == "2026-05-01"
     assert record.most_recent_quarter == "2026-03-31"
+    assert record.metric_sources["total_assets"] == "sec_edgar.us-gaap.Assets"
+    assert record.metric_sources["total_liabilities"] == "sec_edgar.us-gaap.Liabilities"
+    assert (
+        record.metric_sources["cash_and_equivalents"]
+        == "sec_edgar.us-gaap.CashAndCashEquivalentsAtCarryingValue"
+    )
     assert record.historical_series["revenue"].frequency == "quarterly"
     assert record.historical_series["free_cash_flow"].points[-1].value == 200.0
     assert record.historical_series["free_cash_flow_margin"].points[-1].value == 200.0 / 1200.0

--- a/web-ui/src/components/domain/workspace/AnalysisDecisionStrip.test.tsx
+++ b/web-ui/src/components/domain/workspace/AnalysisDecisionStrip.test.tsx
@@ -242,3 +242,29 @@ describe('AnalysisDecisionStrip — metric grid layout', () => {
     expect(gridWrapper).not.toBeNull();
   });
 });
+
+describe('AnalysisDecisionStrip — source chips', () => {
+  it('renders compact provider and status chips from candidate data sources', () => {
+    const candidate = buildCandidate({
+      dataSourceSummary: {
+        marketData: {
+          provider: 'yfinance',
+          status: 'ok',
+          qualityScore: 0.65,
+          warnings: [],
+        },
+        fundamentals: {
+          provider: 'sec_edgar',
+          status: 'degraded',
+          qualityScore: 0.72,
+          warnings: ['stale'],
+        },
+      },
+    });
+
+    render(<AnalysisDecisionStrip ticker="AAPL" candidate={candidate} />);
+
+    expect(screen.getByText('Market: yfinance (ok)')).toBeInTheDocument();
+    expect(screen.getByText('Fundamentals: sec_edgar (degraded)')).toBeInTheDocument();
+  });
+});

--- a/web-ui/src/components/domain/workspace/AnalysisDecisionStrip.tsx
+++ b/web-ui/src/components/domain/workspace/AnalysisDecisionStrip.tsx
@@ -1,6 +1,7 @@
 import Badge from '@/components/common/Badge';
 import type { SymbolAnalysisCandidate } from '@/components/domain/workspace/types';
 import type {
+  DataSourceHealth,
   DecisionAction,
   DecisionConviction,
 } from '@/features/screener/types';
@@ -61,6 +62,18 @@ function compactValue(label: string, value: string, secondary?: string) {
   );
 }
 
+function sourceBadgeVariant(source: DataSourceHealth): 'success' | 'warning' | 'error' | 'default' {
+  switch (source.status) {
+    case 'ok':
+      return 'success';
+    case 'failed':
+      return 'error';
+    case 'degraded':
+    case 'unknown':
+      return 'warning';
+  }
+}
+
 export default function AnalysisDecisionStrip({
   ticker,
   candidate,
@@ -93,6 +106,14 @@ export default function AnalysisDecisionStrip({
   const closeSecondary = usesSuggestedEntry && isPositiveNumber(closeEntry)
     ? `${t('workspacePage.panels.analysis.decisionSummary.tradePlan.close')} ${formatCurrency(closeEntry, currency)}`
     : undefined;
+  const sourceItems = [
+    ['Market', candidate?.dataSourceSummary?.marketData],
+    ['Fundamentals', candidate?.dataSourceSummary?.fundamentals],
+    ['Events', candidate?.dataSourceSummary?.calendar],
+  ] as const;
+  const visibleSourceItems = sourceItems.filter(
+    (item): item is readonly [typeof item[0], DataSourceHealth] => Boolean(item[1])
+  );
 
   return (
     <div className="sticky top-0 z-10 rounded-xl border border-slate-200 bg-slate-50/95 p-3 shadow-sm backdrop-blur supports-[backdrop-filter]:bg-slate-50/85">
@@ -103,6 +124,11 @@ export default function AnalysisDecisionStrip({
               <h2 className="text-base font-semibold text-slate-900">{ticker}</h2>
               {summary ? <Badge variant="primary">{actionLabel(summary.action)}</Badge> : null}
               {summary ? <Badge variant="default">{convictionLabel(summary.conviction)}</Badge> : null}
+              {visibleSourceItems.map(([label, source]) => (
+                <Badge key={label} variant={sourceBadgeVariant(source)}>
+                  {label}: {source.provider || 'unknown'} ({source.status})
+                </Badge>
+              ))}
             </div>
             <p className="text-xs text-slate-600">
               {summary?.explanation?.summaryLine

--- a/web-ui/src/components/domain/workspace/types.ts
+++ b/web-ui/src/components/domain/workspace/types.ts
@@ -1,5 +1,9 @@
 import type { Recommendation } from '@/types/recommendation';
-import type { DecisionSummary, SameSymbolCandidateContext } from '@/features/screener/types';
+import type {
+  CandidateDataSourceSummary,
+  DecisionSummary,
+  SameSymbolCandidateContext,
+} from '@/features/screener/types';
 
 export type WorkspaceAnalysisTab = 'overview' | 'fundamentals' | 'order';
 
@@ -31,4 +35,5 @@ export interface SymbolAnalysisCandidate {
   executionNote?: string;
   sameSymbol?: SameSymbolCandidateContext;
   decisionSummary?: DecisionSummary;
+  dataSourceSummary?: CandidateDataSourceSummary;
 }

--- a/web-ui/src/features/screener/types.test.ts
+++ b/web-ui/src/features/screener/types.test.ts
@@ -85,4 +85,96 @@ describe('transformScreenerResponse', () => {
     expect(result.candidates[0].decisionSummary?.valuationContext.priceToBook).toBe(5.4);
     expect(result.candidates[0].decisionSummary?.valuationContext.fairValueBase).toBe(107.32);
   });
+
+  it('maps data source summary from API payload', () => {
+    const apiResponse: ScreenerResponseAPI = {
+      asof_date: '2026-03-02',
+      total_screened: 1,
+      data_freshness: 'final_close',
+      candidates: [
+        {
+          ticker: 'AAPL',
+          close: 100,
+          sma_20: 99,
+          sma_50: 95,
+          sma_200: 90,
+          atr: 2,
+          momentum_6m: 0.2,
+          momentum_12m: 0.3,
+          rel_strength: 1.1,
+          score: 0.8,
+          confidence: 78,
+          rank: 1,
+          data_source_summary: {
+            market_data: {
+              provider: 'yfinance',
+              status: 'ok',
+              quality_score: 0.65,
+              delay_policy: 'delayed_or_eod',
+              warnings: ['unofficial_provider'],
+            },
+            fundamentals: {
+              provider: 'sec_edgar',
+              status: 'ok',
+              quality_score: 0.9,
+            },
+          },
+        },
+      ],
+    };
+
+    const result = transformScreenerResponse(apiResponse);
+
+    expect(result.candidates[0].dataSourceSummary?.marketData?.provider).toBe('yfinance');
+    expect(result.candidates[0].dataSourceSummary?.marketData?.qualityScore).toBe(0.65);
+    expect(result.candidates[0].dataSourceSummary?.marketData?.delayPolicy).toBe('delayed_or_eod');
+    expect(result.candidates[0].dataSourceSummary?.marketData?.warnings).toEqual(['unofficial_provider']);
+    expect(result.candidates[0].dataSourceSummary?.fundamentals?.provider).toBe('sec_edgar');
+  });
+
+  it('maps camelCase data source summary from API payload', () => {
+    const apiResponse: ScreenerResponseAPI = {
+      asof_date: '2026-03-02',
+      total_screened: 1,
+      data_freshness: 'final_close',
+      candidates: [
+        {
+          ticker: 'MSFT',
+          close: 300,
+          sma_20: 295,
+          sma_50: 290,
+          sma_200: 280,
+          atr: 5,
+          momentum_6m: 0.15,
+          momentum_12m: 0.22,
+          rel_strength: 1.05,
+          score: 0.75,
+          confidence: 72,
+          rank: 2,
+          dataSourceSummary: {
+            marketData: {
+              provider: 'alpaca',
+              status: 'degraded',
+              qualityScore: 0.8,
+              delayPolicy: 'intraday',
+              warnings: ['limited_history'],
+            },
+            calendar: {
+              provider: 'finnhub',
+              status: 'ok',
+              qualityScore: 0.85,
+            },
+          },
+        },
+      ],
+    };
+
+    const result = transformScreenerResponse(apiResponse);
+
+    expect(result.candidates[0].dataSourceSummary?.marketData?.provider).toBe('alpaca');
+    expect(result.candidates[0].dataSourceSummary?.marketData?.status).toBe('degraded');
+    expect(result.candidates[0].dataSourceSummary?.marketData?.qualityScore).toBe(0.8);
+    expect(result.candidates[0].dataSourceSummary?.marketData?.delayPolicy).toBe('intraday');
+    expect(result.candidates[0].dataSourceSummary?.calendar?.provider).toBe('finnhub');
+  });
 });

--- a/web-ui/src/features/screener/types.ts
+++ b/web-ui/src/features/screener/types.ts
@@ -93,6 +93,21 @@ export interface DecisionSummary {
   catalystSources: string[];
 }
 
+export interface DataSourceHealth {
+  provider: string;
+  status: 'ok' | 'degraded' | 'failed' | 'unknown';
+  qualityScore: number;
+  delayPolicy?: string;
+  warnings: string[];
+}
+
+export interface CandidateDataSourceSummary {
+  marketData?: DataSourceHealth;
+  fundamentals?: DataSourceHealth;
+  calendar?: DataSourceHealth;
+  intelligence?: DataSourceHealth;
+}
+
 export interface ScreenerCandidate {
   ticker: string;
   currency: string;
@@ -141,6 +156,7 @@ export interface ScreenerCandidate {
   volumeRatio?: number;
   avgDailyVolumeEur?: number;
   weeklyTrend?: 'up' | 'down' | 'neutral';
+  dataSourceSummary?: CandidateDataSourceSummary;
 }
 
 export interface DecisionTradePlanAPI {
@@ -259,6 +275,8 @@ export interface ScreenerCandidateAPI {
   volume_ratio?: number;
   avg_daily_volume_eur?: number;
   weekly_trend?: 'up' | 'down' | 'neutral' | null;
+  data_source_summary?: Record<string, unknown> | null;
+  dataSourceSummary?: Record<string, unknown> | null;
 }
 
 export interface ScreenerRequest {
@@ -402,6 +420,44 @@ function transformDecisionSummary(apiSummary: DecisionSummaryAPI): DecisionSumma
   };
 }
 
+const sourceStatuses: DataSourceHealth['status'][] = ['ok', 'degraded', 'failed', 'unknown'];
+
+function transformDataSourceHealth(value: unknown): DataSourceHealth | undefined {
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+
+  const payload = value as Record<string, unknown>;
+  const rawStatus = String(payload.status ?? 'unknown');
+
+  return {
+    provider: String(payload.provider ?? ''),
+    status: sourceStatuses.includes(rawStatus as DataSourceHealth['status'])
+      ? rawStatus as DataSourceHealth['status']
+      : 'unknown',
+    qualityScore: Number(payload.quality_score ?? payload.qualityScore ?? 0.5),
+    delayPolicy: payload.delay_policy || payload.delayPolicy
+      ? String(payload.delay_policy ?? payload.delayPolicy)
+      : undefined,
+    warnings: Array.isArray(payload.warnings) ? payload.warnings.map(String) : [],
+  };
+}
+
+function transformDataSourceSummary(value: unknown): CandidateDataSourceSummary {
+  if (!value || typeof value !== 'object') {
+    return {};
+  }
+
+  const payload = value as Record<string, unknown>;
+
+  return {
+    marketData: transformDataSourceHealth(payload.market_data ?? payload.marketData),
+    fundamentals: transformDataSourceHealth(payload.fundamentals),
+    calendar: transformDataSourceHealth(payload.calendar),
+    intelligence: transformDataSourceHealth(payload.intelligence),
+  };
+}
+
 // Transform API response to UI format
 export function transformScreenerResponse(apiResponse: ScreenerResponseAPI): ScreenerResponse {
   return {
@@ -466,6 +522,7 @@ export function transformScreenerResponse(apiResponse: ScreenerResponseAPI): Scr
       volumeRatio: c.volume_ratio ?? undefined,
       avgDailyVolumeEur: c.avg_daily_volume_eur ?? undefined,
       weeklyTrend: c.weekly_trend ?? undefined,
+      dataSourceSummary: transformDataSourceSummary(c.data_source_summary ?? c.dataSourceSummary),
     })),
     asofDate: apiResponse.asof_date,
     totalScreened: apiResponse.total_screened,


### PR DESCRIPTION
## Summary
- Add shared source-health/provenance models and surface market provider quality in screener candidates.
- Enrich fundamentals and calendar data with source health, confidence, SEC filing fields, and ranking confidence modifiers.
- Show data-source context in the workspace UI and document roadmap-only paid providers without enabling them.

## Verification
- `pytest tests/data/test_source_health.py tests/test_fundamentals_service.py tests/test_fundamentals_scoring.py tests/test_sec_edgar_fundamentals_provider.py tests/test_fundamentals_snapshot_roundtrip.py tests/test_calendar_service.py tests/test_combined_priority.py tests/api/test_screener_endpoints.py tests/test_tier1_stack_smoke.py -q` -> 98 passed
- `cd web-ui && npm test -- src/features/screener/types.test.ts src/components/domain/workspace/AnalysisDecisionStrip.test.tsx --run` -> 15 passed
- `cd web-ui && npm run typecheck` -> passed
- `git diff --check` -> passed