### PR TITLE
perf(screener): fetch rolling OHLCV window instead of fixed 2022 start

### DIFF
--- a/api/services/screener_service.py
+++ b/api/services/screener_service.py
@@ -288,6 +288,24 @@ def _resolve_data_freshness(asof_date: str, now_utc: dt.datetime, currencies: li
     return "final_close" if _all_markets_closed(now_utc, currencies) else "intraday"
 
 
+_FETCH_TRADING_TO_CALENDAR = 1.45
+_FETCH_WINDOW_BUFFER_DAYS = 45
+_FETCH_MIN_BARS = 260
+
+
+def _resolve_fetch_start_date(asof_date: str, min_history: int) -> str:
+    """Start of the OHLCV fetch window: enough calendar days before asof to
+    yield at least max(min_history, 260) trading bars, instead of a fixed
+    start date whose window grows unbounded over time."""
+    try:
+        asof = dt.date.fromisoformat(asof_date)
+    except ValueError:
+        return "2022-01-01"
+    bars_needed = max(int(min_history), _FETCH_MIN_BARS)
+    calendar_days = math.ceil(bars_needed * _FETCH_TRADING_TO_CALENDAR) + _FETCH_WINDOW_BUFFER_DAYS
+    return (asof - dt.timedelta(days=calendar_days)).isoformat()
+
+
 def _to_date_iso(ts) -> Optional[str]:
     if ts is None or pd.isna(ts):
         return None
@@ -777,11 +795,15 @@ class ScreenerService:
             if len(tickers) <= 1 and benchmark in tickers:
                 raise HTTPException(status_code=404, detail="No tickers left after applying screener filters")
 
-            from swing_screener.data.market_data import MarketDataConfig
+            signals_cfg = build_entry_config(strategy)
+            if "breakout_lookback" in fields_set and request.breakout_lookback is not None:
+                signals_cfg = replace(signals_cfg, breakout_lookback=request.breakout_lookback)
+            if "pullback_ma" in fields_set and request.pullback_ma is not None:
+                signals_cfg = replace(signals_cfg, pullback_ma=request.pullback_ma)
+            if "min_history" in fields_set and request.min_history is not None:
+                signals_cfg = replace(signals_cfg, min_history=request.min_history)
 
-            # Note: MarketDataConfig is kept for backward compatibility
-            # but not passed to provider (provider has its own defaults)
-            start_date = "2022-01-01"
+            start_date = _resolve_fetch_start_date(asof_str, signals_cfg.min_history)
             end_date = asof_str
             sector_context_tickers = ["SPY", *sector_rotation.SECTOR_ETFS.keys()]
             sector_ohlcv = pd.DataFrame()
@@ -861,14 +883,6 @@ class ScreenerService:
             prefilter_pool = requested_top * combined_priority_cfg.prefilter_multiplier
             if ranking_cfg.top_n < prefilter_pool:
                 ranking_cfg = replace(ranking_cfg, top_n=prefilter_pool)
-
-            signals_cfg = build_entry_config(strategy)
-            if "breakout_lookback" in fields_set and request.breakout_lookback is not None:
-                signals_cfg = replace(signals_cfg, breakout_lookback=request.breakout_lookback)
-            if "pullback_ma" in fields_set and request.pullback_ma is not None:
-                signals_cfg = replace(signals_cfg, pullback_ma=request.pullback_ma)
-            if "min_history" in fields_set and request.min_history is not None:
-                signals_cfg = replace(signals_cfg, min_history=request.min_history)
 
             risk_cfg = build_risk_config(strategy)
             multiplier, regime_meta = compute_regime_risk_multiplier(ohlcv, benchmark, risk_cfg)

--- a/tests/api/test_screener_endpoints.py
+++ b/tests/api/test_screener_endpoints.py
@@ -701,6 +701,53 @@ def test_screener_returns_same_symbol_add_on_metadata(monkeypatch):
         app.dependency_overrides.pop(get_portfolio_service, None)
 
 
+def test_resolve_fetch_start_date_covers_min_history():
+    start = screener_service._resolve_fetch_start_date("2026-03-02", 260)
+    asof = dt.date.fromisoformat("2026-03-02")
+    window_days = (asof - dt.date.fromisoformat(start)).days
+    # Enough calendar days to yield >= 260 trading bars, but no multi-year window
+    assert window_days >= 260 * 1.4
+    assert window_days <= 600
+
+
+def test_resolve_fetch_start_date_grows_with_min_history():
+    short = screener_service._resolve_fetch_start_date("2026-03-02", 260)
+    long = screener_service._resolve_fetch_start_date("2026-03-02", 400)
+    assert dt.date.fromisoformat(long) < dt.date.fromisoformat(short)
+
+
+def test_screener_fetches_rolling_window_not_fixed_start(monkeypatch):
+    ohlcv = _ohlcv_with_spy()
+    mock_provider = _create_mock_provider(ohlcv)
+    captured: dict = {}
+
+    original_return = mock_provider.fetch_ohlcv.return_value
+
+    def record_fetch(tickers, start_date=None, end_date=None, **kwargs):
+        captured.setdefault("start_dates", []).append(start_date)
+        return original_return
+
+    mock_provider.fetch_ohlcv.side_effect = record_fetch
+
+    def fake_build_daily_report(ohlcv, cfg, exclude_tickers=None, sector_benchmark_returns=None):
+        return pd.DataFrame()
+
+    monkeypatch.setattr(screener_service, "get_default_provider", lambda **kwargs: mock_provider)
+    monkeypatch.setattr(screener_service, "build_daily_report", fake_build_daily_report)
+    monkeypatch.setattr(screener_service, "get_multiple_ticker_info", lambda tickers: {})
+
+    client = TestClient(app)
+    res = client.post(
+        "/api/screener/run",
+        json={"universe": "broad_market_stocks", "top": 5, "asof_date": "2026-03-02"},
+    )
+    assert res.status_code == 200
+
+    assert captured["start_dates"]
+    for start in captured["start_dates"]:
+        assert start == screener_service._resolve_fetch_start_date("2026-03-02", 260)
+
+
 def test_screener_widens_ranking_pool_for_combined_priority(monkeypatch):
     """Stage 1 must rank a pool of top * prefilter_multiplier candidates so the
     combined-priority stage can actually re-rank beyond the requested top-N."""


### PR DESCRIPTION
start_date was hardcoded to 2022-01-01, so the fetch window grows unbounded over time (4+ years already). The window is now derived from asof and the strategy's min_history: enough calendar days to yield at least max(min_history, 260) trading bars plus a holiday buffer.