### PR TITLE
feat(workspace): position-aware decision strip + portfolio nav fix

### DIFF
--- a/web-ui/src/components/domain/workspace/AnalysisDecisionStrip.tsx
+++ b/web-ui/src/components/domain/workspace/AnalysisDecisionStrip.tsx
@@ -5,12 +5,14 @@ import type {
   DecisionAction,
   DecisionConviction,
 } from '@/features/screener/types';
+import type { PositionWithMetrics } from '@/features/portfolio/api';
 import { t } from '@/i18n/t';
 import { formatCurrency, formatNumber } from '@/utils/formatters';
 
 interface AnalysisDecisionStripProps {
   ticker: string;
   candidate?: SymbolAnalysisCandidate | null;
+  position?: PositionWithMetrics | null;
   onPrepareOrder?: () => void;
   isWatched?: boolean;
   isPendingWatch?: boolean;
@@ -77,6 +79,7 @@ function sourceBadgeVariant(source: DataSourceHealth): 'success' | 'warning' | '
 export default function AnalysisDecisionStrip({
   ticker,
   candidate,
+  position,
   onPrepareOrder,
   isWatched,
   isPendingWatch,
@@ -85,21 +88,24 @@ export default function AnalysisDecisionStrip({
 }: AnalysisDecisionStripProps) {
   const summary = candidate?.decisionSummary;
   const currency = candidate?.currency ?? 'USD';
-  const closeEntry = summary?.tradePlan.entry ?? candidate?.recommendation?.risk?.entry ?? candidate?.entry;
+  const closeEntry = summary?.tradePlan.entry ?? candidate?.recommendation?.risk?.entry ?? candidate?.entry ?? position?.entryPrice ?? null;
   const suggestedOrderEntry = isPositiveNumber(candidate?.suggestedOrderPrice) ? candidate.suggestedOrderPrice : null;
   const usesSuggestedEntry =
     suggestedOrderEntry != null &&
     (!isPositiveNumber(closeEntry) || Math.abs(suggestedOrderEntry - closeEntry) >= 0.005);
   const entry = usesSuggestedEntry ? suggestedOrderEntry : closeEntry;
-  const stop = summary?.tradePlan.stop ?? candidate?.recommendation?.risk?.stop ?? candidate?.stop;
-  const target = summary?.tradePlan.target ?? candidate?.recommendation?.risk?.target;
+  const stop = summary?.tradePlan.stop ?? candidate?.recommendation?.risk?.stop ?? candidate?.stop ?? position?.stopPrice ?? null;
+  const target = summary?.tradePlan.target ?? candidate?.recommendation?.risk?.target ?? null;
   const computedRr = target != null && entry != null && stop != null && entry > stop
     ? (target - entry) / (entry - stop)
     : null;
-  const rr = computedRr ?? summary?.tradePlan.rr ?? candidate?.recommendation?.risk?.rr ?? candidate?.rr;
+  const rr = computedRr ?? summary?.tradePlan.rr ?? candidate?.recommendation?.risk?.rr ?? candidate?.rr ?? null;
   const oneR = entry != null && stop != null ? entry - stop : null;
   const pctToTarget = target != null && entry != null && entry > 0 ? (target - entry) / entry * 100 : null;
-  const riskPct = candidate?.recommendation?.risk?.riskPct;
+  const riskPct = candidate?.recommendation?.risk?.riskPct
+    ?? (position != null && isPositiveNumber(position.perShareRisk) && isPositiveNumber(position.entryPrice)
+      ? position.perShareRisk / position.entryPrice
+      : undefined);
   const entryLabel = usesSuggestedEntry
     ? t('workspacePage.panels.analysis.decisionSummary.tradePlan.plannedEntry')
     : t('workspacePage.panels.analysis.decisionSummary.tradePlan.entryClose');

--- a/web-ui/src/components/domain/workspace/ScreenerInboxPanel.tsx
+++ b/web-ui/src/components/domain/workspace/ScreenerInboxPanel.tsx
@@ -327,7 +327,7 @@ export default function ScreenerInboxPanel() {
 
       <div className="px-3 pt-3">
         <OpenPositionIntelligencePanel
-          onTickerSelect={(ticker) => setSelectedTicker(ticker, 'screener')}
+          onTickerSelect={(ticker) => setSelectedTicker(ticker, 'portfolio')}
         />
       </div>
 

--- a/web-ui/src/components/domain/workspace/SymbolAnalysisContent.tsx
+++ b/web-ui/src/components/domain/workspace/SymbolAnalysisContent.tsx
@@ -149,6 +149,7 @@ export default function SymbolAnalysisContent({
         <AnalysisDecisionStrip
           ticker={ticker}
           candidate={candidate}
+          position={position}
           onPrepareOrder={() => onTabChange('order')}
           isWatched={isWatched}
           isPendingWatch={isWatchPending}

--- a/web-ui/src/features/intelligence/api.test.ts
+++ b/web-ui/src/features/intelligence/api.test.ts
@@ -62,16 +62,28 @@ describe('candidateToPayload', () => {
     expect(payload!.days_open).toBe(12);
   });
 
-  it('position context does not overwrite candidate technical fields', () => {
+  it('position context does not overwrite stop/entry when position has no stopPrice', () => {
     const position = {
       entryPrice: 140,
       rNow: 1.5,
       daysOpen: 12,
     } as PositionWithMetrics;
     const payload = candidateToPayload({ ...baseCandidate, entry: 152, stop: 143 }, position);
-    expect(payload!.entry).toBe(152);
     expect(payload!.stop).toBe(143);
     expect(payload!.entry_price).toBe(140);
+  });
+
+  it('overrides stop and entry with position values when position has stopPrice', () => {
+    const position = {
+      entryPrice: 47.72,
+      stopPrice: 50.50,
+      rNow: 1.17,
+      daysOpen: 20,
+    } as PositionWithMetrics;
+    const payload = candidateToPayload({ ...baseCandidate, entry: 45.0, stop: 49.00 }, position);
+    expect(payload!.stop).toBe(50.50);
+    expect(payload!.entry).toBe(47.72);
+    expect(payload!.entry_price).toBe(47.72);
   });
 
   it('maps rr, atr, rel_strength and sector rotation fields from candidate fields', () => {

--- a/web-ui/src/features/intelligence/api.ts
+++ b/web-ui/src/features/intelligence/api.ts
@@ -77,6 +77,10 @@ export function candidateToPayload(
   payload.days_to_earnings = candidate.daysToEarnings ?? null;
   if (position != null) {
     payload.entry_price = position.entryPrice;
+    payload.entry = position.entryPrice;
+    if (position.stopPrice != null) {
+      payload.stop = position.stopPrice;
+    }
     payload.r_now = position.rNow;
     payload.days_open = position.daysOpen;
   }


### PR DESCRIPTION
- AnalysisDecisionStrip accepts optional position prop; falls back to position.entryPrice / stopPrice / perShareRisk when no candidate data
- SymbolAnalysisContent passes position down to the strip
- ScreenerInboxPanel: fix ticker source 'screener' → 'portfolio' when navigating from OpenPositionIntelligencePanel