### PR TITLE
perf(screener): load fundamentals snapshots once per run

### DIFF
--- a/api/services/screener_service.py
+++ b/api/services/screener_service.py
@@ -468,21 +468,32 @@ def _fundamentals_summary(snapshot) -> str | None:
     return None
 
 
+def _load_fundamentals_snapshots(
+    candidates: list[ScreenerCandidate],
+    *,
+    storage: FundamentalsStorage | None = None,
+) -> dict[str, object]:
+    """Load each unique candidate ticker's snapshot once (None when missing)."""
+    fundamentals_storage = storage or FundamentalsStorage()
+    return {
+        ticker: fundamentals_storage.load_snapshot(ticker)
+        for ticker in {c.ticker for c in candidates}
+    }
+
+
 def _apply_cached_fundamentals_context(
     candidates: list[ScreenerCandidate],
     *,
+    snapshots: dict[str, object] | None = None,
     storage: FundamentalsStorage | None = None,
 ) -> list[ScreenerCandidate]:
     if not candidates:
         return candidates
-    fundamentals_storage = storage or FundamentalsStorage()
-    # Load each unique ticker's snapshot once to avoid N redundant file reads.
-    unique_tickers = {c.ticker for c in candidates}
-    snapshot_cache: dict[str, object] = {}
-    for ticker in unique_tickers:
-        snap = fundamentals_storage.load_snapshot(ticker)
-        if snap is not None:
-            snapshot_cache[ticker] = snap
+    snapshot_cache = (
+        snapshots
+        if snapshots is not None
+        else _load_fundamentals_snapshots(candidates, storage=storage)
+    )
     enriched: list[ScreenerCandidate] = []
     for candidate in candidates:
         snapshot = snapshot_cache.get(candidate.ticker)
@@ -504,12 +515,11 @@ def _apply_cached_fundamentals_context(
 def _apply_decision_summary_context(
     candidates: list[ScreenerCandidate],
     *,
+    snapshots: dict[str, object] | None = None,
     fundamentals_storage: FundamentalsStorage | None = None,
 ) -> list[ScreenerCandidate]:
     if not candidates:
         return candidates
-
-    fundamentals = fundamentals_storage or FundamentalsStorage()
 
     # Load today's catalyst opportunity index once for all candidates
     catalyst_index: dict = {}
@@ -519,8 +529,11 @@ def _apply_decision_summary_context(
     except Exception as exc:
         logger.warning("Failed to load catalyst index: %s", exc)
 
-    unique_tickers = {candidate.ticker for candidate in candidates}
-    snapshot_cache = {ticker: fundamentals.load_snapshot(ticker) for ticker in unique_tickers}
+    snapshot_cache = (
+        snapshots
+        if snapshots is not None
+        else _load_fundamentals_snapshots(candidates, storage=fundamentals_storage)
+    )
 
     enriched: list[ScreenerCandidate] = []
     for candidate in candidates:
@@ -1150,8 +1163,9 @@ class ScreenerService:
                     filtered_candidates.append(enriched_candidate)
 
             candidates = filtered_candidates
-            candidates = _apply_cached_fundamentals_context(candidates)
-            candidates = _apply_decision_summary_context(candidates)
+            fundamentals_snapshots = _load_fundamentals_snapshots(candidates)
+            candidates = _apply_cached_fundamentals_context(candidates, snapshots=fundamentals_snapshots)
+            candidates = _apply_decision_summary_context(candidates, snapshots=fundamentals_snapshots)
 
             finnhub_key = os.environ.get("FINNHUB_API_KEY")
             earnings_asof_date = dt.date.fromisoformat(asof_str)

--- a/tests/api/test_screener_endpoints.py
+++ b/tests/api/test_screener_endpoints.py
@@ -701,6 +701,46 @@ def test_screener_returns_same_symbol_add_on_metadata(monkeypatch):
         app.dependency_overrides.pop(get_portfolio_service, None)
 
 
+def test_screener_loads_each_fundamentals_snapshot_once(monkeypatch):
+    ohlcv = _ohlcv_with_spy()
+    mock_provider = _create_mock_provider(ohlcv)
+    load_calls: list[str] = []
+
+    def fake_build_daily_report(ohlcv, cfg, exclude_tickers=None, sector_benchmark_returns=None):
+        idx = ["AAA", "BBB"]
+        data = {
+            "atr14": [1.2, 1.1],
+            "mom_6m": [0.1, 0.1],
+            "mom_12m": [0.2, 0.2],
+            "rs_6m": [0.05, 0.04],
+            "score": [0.5, 0.4],
+            "confidence": [80.0, 70.0],
+            "last": [20.0, 21.0],
+            "ma20_level": [19.0, 20.0],
+            "dist_sma50_pct": [5.0, 5.0],
+            "dist_sma200_pct": [15.0, 15.0],
+            "rank": [1, 2],
+            "signal": ["breakout", "breakout"],
+        }
+        return pd.DataFrame(data, index=idx)
+
+    def fake_load_snapshot(self, symbol):
+        load_calls.append(symbol)
+        return None
+
+    monkeypatch.setattr(screener_service, "get_default_provider", lambda **kwargs: mock_provider)
+    monkeypatch.setattr(screener_service, "build_daily_report", fake_build_daily_report)
+    monkeypatch.setattr(screener_service, "get_multiple_ticker_info", lambda tickers: {})
+    monkeypatch.setattr(screener_service.FundamentalsStorage, "load_snapshot", fake_load_snapshot)
+
+    client = TestClient(app)
+    res = client.post("/api/screener/run", json={"universe": "broad_market_stocks", "top": 5})
+    assert res.status_code == 200
+    assert len(res.json()["candidates"]) == 2
+
+    assert sorted(load_calls) == ["AAA", "BBB"]
+
+
 def test_resolve_fetch_start_date_covers_min_history():
     start = screener_service._resolve_fetch_start_date("2026-03-02", 260)
     asof = dt.date.fromisoformat("2026-03-02")
@@ -787,6 +827,7 @@ def test_screener_widens_ranking_pool_for_combined_priority(monkeypatch):
     multiplier = CombinedPriorityConfig().prefilter_multiplier
     assert captured["ranking_top_n"] >= 50 * multiplier
     assert len(res.json()["candidates"]) == 50
+
 
 
 def test_screener_pending_entry_order_blocks_add_on(monkeypatch):


### PR DESCRIPTION
_apply_cached_fundamentals_context and _apply_decision_summary_context each loaded every candidate's snapshot from disk back-to-back. Snapshots are now loaded once via _load_fundamentals_snapshots and shared by both enrichment passes.