### PR TITLE
Open symbol detail modal from universes screener results

### DIFF
--- a/web-ui/docs/WEB_UI_GUIDE.md
+++ b/web-ui/docs/WEB_UI_GUIDE.md
@@ -15,7 +15,7 @@ Daily trading workflow through the Swing Screener web interface.
 | Calendar | `/calendar` | Earnings calendar, upcoming catalyst events |
 | Book | `/book` | Open positions: stop updates, partial close, trail config; order management: create, fill, cancel |
 | Research | `/research` | Screener run and candidates, symbol intelligence analysis, watchlist |
-| Universes | `/universes` | Universe management, manual refresh, benchmark |
+| Universes | `/universes` | Universe management, manual refresh, benchmark, symbol discovery with ad-hoc screener run (row click opens symbol detail modal) |
 | Strategy | `/strategy` | Strategy CRUD, activation, and validation |
 | Journal | `/journal` | Weekly reviews and trade log |
 | Onboarding | `/onboarding` | Setup guide for new users |

--- a/web-ui/src/pages/Universes.test.tsx
+++ b/web-ui/src/pages/Universes.test.tsx
@@ -26,4 +26,17 @@ describe('Universes page', () => {
       expect(screen.queryByText('Discovering…')).not.toBeInTheDocument()
     })
   })
+
+  it('opens the symbol detail modal when a screener result row is clicked', async () => {
+    const { user } = renderWithProviders(<Universes />)
+
+    await user.click(screen.getByRole('button', { name: /discover symbols/i }))
+    await screen.findByText('NVDA')
+    await user.click(screen.getByRole('button', { name: /run screener on these symbols/i }))
+    await screen.findByText('Screener Results for Discovered Symbols')
+
+    await user.click(screen.getByText('AAPL'))
+
+    expect(await screen.findByText('AAPL Details')).toBeInTheDocument()
+  })
 })

--- a/web-ui/src/pages/Universes.tsx
+++ b/web-ui/src/pages/Universes.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from 'react';
 import Card from '@/components/common/Card';
 import Button from '@/components/common/Button';
 import Badge from '@/components/common/Badge';
+import WorkspaceSymbolModal from '@/components/domain/workspace/WorkspaceSymbolModal';
 import { useRefreshUniverseMutation, useSymbolDiscoveryMutation, useUniverseCatalog, useUniverseDetail, useUpdateUniverseBenchmarkMutation } from '@/features/universes/hooks';
 import type { ScreenerCandidate, UniverseSummary } from '@/features/screener/types';
 import type { SymbolDiscoveryRequest } from '@/features/universes/types';
@@ -141,6 +142,7 @@ export default function Universes() {
   const [discoveryMinVolume, setDiscoveryMinVolume] = useState(1_000_000);
   const [discoveryMinMarketCap, setDiscoveryMinMarketCap] = useState(0);
   const [screenerTop, setScreenerTop] = useState(20);
+  const [detailTicker, setDetailTicker] = useState<string | null>(null);
 
   useEffect(() => {
     if (!selectedUniverseId && universes.length > 0) {
@@ -531,7 +533,11 @@ export default function Universes() {
                   </thead>
                   <tbody className="divide-y divide-gray-100 bg-white">
                     {discoveryScreenerResult.candidates.map((candidate) => (
-                      <tr key={candidate.ticker}>
+                      <tr
+                        key={candidate.ticker}
+                        onClick={() => setDetailTicker(candidate.ticker)}
+                        className="cursor-pointer hover:bg-gray-50"
+                      >
                         <td className="px-3 py-2 font-medium text-gray-900">#{candidate.priorityRank ?? candidate.rank}</td>
                         <td className="px-3 py-2">
                           <div className="font-semibold text-gray-900">{candidate.ticker}</div>
@@ -866,6 +872,10 @@ export default function Universes() {
           ) : null}
         </div>
       </div>
+
+      {detailTicker ? (
+        <WorkspaceSymbolModal ticker={detailTicker} onBack={() => setDetailTicker(null)} />
+      ) : null}
     </div>
   );
 }

--- a/web-ui/src/test/mocks/handlers.ts
+++ b/web-ui/src/test/mocks/handlers.ts
@@ -679,6 +679,10 @@ export const handlers = [
     return HttpResponse.json([])
   }),
 
+  http.get(`${API_BASE_URL}/api/intelligence/:ticker/latest`, ({ params }) => {
+    return HttpResponse.json({ detail: `No cached analysis for ${params.ticker}` }, { status: 404 })
+  }),
+
   // Orders endpoints
   http.get(`${API_BASE_URL}/api/portfolio/orders`, ({ request }) => {
     const url = new URL(request.url)


### PR DESCRIPTION
The discovery screener on /universes already returns the full candidate payload (decision summary, trade plan, entry/stop, sizing) but the results table only rendered the summary columns, so there was no way to see the order setup for a discovered symbol.
Now each result row is clickable and opens WorkspaceSymbolModal (same modal the portfolio table uses), giving the full Overview / Fundamentals / Order view without leaving the page.
Also added an MSW handler for /api/intelligence/:ticker/latest (404) so the new test runs without unhandled-request warnings.