### PR TITLE
fix(screener): widen stage-1 ranking pool to top x prefilter_multiplier

### DIFF
--- a/api/services/screener_service.py
+++ b/api/services/screener_service.py
@@ -856,8 +856,11 @@ class ScreenerService:
                 universe_cfg = replace(universe_cfg, filt=replace(filt, require_weekly_uptrend=request.require_weekly_uptrend))
 
             ranking_cfg = build_ranking_config(strategy)
-            if ranking_cfg.top_n < requested_top:
-                ranking_cfg = replace(ranking_cfg, top_n=requested_top)
+            # Rank a pool of top * prefilter_multiplier so the combined-priority
+            # stage can re-rank beyond the requested top-N (stage 1 of 2).
+            prefilter_pool = requested_top * combined_priority_cfg.prefilter_multiplier
+            if ranking_cfg.top_n < prefilter_pool:
+                ranking_cfg = replace(ranking_cfg, top_n=prefilter_pool)
 
             signals_cfg = build_entry_config(strategy)
             if "breakout_lookback" in fields_set and request.breakout_lookback is not None:

--- a/tests/api/test_screener_endpoints.py
+++ b/tests/api/test_screener_endpoints.py
@@ -701,6 +701,47 @@ def test_screener_returns_same_symbol_add_on_metadata(monkeypatch):
         app.dependency_overrides.pop(get_portfolio_service, None)
 
 
+def test_screener_widens_ranking_pool_for_combined_priority(monkeypatch):
+    """Stage 1 must rank a pool of top * prefilter_multiplier candidates so the
+    combined-priority stage can actually re-rank beyond the requested top-N."""
+    from swing_screener.recommendation.priority import CombinedPriorityConfig
+
+    ohlcv = _ohlcv_with_spy()
+    mock_provider = _create_mock_provider(ohlcv)
+    captured: dict = {}
+
+    def fake_build_daily_report(ohlcv, cfg, exclude_tickers=None, sector_benchmark_returns=None):
+        captured["ranking_top_n"] = cfg.ranking.top_n
+        idx = [f"T{i:03d}" for i in range(min(cfg.ranking.top_n, 200))]
+        data = {
+            "atr14": [1.2] * len(idx),
+            "mom_6m": [0.1] * len(idx),
+            "mom_12m": [0.2] * len(idx),
+            "rs_6m": [0.05] * len(idx),
+            "score": [0.5] * len(idx),
+            "confidence": [80.0 - i for i in range(len(idx))],
+            "last": [20.0] * len(idx),
+            "ma20_level": [19.0] * len(idx),
+            "dist_sma50_pct": [5.0] * len(idx),
+            "dist_sma200_pct": [15.0] * len(idx),
+            "rank": list(range(1, len(idx) + 1)),
+            "signal": ["breakout"] * len(idx),
+        }
+        return pd.DataFrame(data, index=idx)
+
+    monkeypatch.setattr(screener_service, "get_default_provider", lambda **kwargs: mock_provider)
+    monkeypatch.setattr(screener_service, "build_daily_report", fake_build_daily_report)
+    monkeypatch.setattr(screener_service, "get_multiple_ticker_info", lambda tickers: {})
+
+    client = TestClient(app)
+    res = client.post("/api/screener/run", json={"universe": "broad_market_stocks", "top": 50})
+    assert res.status_code == 200
+
+    multiplier = CombinedPriorityConfig().prefilter_multiplier
+    assert captured["ranking_top_n"] >= 50 * multiplier
+    assert len(res.json()["candidates"]) == 50
+
+
 def test_screener_pending_entry_order_blocks_add_on(monkeypatch):
     ohlcv = _ohlcv_with_spy()
     mock_provider = _create_mock_provider(ohlcv)


### PR DESCRIPTION
ranking top_n was only raised to the requested top, so build_daily_report already trimmed results to top-N before the stage-1 prefilter head() ran, making the combined-priority re-rank a no-op whenever top * prefilter_multiplier exceeded the strategy's top_n.