### PR TITLE
refactor: remove dead code and deduplicate _to_iso across services

### DIFF
--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -12,8 +12,10 @@ from api.repositories.config_repo import ConfigRepository
 from api.repositories.fundamentals_config_repo import FundamentalsConfigRepository
 from api.repositories.orders_repo import OrdersRepository
 from api.repositories.positions_repo import PositionsRepository
+from api.repositories.screener_history_repo import ScreenerHistoryRepository
 from api.repositories.strategy_repo import StrategyRepository
 from api.repositories.watchlist_repo import WatchlistRepository
+from api.repositories.weekly_reviews_repo import WeeklyReviewsRepository
 from api.services.fundamentals_service import FundamentalsService
 from api.services.orders_service import OrdersService
 from api.services.portfolio_service import PortfolioService
@@ -155,15 +157,11 @@ def get_fundamentals_service(
 
 
 
-from api.repositories.screener_history_repo import ScreenerHistoryRepository
-
 SCREENER_HISTORY_FILE = DATA_DIR / "screener_history.json"
 
 def get_screener_history_repo() -> ScreenerHistoryRepository:
     return ScreenerHistoryRepository(SCREENER_HISTORY_FILE)
 
-
-from api.repositories.weekly_reviews_repo import WeeklyReviewsRepository
 
 WEEKLY_REVIEWS_FILE = DATA_DIR / "weekly_reviews.json"
 

--- a/api/models/recommendation.py
+++ b/api/models/recommendation.py
@@ -50,47 +50,6 @@ class RecommendationEducation(BaseModel):
     what_would_make_valid: list[str] = Field(default_factory=list)
 
 
-class RecommendationBeginnerExplanation(BaseModel):
-    text: str
-    source: Literal["llm", "deterministic_fallback"]
-    model: Optional[str] = None
-    generated_at: Optional[str] = None
-
-
-class RecommendationGeneratedEducationError(BaseModel):
-    view: Literal["recommendation", "thesis", "learn"]
-    code: str
-    message: str
-    retryable: bool = False
-    provider_error_id: Optional[str] = None
-
-
-class RecommendationGeneratedEducationView(BaseModel):
-    title: str
-    summary: str
-    bullets: list[str] = Field(default_factory=list)
-    watchouts: list[str] = Field(default_factory=list)
-    next_steps: list[str] = Field(default_factory=list)
-    glossary_links: list[str] = Field(default_factory=list)
-    facts_used: list[str] = Field(default_factory=list)
-    source: Literal["llm", "deterministic_fallback"]
-    template_version: str = "v1"
-    generated_at: str
-    debug_ref: Optional[str] = None
-
-
-class RecommendationGeneratedEducationPayload(BaseModel):
-    recommendation: Optional[RecommendationGeneratedEducationView] = None
-    thesis: Optional[RecommendationGeneratedEducationView] = None
-    learn: Optional[RecommendationGeneratedEducationView] = None
-    generated_at: Optional[str] = None
-    status: Optional[Literal["ok", "partial", "error"]] = None
-    source: Optional[Literal["llm", "deterministic_fallback", "cache"]] = None
-    template_version: Optional[str] = None
-    deterministic_facts: dict[str, str] = Field(default_factory=dict)
-    errors: list[RecommendationGeneratedEducationError] = Field(default_factory=list)
-
-
 class Recommendation(BaseModel):
     verdict: RecommendationVerdict
     reasons_short: list[str]

--- a/api/services/portfolio_service.py
+++ b/api/services/portfolio_service.py
@@ -29,6 +29,7 @@ from api.models.portfolio import (
 from api.repositories.config_repo import ConfigRepository
 from api.repositories.positions_repo import PositionsRepository
 from api.utils.files import get_today_str
+from api.utils.converters import to_iso as _to_iso
 from swing_screener.portfolio.state import (
     ManageConfig as ManageStateConfig,
     Position as StatePosition,
@@ -46,11 +47,6 @@ from swing_screener.portfolio.metrics import (
 from swing_screener.utils.date_helpers import get_default_history_start
 
 logger = logging.getLogger(__name__)
-
-
-def _resolve_isin(ticker: str) -> Optional[str]:
-    """Return an ISIN when one is provided by supported static metadata."""
-    return None
 
 
 # Simple cache for EURUSD rate with 5-minute TTL
@@ -94,18 +90,6 @@ def _country_from_ticker(ticker: str) -> str:
         if upper.endswith(suffix):
             return country
     return "US"
-
-
-def _to_iso(ts) -> Optional[str]:
-    if ts is None or pd.isna(ts):
-        return None
-    if isinstance(ts, pd.Timestamp):
-        ts = ts.to_pydatetime()
-    if isinstance(ts, dt.datetime):
-        return ts.isoformat()
-    if isinstance(ts, dt.date):
-        return dt.datetime.combine(ts, dt.time()).isoformat()
-    return str(ts)
 
 
 def _last_close_map(ohlcv: pd.DataFrame) -> tuple[dict[str, float], dict[str, str]]:
@@ -690,7 +674,7 @@ class PortfolioService:
         ticker = request.ticker.upper()
         position_id = f"POS-{uuid.uuid4().hex[:8].upper()}"
         initial_risk = round(request.entry_price - request.stop_price, 4)
-        isin = request.isin or _resolve_isin(ticker)
+        isin = request.isin
 
         new_position: dict = {
             "position_id": position_id,

--- a/api/services/screener_service.py
+++ b/api/services/screener_service.py
@@ -52,6 +52,7 @@ from swing_screener.strategy.config import (
     build_universe_config,
 )
 from swing_screener.risk.regime import compute_regime_risk_multiplier
+from api.utils.converters import to_iso as _to_iso
 
 # Map of removed universe ids to their replacements (or None if dropped with no replacement).
 _REMOVED_UNIVERSE_IDS: dict[str, str | None] = {
@@ -285,18 +286,6 @@ def _resolve_data_freshness(asof_date: str, now_utc: dt.datetime, currencies: li
     if resolved > now_utc.date():
         return "intraday"
     return "final_close" if _all_markets_closed(now_utc, currencies) else "intraday"
-
-
-def _to_iso(ts) -> Optional[str]:
-    if ts is None or pd.isna(ts):
-        return None
-    if isinstance(ts, pd.Timestamp):
-        ts = ts.to_pydatetime()
-    if isinstance(ts, dt.datetime):
-        return ts.isoformat()
-    if isinstance(ts, dt.date):
-        return dt.datetime.combine(ts, dt.time()).isoformat()
-    return str(ts)
 
 
 def _to_date_iso(ts) -> Optional[str]:

--- a/api/services/watchlist_service.py
+++ b/api/services/watchlist_service.py
@@ -11,6 +11,7 @@ from api.models.screener import PriceHistoryPoint
 from api.models.watchlist import WatchItem, WatchlistItemView
 from api.repositories.strategy_repo import StrategyRepository
 from api.repositories.watchlist_repo import WatchlistRepository
+from api.utils.converters import to_iso as _to_iso
 from api.utils.files import get_today_str
 from swing_screener.data.providers import MarketDataProvider, get_default_provider
 from swing_screener.selection.entries import build_signal_board
@@ -21,16 +22,6 @@ from swing_screener.utils.date_helpers import get_default_history_start
 logger = logging.getLogger(__name__)
 
 WATCHLIST_SPARKLINE_BARS = 5
-
-
-def _to_iso(ts) -> Optional[str]:
-    if ts is None or pd.isna(ts):
-        return None
-    if isinstance(ts, pd.Timestamp):
-        ts = ts.to_pydatetime()
-    if hasattr(ts, "isoformat"):
-        return ts.isoformat()
-    return str(ts)
 
 
 def _last_close_map(ohlcv: pd.DataFrame) -> tuple[dict[str, float], dict[str, str]]:

--- a/api/utils/converters.py
+++ b/api/utils/converters.py
@@ -1,0 +1,19 @@
+"""Shared type-conversion utilities for API services."""
+from __future__ import annotations
+
+import datetime as dt
+from typing import Optional
+
+import pandas as pd
+
+
+def to_iso(ts) -> Optional[str]:
+    if ts is None or pd.isna(ts):
+        return None
+    if isinstance(ts, pd.Timestamp):
+        ts = ts.to_pydatetime()
+    if isinstance(ts, dt.datetime):
+        return ts.isoformat()
+    if isinstance(ts, dt.date):
+        return dt.datetime.combine(ts, dt.time()).isoformat()
+    return str(ts)

--- a/src/swing_screener/cli.py
+++ b/src/swing_screener/cli.py
@@ -201,8 +201,6 @@ def main() -> None:
         ohlcv = provider.fetch_ohlcv(tickers, start_date="2022-01-01", end_date=end_date)
         exclude_tickers = None
         if args.positions:
-            from swing_screener.portfolio.state import load_positions
-
             positions = load_positions(args.positions)
             exclude_tickers = [
                 p.ticker for p in positions if p.status == "open"


### PR DESCRIPTION
- Delete 4 unused recommendation education model classes (BeginnerExplanation, GeneratedEducationError, GeneratedEducationView, GeneratedEducationPayload) — defined but never imported or referenced outside their file
- Extract _to_iso() to api/utils/converters.py; remove 3 per-service copies from screener_service, portfolio_service, watchlist_service
- Remove _resolve_isin() stub (always returned None); simplify call site to request.isin directly
- Remove duplicate load_positions import inside cli.py function body (already imported at module level)
- Move ScreenerHistoryRepository and WeeklyReviewsRepository imports to top-level block in dependencies.py; remove orphaned mid-file imports