### PR TITLE
fix(screener): pass real orders to same-symbol evaluator

### DIFF
--- a/agent/cli.py
+++ b/agent/cli.py
@@ -49,12 +49,30 @@ def _strategy_service():
     return StrategyService(strategy_repo=StrategyRepository())
 
 
+def _orders_service():
+    from api.repositories.orders_repo import OrdersRepository
+    from api.repositories.positions_repo import PositionsRepository
+    from api.services.orders_service import OrdersService
+    from api.utils.files import get_today_str, write_json_file
+    orders_path = _data_dir() / "orders.json"
+    if not orders_path.exists():
+        write_json_file(orders_path, {"asof": get_today_str(), "orders": []})
+    positions_path = _data_dir() / "positions.json"
+    if not positions_path.exists():
+        write_json_file(positions_path, {"asof": get_today_str(), "positions": []})
+    return OrdersService(
+        orders_repo=OrdersRepository(orders_path),
+        positions_repo=PositionsRepository(positions_path),
+    )
+
+
 def _screener_service():
     from api.repositories.strategy_repo import StrategyRepository
     from api.services.screener_service import ScreenerService
     return ScreenerService(
         strategy_repo=StrategyRepository(),
         portfolio_service=_portfolio_service(),
+        orders_service=_orders_service(),
     )
 
 

--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -141,8 +141,13 @@ def get_strategy_service(
 def get_screener_service(
     strategy_repo: StrategyRepository = Depends(get_strategy_repo),
     portfolio_service: PortfolioService = Depends(get_portfolio_service),
+    orders_service: OrdersService = Depends(get_orders_service),
 ) -> ScreenerService:
-    return ScreenerService(strategy_repo=strategy_repo, portfolio_service=portfolio_service)
+    return ScreenerService(
+        strategy_repo=strategy_repo,
+        portfolio_service=portfolio_service,
+        orders_service=orders_service,
+    )
 
 
 def get_fundamentals_service(

--- a/api/services/same_symbol_reentry.py
+++ b/api/services/same_symbol_reentry.py
@@ -23,15 +23,22 @@ def _safe_round(value: Optional[float], digits: int = 4) -> Optional[float]:
     return round(float(value), digits)
 
 
+def _order_field(order: object, key: str, default=None):
+    """Read an order attribute from either a model object or a raw dict."""
+    if isinstance(order, dict):
+        return order.get(key, default)
+    return getattr(order, key, default)
+
+
 def _count_add_ons_for_position(orders: list[object], position_id: Optional[str]) -> int:
     if not position_id:
         return 0
     filled_entries = [
         order
         for order in orders
-        if getattr(order, "status", None) == "filled"
-        and getattr(order, "position_id", None) == position_id
-        and getattr(order, "order_kind", None) == "entry"
+        if _order_field(order, "status") == "filled"
+        and _order_field(order, "position_id") == position_id
+        and _order_field(order, "order_kind") == "entry"
     ]
     return max(0, len(filled_entries) - 1)
 
@@ -39,9 +46,9 @@ def _count_add_ons_for_position(orders: list[object], position_id: Optional[str]
 def _has_pending_entry_for_ticker(orders: list[object], ticker: str) -> bool:
     normalized = ticker.upper()
     return any(
-        getattr(order, "status", None) in ("pending", "submitted")
-        and getattr(order, "ticker", "").upper() == normalized
-        and getattr(order, "order_kind", None) == "entry"
+        _order_field(order, "status") in ("pending", "submitted")
+        and str(_order_field(order, "ticker", "") or "").upper() == normalized
+        and _order_field(order, "order_kind") == "entry"
         for order in orders
     )
 

--- a/api/services/screener_service.py
+++ b/api/services/screener_service.py
@@ -676,14 +676,16 @@ def _safe_list(val):
 
 class ScreenerService:
     def __init__(
-        self, 
+        self,
         strategy_repo: StrategyRepository,
         portfolio_service: PortfolioService,
-        provider: Optional[MarketDataProvider] = None
+        provider: Optional[MarketDataProvider] = None,
+        orders_service=None,
     ) -> None:
         self._strategy_repo = strategy_repo
         self._portfolio_service = portfolio_service
         self._provider = provider or get_default_provider()
+        self._orders_service = orders_service
 
     def _resolve_strategy(self, strategy_id: Optional[str], strategy_override: Optional[dict] = None) -> dict:
         if strategy_override is not None:
@@ -1097,6 +1099,11 @@ class ScreenerService:
             portfolio_positions = self._portfolio_service.list_positions(status="open").positions
             portfolio_closed = self._portfolio_service.list_positions(status="closed").positions
             portfolio_orders: list = []
+            if self._orders_service is not None:
+                try:
+                    portfolio_orders = self._orders_service.list_local_orders().get("orders", [])
+                except Exception as exc:
+                    logger.warning("Failed to load orders for same-symbol evaluation: %s", exc)
             same_symbol_evaluator = SameSymbolReentryEvaluator(self._portfolio_service)
             same_symbol_suppressed_count = 0
             same_symbol_add_on_count = 0

--- a/data/intelligence/instrument_master.json
+++ b/data/intelligence/instrument_master.json
@@ -1,5 +1,24 @@
 [
   {
+    "symbol": "A2A.MI",
+    "exchange_mic": "XMIL",
+    "country_code": "IT",
+    "currency": "EUR",
+    "timezone": "Europe/Rome",
+    "provider_symbol_map": {
+      "yahoo_finance": "A2A.MI",
+      "stooq": "a2a.mi.it"
+    },
+    "primary_listing": true,
+    "status": "active",
+    "status_reason": null,
+    "replacement_symbol": null,
+    "source": "manual",
+    "source_asof": "2026-06-10",
+    "last_reviewed_at": "2026-06-10",
+    "instrument_type": "equity"
+  },
+  {
     "symbol": "AALB.AS",
     "exchange_mic": "XAMS",
     "country_code": "NL",
@@ -452,6 +471,25 @@
     "instrument_type": "equity"
   },
   {
+    "symbol": "AMP.MI",
+    "exchange_mic": "XMIL",
+    "country_code": "IT",
+    "currency": "EUR",
+    "timezone": "Europe/Rome",
+    "provider_symbol_map": {
+      "yahoo_finance": "AMP.MI",
+      "stooq": "amp.mi.it"
+    },
+    "primary_listing": true,
+    "status": "active",
+    "status_reason": null,
+    "replacement_symbol": null,
+    "source": "manual",
+    "source_asof": "2026-06-10",
+    "last_reviewed_at": "2026-06-10",
+    "instrument_type": "equity"
+  },
+  {
     "symbol": "AMZN",
     "exchange_mic": "XNAS",
     "country_code": "US",
@@ -685,6 +723,25 @@
     "instrument_type": "equity"
   },
   {
+    "symbol": "AZM.MI",
+    "exchange_mic": "XMIL",
+    "country_code": "IT",
+    "currency": "EUR",
+    "timezone": "Europe/Rome",
+    "provider_symbol_map": {
+      "yahoo_finance": "AZM.MI",
+      "stooq": "azm.mi.it"
+    },
+    "primary_listing": true,
+    "status": "active",
+    "status_reason": null,
+    "replacement_symbol": null,
+    "source": "manual",
+    "source_asof": "2026-06-10",
+    "last_reviewed_at": "2026-06-10",
+    "instrument_type": "equity"
+  },
+  {
     "symbol": "AZN",
     "exchange_mic": "XNYS",
     "country_code": "US",
@@ -796,6 +853,25 @@
     "source": "manual",
     "source_asof": "2026-04-11",
     "last_reviewed_at": "2026-04-11",
+    "instrument_type": "equity"
+  },
+  {
+    "symbol": "BAMI.MI",
+    "exchange_mic": "XMIL",
+    "country_code": "IT",
+    "currency": "EUR",
+    "timezone": "Europe/Rome",
+    "provider_symbol_map": {
+      "yahoo_finance": "BAMI.MI",
+      "stooq": "bami.mi.it"
+    },
+    "primary_listing": true,
+    "status": "active",
+    "status_reason": null,
+    "replacement_symbol": null,
+    "source": "manual",
+    "source_asof": "2026-06-10",
+    "last_reviewed_at": "2026-06-10",
     "instrument_type": "equity"
   },
   {
@@ -1122,6 +1198,25 @@
     "instrument_type": "equity"
   },
   {
+    "symbol": "BMED.MI",
+    "exchange_mic": "XMIL",
+    "country_code": "IT",
+    "currency": "EUR",
+    "timezone": "Europe/Rome",
+    "provider_symbol_map": {
+      "yahoo_finance": "BMED.MI",
+      "stooq": "bmed.mi.it"
+    },
+    "primary_listing": true,
+    "status": "active",
+    "status_reason": null,
+    "replacement_symbol": null,
+    "source": "manual",
+    "source_asof": "2026-06-10",
+    "last_reviewed_at": "2026-06-10",
+    "instrument_type": "equity"
+  },
+  {
     "symbol": "BMO",
     "exchange_mic": "XNYS",
     "country_code": "US",
@@ -1138,6 +1233,25 @@
     "source": "manual",
     "source_asof": "2026-04-11",
     "last_reviewed_at": "2026-04-11",
+    "instrument_type": "equity"
+  },
+  {
+    "symbol": "BMPS.MI",
+    "exchange_mic": "XMIL",
+    "country_code": "IT",
+    "currency": "EUR",
+    "timezone": "Europe/Rome",
+    "provider_symbol_map": {
+      "yahoo_finance": "BMPS.MI",
+      "stooq": "bmps.mi.it"
+    },
+    "primary_listing": true,
+    "status": "active",
+    "status_reason": null,
+    "replacement_symbol": null,
+    "source": "manual",
+    "source_asof": "2026-06-10",
+    "last_reviewed_at": "2026-06-10",
     "instrument_type": "equity"
   },
   {
@@ -1255,6 +1369,25 @@
     "instrument_type": "equity"
   },
   {
+    "symbol": "BPE.MI",
+    "exchange_mic": "XMIL",
+    "country_code": "IT",
+    "currency": "EUR",
+    "timezone": "Europe/Rome",
+    "provider_symbol_map": {
+      "yahoo_finance": "BPE.MI",
+      "stooq": "bpe.mi.it"
+    },
+    "primary_listing": true,
+    "status": "active",
+    "status_reason": null,
+    "replacement_symbol": null,
+    "source": "manual",
+    "source_asof": "2026-06-10",
+    "last_reviewed_at": "2026-06-10",
+    "instrument_type": "equity"
+  },
+  {
     "symbol": "BRK-B",
     "exchange_mic": "XNYS",
     "country_code": "US",
@@ -1328,6 +1461,25 @@
     "source": "manual",
     "source_asof": "2026-04-11",
     "last_reviewed_at": "2026-04-11",
+    "instrument_type": "equity"
+  },
+  {
+    "symbol": "BUZZI.MI",
+    "exchange_mic": "XMIL",
+    "country_code": "IT",
+    "currency": "EUR",
+    "timezone": "Europe/Rome",
+    "provider_symbol_map": {
+      "yahoo_finance": "BUZZI.MI",
+      "stooq": "buzzi.mi.it"
+    },
+    "primary_listing": true,
+    "status": "active",
+    "status_reason": null,
+    "replacement_symbol": null,
+    "source": "manual",
+    "source_asof": "2026-06-10",
+    "last_reviewed_at": "2026-06-10",
     "instrument_type": "equity"
   },
   {
@@ -1502,6 +1654,25 @@
     "instrument_type": "equity"
   },
   {
+    "symbol": "CNH.MI",
+    "exchange_mic": "XMIL",
+    "country_code": "IT",
+    "currency": "EUR",
+    "timezone": "Europe/Rome",
+    "provider_symbol_map": {
+      "yahoo_finance": "CNH.MI",
+      "stooq": "cnh.mi.it"
+    },
+    "primary_listing": true,
+    "status": "active",
+    "status_reason": null,
+    "replacement_symbol": null,
+    "source": "manual",
+    "source_asof": "2026-06-10",
+    "last_reviewed_at": "2026-06-10",
+    "instrument_type": "equity"
+  },
+  {
     "symbol": "CNI",
     "exchange_mic": "XNYS",
     "country_code": "US",
@@ -1613,6 +1784,25 @@
     "source": "manual",
     "source_asof": "2026-04-11",
     "last_reviewed_at": "2026-04-11",
+    "instrument_type": "equity"
+  },
+  {
+    "symbol": "CPR.MI",
+    "exchange_mic": "XMIL",
+    "country_code": "IT",
+    "currency": "EUR",
+    "timezone": "Europe/Rome",
+    "provider_symbol_map": {
+      "yahoo_finance": "CPR.MI",
+      "stooq": "cpr.mi.it"
+    },
+    "primary_listing": true,
+    "status": "active",
+    "status_reason": null,
+    "replacement_symbol": null,
+    "source": "manual",
+    "source_asof": "2026-06-10",
+    "last_reviewed_at": "2026-06-10",
     "instrument_type": "equity"
   },
   {
@@ -2002,6 +2192,25 @@
     "instrument_type": "etf"
   },
   {
+    "symbol": "DIA.MI",
+    "exchange_mic": "XMIL",
+    "country_code": "IT",
+    "currency": "EUR",
+    "timezone": "Europe/Rome",
+    "provider_symbol_map": {
+      "yahoo_finance": "DIA.MI",
+      "stooq": "dia.mi.it"
+    },
+    "primary_listing": true,
+    "status": "active",
+    "status_reason": null,
+    "replacement_symbol": null,
+    "source": "manual",
+    "source_asof": "2026-06-10",
+    "last_reviewed_at": "2026-06-10",
+    "instrument_type": "equity"
+  },
+  {
     "symbol": "DIS",
     "exchange_mic": "XNAS",
     "country_code": "US",
@@ -2018,6 +2227,25 @@
     "source": "manual",
     "source_asof": "2026-04-11",
     "last_reviewed_at": "2026-04-11",
+    "instrument_type": "equity"
+  },
+  {
+    "symbol": "DLGI.MI",
+    "exchange_mic": "XMIL",
+    "country_code": "IT",
+    "currency": "EUR",
+    "timezone": "Europe/Rome",
+    "provider_symbol_map": {
+      "yahoo_finance": "DLGI.MI",
+      "stooq": "dlgi.mi.it"
+    },
+    "primary_listing": true,
+    "status": "active",
+    "status_reason": null,
+    "replacement_symbol": null,
+    "source": "manual",
+    "source_asof": "2026-06-10",
+    "last_reviewed_at": "2026-06-10",
     "instrument_type": "equity"
   },
   {
@@ -2254,6 +2482,25 @@
     "instrument_type": "equity"
   },
   {
+    "symbol": "ERG.MI",
+    "exchange_mic": "XMIL",
+    "country_code": "IT",
+    "currency": "EUR",
+    "timezone": "Europe/Rome",
+    "provider_symbol_map": {
+      "yahoo_finance": "ERG.MI",
+      "stooq": "erg.mi.it"
+    },
+    "primary_listing": true,
+    "status": "active",
+    "status_reason": null,
+    "replacement_symbol": null,
+    "source": "manual",
+    "source_asof": "2026-06-10",
+    "last_reviewed_at": "2026-06-10",
+    "instrument_type": "equity"
+  },
+  {
     "symbol": "EUNL.DE",
     "exchange_mic": "XETR",
     "country_code": "DE",
@@ -2371,6 +2618,25 @@
     "source": "manual",
     "source_asof": "2026-04-11",
     "last_reviewed_at": "2026-04-11",
+    "instrument_type": "equity"
+  },
+  {
+    "symbol": "FBK.MI",
+    "exchange_mic": "XMIL",
+    "country_code": "IT",
+    "currency": "EUR",
+    "timezone": "Europe/Rome",
+    "provider_symbol_map": {
+      "yahoo_finance": "FBK.MI",
+      "stooq": "fbk.mi.it"
+    },
+    "primary_listing": true,
+    "status": "active",
+    "status_reason": null,
+    "replacement_symbol": null,
+    "source": "manual",
+    "source_asof": "2026-06-10",
+    "last_reviewed_at": "2026-06-10",
     "instrument_type": "equity"
   },
   {
@@ -2504,6 +2770,25 @@
     "source": "manual",
     "source_asof": "2026-04-11",
     "last_reviewed_at": "2026-04-11",
+    "instrument_type": "equity"
+  },
+  {
+    "symbol": "G.MI",
+    "exchange_mic": "XMIL",
+    "country_code": "IT",
+    "currency": "EUR",
+    "timezone": "Europe/Rome",
+    "provider_symbol_map": {
+      "yahoo_finance": "G.MI",
+      "stooq": "g.mi.it"
+    },
+    "primary_listing": true,
+    "status": "active",
+    "status_reason": null,
+    "replacement_symbol": null,
+    "source": "manual",
+    "source_asof": "2026-06-10",
+    "last_reviewed_at": "2026-06-10",
     "instrument_type": "equity"
   },
   {
@@ -2868,6 +3153,25 @@
     "instrument_type": "equity"
   },
   {
+    "symbol": "HER.MI",
+    "exchange_mic": "XMIL",
+    "country_code": "IT",
+    "currency": "EUR",
+    "timezone": "Europe/Rome",
+    "provider_symbol_map": {
+      "yahoo_finance": "HER.MI",
+      "stooq": "her.mi.it"
+    },
+    "primary_listing": true,
+    "status": "active",
+    "status_reason": null,
+    "replacement_symbol": null,
+    "source": "manual",
+    "source_asof": "2026-06-10",
+    "last_reviewed_at": "2026-06-10",
+    "instrument_type": "equity"
+  },
+  {
     "symbol": "HII",
     "exchange_mic": "XNYS",
     "country_code": "US",
@@ -3194,6 +3498,25 @@
     "instrument_type": "equity"
   },
   {
+    "symbol": "IG.MI",
+    "exchange_mic": "XMIL",
+    "country_code": "IT",
+    "currency": "EUR",
+    "timezone": "Europe/Rome",
+    "provider_symbol_map": {
+      "yahoo_finance": "IG.MI",
+      "stooq": "ig.mi.it"
+    },
+    "primary_listing": true,
+    "status": "active",
+    "status_reason": null,
+    "replacement_symbol": null,
+    "source": "manual",
+    "source_asof": "2026-06-10",
+    "last_reviewed_at": "2026-06-10",
+    "instrument_type": "equity"
+  },
+  {
     "symbol": "IHE",
     "exchange_mic": "ARCX",
     "country_code": "US",
@@ -3381,6 +3704,44 @@
     "source": "manual",
     "source_asof": "2026-04-11",
     "last_reviewed_at": "2026-04-11",
+    "instrument_type": "equity"
+  },
+  {
+    "symbol": "INW.MI",
+    "exchange_mic": "XMIL",
+    "country_code": "IT",
+    "currency": "EUR",
+    "timezone": "Europe/Rome",
+    "provider_symbol_map": {
+      "yahoo_finance": "INW.MI",
+      "stooq": "inw.mi.it"
+    },
+    "primary_listing": true,
+    "status": "active",
+    "status_reason": null,
+    "replacement_symbol": null,
+    "source": "manual",
+    "source_asof": "2026-06-10",
+    "last_reviewed_at": "2026-06-10",
+    "instrument_type": "equity"
+  },
+  {
+    "symbol": "IP.MI",
+    "exchange_mic": "XMIL",
+    "country_code": "IT",
+    "currency": "EUR",
+    "timezone": "Europe/Rome",
+    "provider_symbol_map": {
+      "yahoo_finance": "IP.MI",
+      "stooq": "ip.mi.it"
+    },
+    "primary_listing": true,
+    "status": "active",
+    "status_reason": null,
+    "replacement_symbol": null,
+    "source": "manual",
+    "source_asof": "2026-06-10",
+    "last_reviewed_at": "2026-06-10",
     "instrument_type": "equity"
   },
   {
@@ -3764,6 +4125,25 @@
     "instrument_type": "equity"
   },
   {
+    "symbol": "LDO.MI",
+    "exchange_mic": "XMIL",
+    "country_code": "IT",
+    "currency": "EUR",
+    "timezone": "Europe/Rome",
+    "provider_symbol_map": {
+      "yahoo_finance": "LDO.MI",
+      "stooq": "ldo.mi.it"
+    },
+    "primary_listing": true,
+    "status": "active",
+    "status_reason": null,
+    "replacement_symbol": null,
+    "source": "manual",
+    "source_asof": "2026-06-10",
+    "last_reviewed_at": "2026-06-10",
+    "instrument_type": "equity"
+  },
+  {
     "symbol": "LDOS",
     "exchange_mic": "XNYS",
     "country_code": "US",
@@ -3995,6 +4375,25 @@
     "instrument_type": "equity"
   },
   {
+    "symbol": "MB.MI",
+    "exchange_mic": "XMIL",
+    "country_code": "IT",
+    "currency": "EUR",
+    "timezone": "Europe/Rome",
+    "provider_symbol_map": {
+      "yahoo_finance": "MB.MI",
+      "stooq": "mb.mi.it"
+    },
+    "primary_listing": true,
+    "status": "active",
+    "status_reason": null,
+    "replacement_symbol": null,
+    "source": "manual",
+    "source_asof": "2026-06-10",
+    "last_reviewed_at": "2026-06-10",
+    "instrument_type": "equity"
+  },
+  {
     "symbol": "MBG.DE",
     "exchange_mic": "XETR",
     "country_code": "DE",
@@ -4188,6 +4587,25 @@
     "source": "manual",
     "source_asof": "2026-04-11",
     "last_reviewed_at": "2026-04-11",
+    "instrument_type": "equity"
+  },
+  {
+    "symbol": "MONC.MI",
+    "exchange_mic": "XMIL",
+    "country_code": "IT",
+    "currency": "EUR",
+    "timezone": "Europe/Rome",
+    "provider_symbol_map": {
+      "yahoo_finance": "MONC.MI",
+      "stooq": "monc.mi.it"
+    },
+    "primary_listing": true,
+    "status": "active",
+    "status_reason": null,
+    "replacement_symbol": null,
+    "source": "manual",
+    "source_asof": "2026-06-10",
+    "last_reviewed_at": "2026-06-10",
     "instrument_type": "equity"
   },
   {
@@ -4427,6 +4845,25 @@
     "source": "manual",
     "source_asof": "2026-04-11",
     "last_reviewed_at": "2026-04-11",
+    "instrument_type": "equity"
+  },
+  {
+    "symbol": "NEXI.MI",
+    "exchange_mic": "XMIL",
+    "country_code": "IT",
+    "currency": "EUR",
+    "timezone": "Europe/Rome",
+    "provider_symbol_map": {
+      "yahoo_finance": "NEXI.MI",
+      "stooq": "nexi.mi.it"
+    },
+    "primary_listing": true,
+    "status": "active",
+    "status_reason": null,
+    "replacement_symbol": null,
+    "source": "manual",
+    "source_asof": "2026-06-10",
+    "last_reviewed_at": "2026-06-10",
     "instrument_type": "equity"
   },
   {
@@ -4948,6 +5385,25 @@
     "instrument_type": "equity"
   },
   {
+    "symbol": "PIRC.MI",
+    "exchange_mic": "XMIL",
+    "country_code": "IT",
+    "currency": "EUR",
+    "timezone": "Europe/Rome",
+    "provider_symbol_map": {
+      "yahoo_finance": "PIRC.MI",
+      "stooq": "pirc.mi.it"
+    },
+    "primary_listing": true,
+    "status": "active",
+    "status_reason": null,
+    "replacement_symbol": null,
+    "source": "manual",
+    "source_asof": "2026-06-10",
+    "last_reviewed_at": "2026-06-10",
+    "instrument_type": "equity"
+  },
+  {
     "symbol": "PJP",
     "exchange_mic": "ARCX",
     "country_code": "US",
@@ -5062,6 +5518,44 @@
     "instrument_type": "equity"
   },
   {
+    "symbol": "PRY.MI",
+    "exchange_mic": "XMIL",
+    "country_code": "IT",
+    "currency": "EUR",
+    "timezone": "Europe/Rome",
+    "provider_symbol_map": {
+      "yahoo_finance": "PRY.MI",
+      "stooq": "pry.mi.it"
+    },
+    "primary_listing": true,
+    "status": "active",
+    "status_reason": null,
+    "replacement_symbol": null,
+    "source": "manual",
+    "source_asof": "2026-06-10",
+    "last_reviewed_at": "2026-06-10",
+    "instrument_type": "equity"
+  },
+  {
+    "symbol": "PST.MI",
+    "exchange_mic": "XMIL",
+    "country_code": "IT",
+    "currency": "EUR",
+    "timezone": "Europe/Rome",
+    "provider_symbol_map": {
+      "yahoo_finance": "PST.MI",
+      "stooq": "pst.mi.it"
+    },
+    "primary_listing": true,
+    "status": "active",
+    "status_reason": null,
+    "replacement_symbol": null,
+    "source": "manual",
+    "source_asof": "2026-06-10",
+    "last_reviewed_at": "2026-06-10",
+    "instrument_type": "equity"
+  },
+  {
     "symbol": "PUM.DE",
     "exchange_mic": "XETR",
     "country_code": "DE",
@@ -5138,6 +5632,25 @@
     "instrument_type": "etf"
   },
   {
+    "symbol": "RACE.MI",
+    "exchange_mic": "XMIL",
+    "country_code": "IT",
+    "currency": "EUR",
+    "timezone": "Europe/Rome",
+    "provider_symbol_map": {
+      "yahoo_finance": "RACE.MI",
+      "stooq": "race.mi.it"
+    },
+    "primary_listing": true,
+    "status": "active",
+    "status_reason": null,
+    "replacement_symbol": null,
+    "source": "manual",
+    "source_asof": "2026-06-10",
+    "last_reviewed_at": "2026-06-10",
+    "instrument_type": "equity"
+  },
+  {
     "symbol": "RAND.AS",
     "exchange_mic": "XAMS",
     "country_code": "NL",
@@ -5173,6 +5686,25 @@
     "source": "manual",
     "source_asof": "2026-04-11",
     "last_reviewed_at": "2026-04-11",
+    "instrument_type": "equity"
+  },
+  {
+    "symbol": "REC.MI",
+    "exchange_mic": "XMIL",
+    "country_code": "IT",
+    "currency": "EUR",
+    "timezone": "Europe/Rome",
+    "provider_symbol_map": {
+      "yahoo_finance": "REC.MI",
+      "stooq": "rec.mi.it"
+    },
+    "primary_listing": true,
+    "status": "active",
+    "status_reason": null,
+    "replacement_symbol": null,
+    "source": "manual",
+    "source_asof": "2026-06-10",
+    "last_reviewed_at": "2026-06-10",
     "instrument_type": "equity"
   },
   {
@@ -5915,6 +6447,25 @@
     "instrument_type": "equity"
   },
   {
+    "symbol": "SPM.MI",
+    "exchange_mic": "XMIL",
+    "country_code": "IT",
+    "currency": "EUR",
+    "timezone": "Europe/Rome",
+    "provider_symbol_map": {
+      "yahoo_finance": "SPM.MI",
+      "stooq": "spm.mi.it"
+    },
+    "primary_listing": true,
+    "status": "active",
+    "status_reason": null,
+    "replacement_symbol": null,
+    "source": "manual",
+    "source_asof": "2026-06-10",
+    "last_reviewed_at": "2026-06-10",
+    "instrument_type": "equity"
+  },
+  {
     "symbol": "SPPE.DE",
     "exchange_mic": "XETR",
     "country_code": "DE",
@@ -5956,6 +6507,25 @@
     "instrument_type": "etf"
   },
   {
+    "symbol": "SRG.MI",
+    "exchange_mic": "XMIL",
+    "country_code": "IT",
+    "currency": "EUR",
+    "timezone": "Europe/Rome",
+    "provider_symbol_map": {
+      "yahoo_finance": "SRG.MI",
+      "stooq": "srg.mi.it"
+    },
+    "primary_listing": true,
+    "status": "active",
+    "status_reason": null,
+    "replacement_symbol": null,
+    "source": "manual",
+    "source_asof": "2026-06-10",
+    "last_reviewed_at": "2026-06-10",
+    "instrument_type": "equity"
+  },
+  {
     "symbol": "SRPT",
     "exchange_mic": "XNAS",
     "country_code": "US",
@@ -5991,6 +6561,44 @@
     "source": "manual",
     "source_asof": "2026-04-11",
     "last_reviewed_at": "2026-04-11",
+    "instrument_type": "equity"
+  },
+  {
+    "symbol": "STLAM.MI",
+    "exchange_mic": "XMIL",
+    "country_code": "IT",
+    "currency": "EUR",
+    "timezone": "Europe/Rome",
+    "provider_symbol_map": {
+      "yahoo_finance": "STLAM.MI",
+      "stooq": "stlam.mi.it"
+    },
+    "primary_listing": true,
+    "status": "active",
+    "status_reason": null,
+    "replacement_symbol": null,
+    "source": "manual",
+    "source_asof": "2026-06-10",
+    "last_reviewed_at": "2026-06-10",
+    "instrument_type": "equity"
+  },
+  {
+    "symbol": "STM.MI",
+    "exchange_mic": "XMIL",
+    "country_code": "IT",
+    "currency": "EUR",
+    "timezone": "Europe/Rome",
+    "provider_symbol_map": {
+      "yahoo_finance": "STM.MI",
+      "stooq": "stm.mi.it"
+    },
+    "primary_listing": true,
+    "status": "active",
+    "status_reason": null,
+    "replacement_symbol": null,
+    "source": "manual",
+    "source_asof": "2026-06-10",
+    "last_reviewed_at": "2026-06-10",
     "instrument_type": "equity"
   },
   {
@@ -6225,6 +6833,25 @@
     "instrument_type": "equity"
   },
   {
+    "symbol": "TEN.MI",
+    "exchange_mic": "XMIL",
+    "country_code": "IT",
+    "currency": "EUR",
+    "timezone": "Europe/Rome",
+    "provider_symbol_map": {
+      "yahoo_finance": "TEN.MI",
+      "stooq": "ten.mi.it"
+    },
+    "primary_listing": true,
+    "status": "active",
+    "status_reason": null,
+    "replacement_symbol": null,
+    "source": "manual",
+    "source_asof": "2026-06-10",
+    "last_reviewed_at": "2026-06-10",
+    "instrument_type": "equity"
+  },
+  {
     "symbol": "TEVA",
     "exchange_mic": "XNYS",
     "country_code": "US",
@@ -6301,6 +6928,25 @@
     "source": "manual",
     "source_asof": "2026-04-11",
     "last_reviewed_at": "2026-04-11",
+    "instrument_type": "equity"
+  },
+  {
+    "symbol": "TIT.MI",
+    "exchange_mic": "XMIL",
+    "country_code": "IT",
+    "currency": "EUR",
+    "timezone": "Europe/Rome",
+    "provider_symbol_map": {
+      "yahoo_finance": "TIT.MI",
+      "stooq": "tit.mi.it"
+    },
+    "primary_listing": true,
+    "status": "active",
+    "status_reason": null,
+    "replacement_symbol": null,
+    "source": "manual",
+    "source_asof": "2026-06-10",
+    "last_reviewed_at": "2026-06-10",
     "instrument_type": "equity"
   },
   {
@@ -6399,6 +7045,25 @@
     "source": "manual",
     "source_asof": "2026-04-11",
     "last_reviewed_at": "2026-04-11",
+    "instrument_type": "equity"
+  },
+  {
+    "symbol": "TRN.MI",
+    "exchange_mic": "XMIL",
+    "country_code": "IT",
+    "currency": "EUR",
+    "timezone": "Europe/Rome",
+    "provider_symbol_map": {
+      "yahoo_finance": "TRN.MI",
+      "stooq": "trn.mi.it"
+    },
+    "primary_listing": true,
+    "status": "active",
+    "status_reason": null,
+    "replacement_symbol": null,
+    "source": "manual",
+    "source_asof": "2026-06-10",
+    "last_reviewed_at": "2026-06-10",
     "instrument_type": "equity"
   },
   {
@@ -6703,6 +7368,25 @@
     "source": "manual",
     "source_asof": "2026-04-11",
     "last_reviewed_at": "2026-04-11",
+    "instrument_type": "equity"
+  },
+  {
+    "symbol": "UNI.MI",
+    "exchange_mic": "XMIL",
+    "country_code": "IT",
+    "currency": "EUR",
+    "timezone": "Europe/Rome",
+    "provider_symbol_map": {
+      "yahoo_finance": "UNI.MI",
+      "stooq": "uni.mi.it"
+    },
+    "primary_listing": true,
+    "status": "active",
+    "status_reason": null,
+    "replacement_symbol": null,
+    "source": "manual",
+    "source_asof": "2026-06-10",
+    "last_reviewed_at": "2026-06-10",
     "instrument_type": "equity"
   },
   {

--- a/tests/api/test_screener_endpoints.py
+++ b/tests/api/test_screener_endpoints.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 from types import SimpleNamespace
 
 from api.main import app
-from api.dependencies import get_portfolio_service
+from api.dependencies import get_orders_service, get_portfolio_service
 import api.services.screener_service as screener_service
 from api.models.screener import ScreenerResponse
 from swing_screener.data.source_health import DataSourceHealth
@@ -699,6 +699,94 @@ def test_screener_returns_same_symbol_add_on_metadata(monkeypatch):
         assert body["candidates"][0]["recommendation"]["risk"]["stop"] == 19.63
     finally:
         app.dependency_overrides.pop(get_portfolio_service, None)
+
+
+def test_screener_pending_entry_order_blocks_add_on(monkeypatch):
+    ohlcv = _ohlcv_with_spy()
+    mock_provider = _create_mock_provider(ohlcv)
+
+    def fake_build_daily_report(ohlcv, cfg, exclude_tickers=None, sector_benchmark_returns=None):
+        idx = ["REP.MC"]
+        data = {
+            "atr14": [0.8],
+            "mom_6m": [0.15],
+            "mom_12m": [0.25],
+            "rs_6m": [0.05],
+            "score": [0.994],
+            "confidence": [92.7],
+            "last": [23.0],
+            "ma20_level": [22.0],
+            "dist_sma50_pct": [9.5],
+            "dist_sma200_pct": [22.0],
+            "rank": [1],
+            "signal": ["breakout"],
+            "entry": [22.83],
+            "stop": [21.62],
+            "shares": [5],
+            "position_value": [114.15],
+            "realized_risk": [6.05],
+        }
+        return pd.DataFrame(data, index=idx)
+
+    class StubPortfolioService:
+        def list_positions(self, status=None):
+            del status
+            return SimpleNamespace(
+                positions=[
+                    SimpleNamespace(
+                        ticker="REP.MC",
+                        status="open",
+                        position_id="POS-REP-1",
+                        entry_price=19.63,
+                        current_price=23.0,
+                        stop_price=19.63,
+                        shares=5,
+                        current_value=115.0,
+                    )
+                ]
+            )
+
+        def suggest_position_stop(self, position_id):
+            del position_id
+            return SimpleNamespace(action="NO_ACTION")
+
+    class StubOrdersService:
+        def list_local_orders(self, status=None):
+            del status
+            return {
+                "orders": [
+                    {
+                        "ticker": "REP.MC",
+                        "status": "pending",
+                        "order_kind": "entry",
+                        "position_id": None,
+                    }
+                ]
+            }
+
+    monkeypatch.setattr(screener_service, "get_default_provider", lambda **kwargs: mock_provider)
+    monkeypatch.setattr(screener_service, "build_daily_report", fake_build_daily_report)
+    monkeypatch.setattr(
+        screener_service,
+        "get_multiple_ticker_info",
+        lambda tickers: {"REP.MC": {"name": "Repsol", "sector": "Energy", "currency": "EUR"}},
+    )
+
+    app.dependency_overrides[get_portfolio_service] = lambda: StubPortfolioService()
+    app.dependency_overrides[get_orders_service] = lambda: StubOrdersService()
+    try:
+        client = TestClient(app)
+        res = client.post("/api/screener/run", json={"universe": "broad_market_stocks", "top": 20})
+        assert res.status_code == 200
+
+        body = res.json()
+        assert body["same_symbol_add_on_count"] == 0
+        candidate = body["candidates"][0]
+        assert candidate["same_symbol"]["pending_entry_exists"] is True
+        assert candidate["same_symbol"]["mode"] == "MANAGE_ONLY"
+    finally:
+        app.dependency_overrides.pop(get_portfolio_service, None)
+        app.dependency_overrides.pop(get_orders_service, None)
 
 
 def test_screener_invalid_currency_rejected():

--- a/tests/test_universe_snapshot.py
+++ b/tests/test_universe_snapshot.py
@@ -26,7 +26,7 @@ _CFG_NO_BENCH = UniverseConfig(benchmark="SPY", ensure_benchmark=False)
 
 def test_list_package_universes_count():
     ids = list_package_universes()
-    assert len(ids) == 14, f"Expected 14 universes, got {len(ids)}: {ids}"
+    assert len(ids) == 15, f"Expected 15 universes, got {len(ids)}: {ids}"
 
 
 def test_list_package_universes_contains_expected():
@@ -38,6 +38,7 @@ def test_list_package_universes_contains_expected():
         "defense_stocks", "defense_etfs",
         "healthcare_stocks", "healthcare_etfs",
         "semiconductor_stocks", "energy_stocks", "financial_stocks",
+        "italy_ftse_mib",
     }
     assert expected == set(ids)
 


### PR DESCRIPTION
PR #213 replaced the orders lookup with an empty list when list_orders moved off PortfolioService, leaving pending-entry suppression and add-on counting dead. Inject OrdersService into ScreenerService (API + CLI) and accept raw dict orders in the evaluator.