### PR TITLE
Decouple the API service layer from FastAPI via a domain-error hierarchy

### DIFF
--- a/agent/cli.py
+++ b/agent/cli.py
@@ -16,6 +16,13 @@ import logging
 import sys
 from pathlib import Path
 
+from swing_screener.errors import DomainError
+
+
+def render_domain_error(exc: DomainError) -> int:
+    print(f"Error: {exc.detail}", file=sys.stderr)
+    return 1
+
 
 def setup_logging(level: str = "INFO") -> None:
     logging.basicConfig(
@@ -114,6 +121,8 @@ def cmd_screen(args: argparse.Namespace) -> int:
                 json.dump(result.model_dump(mode="json"), f, indent=2)
             print(f"\nResults saved to {args.output}")
         return 0
+    except DomainError:
+        raise
     except Exception as e:
         logging.error(f"Screening failed: {e}", exc_info=True)
         return 1
@@ -137,6 +146,8 @@ def cmd_positions_review(args: argparse.Namespace) -> int:
         else:
             print("\nNo open positions.")
         return 0
+    except DomainError:
+        raise
     except Exception as e:
         logging.error(f"Position review failed: {e}", exc_info=True)
         return 1
@@ -153,6 +164,8 @@ def cmd_positions_suggest_stops(args: argparse.Namespace) -> int:
                 suggestion = service.suggest_position_stop(p.position_id)
                 if suggestion.should_update:
                     suggestions.append((p.ticker, p.stop_price, suggestion))
+            except DomainError:
+                raise
             except Exception:
                 pass
         if suggestions:
@@ -166,6 +179,8 @@ def cmd_positions_suggest_stops(args: argparse.Namespace) -> int:
         else:
             print("\nNo stop updates recommended.")
         return 0
+    except DomainError:
+        raise
     except Exception as e:
         logging.error(f"Stop suggestion failed: {e}", exc_info=True)
         return 1
@@ -181,6 +196,8 @@ def cmd_positions_update_stop(args: argparse.Namespace) -> int:
         )
         print(f"\nStop updated for {args.position_id} -> ${args.new_stop:.2f}")
         return 0
+    except DomainError:
+        raise
     except Exception as e:
         logging.error(f"Stop update failed: {e}", exc_info=True)
         return 1
@@ -203,6 +220,8 @@ def cmd_orders_list(args: argparse.Namespace) -> int:
         else:
             print("  No orders found.")
         return 0
+    except DomainError:
+        raise
     except Exception as e:
         logging.error(f"Order listing failed: {e}", exc_info=True)
         return 1
@@ -230,6 +249,8 @@ def cmd_daily_review(args: argparse.Namespace) -> int:
             for u in update:
                 print(f"  {u.ticker}  new stop=${u.new_stop:.2f}")
         return 0
+    except DomainError:
+        raise
     except Exception as e:
         logging.error(f"Daily review failed: {e}", exc_info=True)
         return 1
@@ -283,26 +304,29 @@ def main() -> int:
 
     setup_logging(args.log_level)
 
-    if args.command == "screen":
-        return cmd_screen(args)
-    elif args.command == "positions":
-        if not args.action:
-            positions_parser.print_help()
-            return 1
-        if args.action == "review":
-            return cmd_positions_review(args)
-        elif args.action == "suggest-stops":
-            return cmd_positions_suggest_stops(args)
-        elif args.action == "update-stop":
-            return cmd_positions_update_stop(args)
-    elif args.command == "orders":
-        if not args.action:
-            orders_parser.print_help()
-            return 1
-        if args.action == "list":
-            return cmd_orders_list(args)
-    elif args.command == "daily-review":
-        return cmd_daily_review(args)
+    try:
+        if args.command == "screen":
+            return cmd_screen(args)
+        elif args.command == "positions":
+            if not args.action:
+                positions_parser.print_help()
+                return 1
+            if args.action == "review":
+                return cmd_positions_review(args)
+            elif args.action == "suggest-stops":
+                return cmd_positions_suggest_stops(args)
+            elif args.action == "update-stop":
+                return cmd_positions_update_stop(args)
+        elif args.command == "orders":
+            if not args.action:
+                orders_parser.print_help()
+                return 1
+            if args.action == "list":
+                return cmd_orders_list(args)
+        elif args.command == "daily-review":
+            return cmd_daily_review(args)
+    except DomainError as exc:
+        return render_domain_error(exc)
 
     parser.print_help()
     return 1

--- a/api/main.py
+++ b/api/main.py
@@ -10,6 +10,7 @@ from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse
 from contextlib import asynccontextmanager
+from swing_screener.errors import DomainError
 from swing_screener.settings import get_settings_manager
 from swing_screener.settings.migration import migrate_legacy_config_to_yaml
 from swing_screener.runtime_env import ensure_runtime_env_loaded
@@ -132,12 +133,21 @@ async def lifespan(app: FastAPI):
     logger.info("Shutting down...")
 
 
+def register_domain_error_handler(target_app) -> None:
+    """Translate DomainError subclasses to HTTP responses (status from err.http_status)."""
+
+    @target_app.exception_handler(DomainError)
+    async def _domain_error_handler(request, exc: DomainError):  # noqa: ANN001
+        return JSONResponse(status_code=exc.http_status, content={"detail": exc.detail})
+
+
 app = FastAPI(
     title="Swing Screener API",
     description="REST API for the Swing Screener trading system",
     version="0.1.0",
     lifespan=lifespan,
 )
+register_domain_error_handler(app)
 
 _DEFAULT_ALLOW_ORIGINS = ["http://localhost:5173", "http://localhost:5174"]
 _raw_allow_origins = _API_SETTINGS.get("allow_origins", _DEFAULT_ALLOW_ORIGINS)

--- a/api/routers/intelligence.py
+++ b/api/routers/intelligence.py
@@ -120,7 +120,7 @@ def analyze_position(
             earnings_days = ep.days_until
             earnings_date = ep.next_earnings_date
     except Exception:
-        pass
+        logger.warning("Earnings proximity fetch failed for %r; proceeding without earnings data", pos.ticker, exc_info=True)
     request = SymbolIntelligenceRequest(
         close=float(pos.current_price if pos.current_price is not None else pos.entry_price),
         signal=stop.action,

--- a/api/routers/screener.py
+++ b/api/routers/screener.py
@@ -1,9 +1,12 @@
 """Screener router - Run screener."""
 from __future__ import annotations
 
+import logging
 import os
 from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
+
+logger = logging.getLogger(__name__)
 
 from api.models.screener import (
     ScreenerRequest,
@@ -36,7 +39,7 @@ def _record_history(history_repo: ScreenerHistoryRepository, result: ScreenerRes
         if tickers:
             history_repo.record_run(result.asof_date, tickers)
     except Exception:
-        pass  # Never fail a screener run due to history recording
+        logger.warning("Failed to record screener history for run dated %r; ignoring", result.asof_date, exc_info=True)
 
 
 @router.post(

--- a/api/services/daily_review_service.py
+++ b/api/services/daily_review_service.py
@@ -5,7 +5,7 @@ from datetime import date
 from pathlib import Path
 from typing import Literal, Optional
 
-from fastapi import HTTPException
+from swing_screener.errors import DomainError
 
 from api.models.daily_review import (
     DailyReview,
@@ -132,8 +132,8 @@ class DailyReviewService:
             # Get stop suggestion for this position
             try:
                 suggestion = self.portfolio.suggest_position_stop(pos.position_id)
-            except HTTPException as exc:
-                reason = exc.detail if isinstance(exc.detail, str) else str(exc.detail)
+            except DomainError as exc:
+                reason = exc.detail
                 logger.warning(
                     "Daily review stop suggestion unavailable for %s: %s",
                     pos.ticker,
@@ -465,8 +465,8 @@ class DailyReviewService:
             position_id = str(pos.get("position_id") or f"LOCAL-{pos.get('ticker', 'UNKNOWN')}")
             try:
                 suggestion = self.portfolio.compute_position_stop_suggestion(pos, manage_payload)
-            except HTTPException as exc:
-                reason = exc.detail if isinstance(exc.detail, str) else str(exc.detail)
+            except DomainError as exc:
+                reason = exc.detail
                 logger.warning(
                     "Stateless daily review stop suggestion unavailable for %s: %s",
                     pos.get("ticker"),

--- a/api/services/fundamentals_service.py
+++ b/api/services/fundamentals_service.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 
 import logging
 
-from fastapi import HTTPException
+from swing_screener.errors import (
+    NotFoundError,
+    ValidationError,
+    ServiceError,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -110,13 +114,13 @@ class FundamentalsService:
     def start_warmup(self, request: FundamentalsWarmupRequest) -> FundamentalsWarmupLaunchResponse:
         if request.source == "watchlist":
             if self._watchlist_repo is None:
-                raise HTTPException(status_code=500, detail="Watchlist repository is not available.")
+                raise ServiceError("Watchlist repository is not available.")
             symbols = [item.ticker for item in self._watchlist_repo.list_items()]
         else:
             symbols = list(request.symbols)
 
         if not symbols:
-            raise HTTPException(status_code=400, detail="No symbols available for fundamentals warmup.")
+            raise ValidationError("No symbols available for fundamentals warmup.")
 
         job_id = self._warmup_manager.start_job(
             symbols=symbols,
@@ -125,11 +129,11 @@ class FundamentalsService:
             cfg=self._build_cfg(),
         )
         if not job_id:
-            raise HTTPException(status_code=400, detail="No valid symbols available for fundamentals warmup.")
+            raise ValidationError("No valid symbols available for fundamentals warmup.")
 
         job = self._warmup_manager.get_job(job_id)
         if job is None:
-            raise HTTPException(status_code=500, detail="Failed to create fundamentals warmup job.")
+            raise ServiceError("Failed to create fundamentals warmup job.")
 
         return FundamentalsWarmupLaunchResponse.model_validate(
             {
@@ -146,5 +150,5 @@ class FundamentalsService:
     def get_warmup_status(self, job_id: str) -> FundamentalsWarmupStatusResponse:
         job = self._warmup_manager.get_job(job_id)
         if job is None:
-            raise HTTPException(status_code=404, detail="Fundamentals warmup job not found.")
+            raise NotFoundError("Fundamentals warmup job not found.")
         return self._serialize_warmup_job_status(job)

--- a/api/services/orders_service.py
+++ b/api/services/orders_service.py
@@ -5,7 +5,11 @@ import uuid
 import logging
 from typing import Optional
 
-from fastapi import HTTPException
+from swing_screener.errors import (
+    NotFoundError,
+    ConflictError,
+    UnprocessableError,
+)
 
 from api.models.portfolio import (
     CreateOrderRequest,
@@ -45,18 +49,17 @@ class OrdersService:
                 for o in orders
             )
             if pending_entry:
-                raise HTTPException(status_code=409, detail=f"{ticker}: pending entry order already exists.")
+                raise ConflictError(f"{ticker}: pending entry order already exists.")
 
             positions, _ = self._positions_repo.list_positions(status="open")
             open_position = next((p for p in positions if p.get("ticker") == ticker), None)
 
             if request.entry_mode == "ADD_ON":
                 if not open_position:
-                    raise HTTPException(status_code=409, detail=f"{ticker}: no open position found for add-on order.")
+                    raise ConflictError(f"{ticker}: no open position found for add-on order.")
             elif open_position:
-                raise HTTPException(
-                    status_code=409,
-                    detail=f"{ticker}: open position already exists. Create this as an ADD_ON order instead.",
+                raise ConflictError(
+                    f"{ticker}: open position already exists. Create this as an ADD_ON order instead.",
                 )
 
         existing_ids = {o.get("order_id", "") for o in orders}
@@ -99,32 +102,32 @@ class OrdersService:
     def submit_order(self, order_id: str) -> dict:
         order = self._orders_repo.submit_order(order_id)
         if order is None:
-            raise HTTPException(status_code=404, detail=f"Order {order_id} not found")
+            raise NotFoundError(f"Order {order_id} not found")
         if order.get("status") != "submitted":
-            raise HTTPException(status_code=409, detail=f"Order {order_id} is already {order.get('status')}")
+            raise ConflictError(f"Order {order_id} is already {order.get('status')}")
         return {"order_id": order_id, "status": "submitted"}
 
     def cancel_order(self, order_id: str) -> dict:
         order = self._orders_repo.cancel_order(order_id)
         if order is None:
-            raise HTTPException(status_code=404, detail=f"Order {order_id} not found")
+            raise NotFoundError(f"Order {order_id} not found")
         if order.get("status") != "cancelled":
-            raise HTTPException(status_code=409, detail=f"Order {order_id} is already {order.get('status')}")
+            raise ConflictError(f"Order {order_id} is already {order.get('status')}")
         return {"order_id": order_id, "status": "cancelled"}
 
     def fill_order(self, order_id: str, request: FillOrderRequest) -> FillOrderResponse:
         order = self._orders_repo.get_order(order_id)
         if order is None:
-            raise HTTPException(status_code=404, detail=f"Order {order_id} not found")
+            raise NotFoundError(f"Order {order_id} not found")
         if order.get("status") not in ("pending", "submitted"):
-            raise HTTPException(status_code=409, detail=f"Order {order_id} is already {order.get('status')}")
+            raise ConflictError(f"Order {order_id} is already {order.get('status')}")
 
         ticker = order["ticker"]
         stop_price = request.stop_price if request.stop_price is not None else order.get("stop_price")
         if not stop_price or stop_price <= 0:
-            raise HTTPException(status_code=422, detail=f"No valid stop price for order {order_id}")
+            raise UnprocessableError(f"No valid stop price for order {order_id}")
         if stop_price >= request.filled_price:
-            raise HTTPException(status_code=422, detail="stop_price must be below filled_price")
+            raise UnprocessableError("stop_price must be below filled_price")
 
         updates = {
             "status": "filled",

--- a/api/services/portfolio_service.py
+++ b/api/services/portfolio_service.py
@@ -8,7 +8,12 @@ from decimal import Decimal, ROUND_HALF_UP
 from typing import Optional
 
 import pandas as pd
-from fastapi import HTTPException
+from swing_screener.errors import (
+    NotFoundError,
+    ValidationError,
+    ServiceError,
+    UpstreamError,
+)
 
 from api.models.portfolio import (
     ConcentrationGroup,
@@ -395,13 +400,13 @@ class PortfolioService:
     def get_position(self, position_id: str) -> Position:
         position = self._positions_repo.get_position(position_id)
         if position is None:
-            raise HTTPException(status_code=404, detail=f"Position not found: {position_id}")
+            raise NotFoundError(f"Position not found: {position_id}")
         return Position(**position)
 
     def get_position_metrics(self, position_id: str) -> PositionMetrics:
         position = self._positions_repo.get_position(position_id)
         if position is None:
-            raise HTTPException(status_code=404, detail=f"Position not found: {position_id}")
+            raise NotFoundError(f"Position not found: {position_id}")
 
         ticker = str(position.get("ticker", "")).upper()
         current_price = self._fallback_price(position)
@@ -709,14 +714,13 @@ class PortfolioService:
         for pos in positions:
             if pos.get("position_id") == position_id:
                 if pos.get("status") != "open":
-                    raise HTTPException(status_code=400, detail="Cannot update stop on closed position")
+                    raise ValidationError("Cannot update stop on closed position")
 
                 old_stop = _round_price(float(pos.get("stop_price")))
 
                 if new_stop <= old_stop:
-                    raise HTTPException(
-                        status_code=400,
-                        detail=f"Cannot move stop down. Current: {old_stop}, Requested: {new_stop}",
+                    raise ValidationError(
+                        f"Cannot move stop down. Current: {old_stop}, Requested: {new_stop}",
                     )
 
                 ticker = pos.get("ticker")
@@ -733,12 +737,9 @@ class PortfolioService:
                     logger.warning("Could not fetch current price for validation: %s", exc)
 
                 if current_price is not None and new_stop > current_price:
-                    raise HTTPException(
-                        status_code=400,
-                        detail=(
-                            f"Stop price ({new_stop}) must be at or below current price "
-                            f"({current_price}) for long positions"
-                        ),
+                    raise ValidationError(
+                        f"Stop price ({new_stop}) must be at or below current price "
+                        f"({current_price}) for long positions",
                     )
 
                 pos["stop_price"] = new_stop
@@ -750,7 +751,7 @@ class PortfolioService:
                 break
 
         if not found:
-            raise HTTPException(status_code=404, detail=f"Position not found: {position_id}")
+            raise NotFoundError(f"Position not found: {position_id}")
 
         data["asof"] = get_today_str()
         self._positions_repo.write(data)
@@ -770,7 +771,7 @@ class PortfolioService:
         for pos in positions:
             if pos.get("position_id") == position_id:
                 if pos.get("status") != "open":
-                    raise HTTPException(status_code=400, detail="Position already closed")
+                    raise ValidationError("Position already closed")
 
                 pos["status"] = "closed"
                 pos["exit_price"] = request.exit_price
@@ -787,7 +788,7 @@ class PortfolioService:
                 break
 
         if not found:
-            raise HTTPException(status_code=404, detail=f"Position not found: {position_id}")
+            raise NotFoundError(f"Position not found: {position_id}")
 
         data["asof"] = get_today_str()
         self._positions_repo.write(data)
@@ -811,13 +812,12 @@ class PortfolioService:
                 continue
 
             if pos.get("status") != "open":
-                raise HTTPException(status_code=400, detail="Position is not open")
+                raise ValidationError("Position is not open")
 
             current_shares = int(pos.get("shares", 0))
             if request.shares_closed >= current_shares:
-                raise HTTPException(
-                    status_code=400,
-                    detail=f"shares_closed ({request.shares_closed}) must be less than current shares ({current_shares}); use close_position to fully close",
+                raise ValidationError(
+                    f"shares_closed ({request.shares_closed}) must be less than current shares ({current_shares}); use close_position to fully close",
                 )
 
             entry_price = float(pos.get("entry_price", 0.0))
@@ -841,7 +841,7 @@ class PortfolioService:
             break
 
         if not found:
-            raise HTTPException(status_code=404, detail=f"Position not found: {position_id}")
+            raise NotFoundError(f"Position not found: {position_id}")
 
         data["asof"] = get_today_str()
         self._positions_repo.write(data)
@@ -875,11 +875,11 @@ class PortfolioService:
         manage_payload: Optional[dict] = None,
     ) -> PositionUpdate:
         if position.get("status") != "open":
-            raise HTTPException(status_code=400, detail="Stop suggestions require an open position")
+            raise ValidationError("Stop suggestions require an open position")
 
         ticker = position.get("ticker")
         if not ticker:
-            raise HTTPException(status_code=400, detail="Position ticker is missing")
+            raise ValidationError("Position ticker is missing")
 
         manage_cfg = self._resolve_manage_cfg(manage_payload)
         start_date = _calc_start_date(position.get("entry_date"), manage_cfg.trail_sma)
@@ -888,23 +888,21 @@ class PortfolioService:
         try:
             ohlcv = self._provider.fetch_ohlcv([ticker], start_date=start_date, end_date=end_date)
         except Exception as exc:
-            raise HTTPException(
-                status_code=502,
-                detail=f"Failed to fetch market data for {ticker}: {exc}",
+            raise UpstreamError(
+                f"Failed to fetch market data for {ticker}: {exc}",
             ) from exc
 
         try:
             updates, _ = evaluate_positions(ohlcv, [_to_state_position(position)], manage_cfg)
         except ValueError as exc:
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
+            raise ValidationError(str(exc)) from exc
         except Exception as exc:
-            raise HTTPException(
-                status_code=500,
-                detail=f"Failed to compute stop suggestion: {exc}",
+            raise ServiceError(
+                f"Failed to compute stop suggestion: {exc}",
             ) from exc
 
         if not updates:
-            raise HTTPException(status_code=500, detail="No stop suggestion available")
+            raise ServiceError("No stop suggestion available")
 
         update = updates[0]
         return PositionUpdate(
@@ -932,7 +930,7 @@ class PortfolioService:
     def suggest_position_stop(self, position_id: str) -> PositionUpdate:
         position = self._positions_repo.get_position(position_id)
         if position is None:
-            raise HTTPException(status_code=404, detail=f"Position not found: {position_id}")
+            raise NotFoundError(f"Position not found: {position_id}")
         return self._suggest_position_stop_from_dict(position)
 
     def suggest_stop_intraday(
@@ -942,13 +940,13 @@ class PortfolioService:
     ) -> PositionUpdate:
         position = self._positions_repo.get_position(position_id)
         if position is None:
-            raise HTTPException(status_code=404, detail=f"Position not found: {position_id}")
+            raise NotFoundError(f"Position not found: {position_id}")
         if position.get("status") != "open":
-            raise HTTPException(status_code=400, detail="Position is not open")
+            raise ValidationError("Position is not open")
 
         ticker = position.get("ticker")
         if not ticker:
-            raise HTTPException(status_code=400, detail="Position ticker is missing")
+            raise ValidationError("Position ticker is missing")
 
         manage_cfg = self._resolve_manage_cfg(None)
         start_date = _calc_start_date(position.get("entry_date"), manage_cfg.trail_sma)
@@ -957,18 +955,16 @@ class PortfolioService:
         try:
             ohlcv = self._provider.fetch_ohlcv([ticker], start_date=start_date, end_date=yesterday)
         except Exception as exc:
-            raise HTTPException(
-                status_code=502,
-                detail=f"Failed to fetch market data: {exc}",
+            raise UpstreamError(
+                f"Failed to fetch market data: {exc}",
             ) from exc
 
         if price is None:
             try:
                 price = self._provider.fetch_latest_price(ticker)
             except Exception as exc:
-                raise HTTPException(
-                    status_code=502,
-                    detail=f"Failed to fetch live price for {ticker}: {exc}",
+                raise UpstreamError(
+                    f"Failed to fetch live price for {ticker}: {exc}",
                 ) from exc
 
         today_idx = pd.Timestamp(dt.date.today())
@@ -981,15 +977,14 @@ class PortfolioService:
         try:
             updates, _ = evaluate_positions(ohlcv, [_to_state_position(position)], manage_cfg)
         except ValueError as exc:
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
+            raise ValidationError(str(exc)) from exc
         except Exception as exc:
-            raise HTTPException(
-                status_code=500,
-                detail=f"Failed to compute stop preview: {exc}",
+            raise ServiceError(
+                f"Failed to compute stop preview: {exc}",
             ) from exc
 
         if not updates:
-            raise HTTPException(status_code=500, detail="No stop preview available")
+            raise ServiceError("No stop preview available")
 
         update = updates[0]
         return PositionUpdate(
@@ -1013,9 +1008,8 @@ class PortfolioService:
         for pos in positions:
             if pos.get("position_id") == position_id:
                 if pos.get("status") != "open":
-                    raise HTTPException(
-                        status_code=400,
-                        detail="Cannot update trail method on a closed position",
+                    raise ValidationError(
+                        "Cannot update trail method on a closed position",
                     )
                 pos["trail_method"] = request.trail_method
                 pos["trail_param"] = request.trail_param
@@ -1027,4 +1021,4 @@ class PortfolioService:
                     "trail_method": request.trail_method,
                     "trail_param": request.trail_param,
                 }
-        raise HTTPException(status_code=404, detail=f"Position {position_id} not found")
+        raise NotFoundError(f"Position {position_id} not found")

--- a/api/services/screener_run_manager.py
+++ b/api/services/screener_run_manager.py
@@ -93,8 +93,8 @@ class ScreenerRunManager:
             logger.warning("Failed to persist screener job %s to %s: %s", job.job_id, target, exc)
             try:
                 tmp.unlink(missing_ok=True)
-            except Exception:
-                pass
+            except Exception as rm_exc:
+                logger.debug("Failed to remove temp screener job file %s: %s", tmp, rm_exc)
 
     def _read_job_from_disk(self, job_id: str) -> Optional[ScreenerRunJob]:
         path = self._job_file(job_id)
@@ -228,7 +228,7 @@ class ScreenerRunManager:
             try:
                 self._job_file(item.job_id).unlink(missing_ok=True)
             except Exception:
-                pass
+                logger.debug("Failed to remove evicted screener job file for %s", item.job_id, exc_info=True)
 
 
 _MANAGER = ScreenerRunManager()

--- a/api/services/screener_service.py
+++ b/api/services/screener_service.py
@@ -11,7 +11,13 @@ import os
 from zoneinfo import ZoneInfo
 
 import pandas as pd
-from fastapi import HTTPException
+from swing_screener.errors import (
+    DomainError,
+    NotFoundError,
+    ValidationError,
+    UnprocessableError,
+    ServiceError,
+)
 
 from api.models.screener import (
     ScreenerRequest,
@@ -740,7 +746,7 @@ class ScreenerService:
         if strategy_id:
             strategy = self._strategy_repo.get_strategy(strategy_id)
             if strategy is None:
-                raise HTTPException(status_code=404, detail=f"Strategy not found: {strategy_id}")
+                raise NotFoundError(f"Strategy not found: {strategy_id}")
             return strategy
         return self._strategy_repo.get_active_strategy()
 
@@ -748,7 +754,7 @@ class ScreenerService:
         try:
             requested_top = request.top or 20
             if requested_top <= 0:
-                raise HTTPException(status_code=422, detail="top must be >= 1")
+                raise UnprocessableError("top must be >= 1")
             combined_priority_cfg = CombinedPriorityConfig()
             warnings: list[str] = []
 
@@ -771,7 +777,7 @@ class ScreenerService:
                             f"Universe '{request.universe}' is not available. "
                             f"Available universes: {sorted(valid_ids)}"
                         )
-                    raise HTTPException(status_code=422, detail=detail)
+                    raise UnprocessableError(detail)
                 uni_benchmark = get_universe_benchmark(request.universe)
                 if uni_benchmark and uni_benchmark != benchmark:
                     universe_cfg = replace(
@@ -822,7 +828,7 @@ class ScreenerService:
                 asof_str = _resolve_default_asof_date(now_utc, active_currencies).isoformat()
 
             if len(tickers) <= 1 and benchmark in tickers:
-                raise HTTPException(status_code=404, detail="No tickers left after applying screener filters")
+                raise NotFoundError("No tickers left after applying screener filters")
 
             signals_cfg = build_entry_config(strategy)
             if "breakout_lookback" in fields_set and request.breakout_lookback is not None:
@@ -860,7 +866,7 @@ class ScreenerService:
 
             if ohlcv is None or ohlcv.empty:
                 logger.error("OHLCV fetch returned empty data (tickers=%s)", len(tickers))
-                raise HTTPException(status_code=404, detail="No market data found for requested tickers")
+                raise NotFoundError("No market data found for requested tickers")
 
             ohlcv = _merge_ohlcv(ohlcv, sector_ohlcv)
 
@@ -869,7 +875,7 @@ class ScreenerService:
                 bench_df = self._provider.fetch_ohlcv([benchmark], start_date=start_date, end_date=end_date)
                 ohlcv = _merge_ohlcv(ohlcv, bench_df)
                 if "Close" not in ohlcv.columns.get_level_values(0) or benchmark not in ohlcv["Close"].columns:
-                    raise HTTPException(status_code=500, detail="Benchmark data missing; cannot compute momentum.")
+                    raise ServiceError("Benchmark data missing; cannot compute momentum.")
 
             last_bar_map = _last_bar_map(ohlcv)
             overall_last_bar = _to_iso(ohlcv.index.max())
@@ -1267,17 +1273,17 @@ class ScreenerService:
             logger.info("Screener completed: candidates=%s", len(candidates))
             return response
 
-        except HTTPException:
+        except DomainError:
             raise
         except ValueError as exc:
             logger.error("Screener configuration error: %s", exc)
-            raise HTTPException(status_code=400, detail=f"Invalid screener configuration: {str(exc)}")
+            raise ValidationError(f"Invalid screener configuration: {str(exc)}")
         except (KeyError, IndexError) as exc:
             logger.error("Screener data error: %s", exc)
-            raise HTTPException(status_code=500, detail="Screener failed due to data error")
+            raise ServiceError("Screener failed due to data error")
         except Exception as exc:
             logger.exception("Unexpected screener error")
-            raise HTTPException(status_code=500, detail="Screener failed unexpectedly")
+            raise ServiceError("Screener failed unexpectedly")
 
     def start_run_async(self, request: ScreenerRequest, on_complete=None) -> ScreenerRunLaunchResponse:
         """Start screener run in background and return job metadata.
@@ -1298,7 +1304,7 @@ class ScreenerService:
         job_id = manager.start_job(run_fn=_run)
         job = manager.get_job(job_id)
         if job is None:
-            raise HTTPException(status_code=500, detail="Failed to start screener run.")
+            raise ServiceError("Failed to start screener run.")
         return ScreenerRunLaunchResponse(
             job_id=job.job_id,
             status=job.status,  # type: ignore[arg-type]
@@ -1310,7 +1316,7 @@ class ScreenerService:
         """Get status for background screener run."""
         job = get_screener_run_manager().get_job(job_id)
         if job is None:
-            raise HTTPException(status_code=404, detail=f"Screener run job not found: {job_id}")
+            raise NotFoundError(f"Screener run job not found: {job_id}")
         return ScreenerRunStatusResponse(
             job_id=job.job_id,
             status=job.status,  # type: ignore[arg-type]

--- a/api/services/strategy_service.py
+++ b/api/services/strategy_service.py
@@ -2,7 +2,11 @@
 from __future__ import annotations
 
 import datetime as dt
-from fastapi import HTTPException
+from swing_screener.errors import (
+    NotFoundError,
+    ValidationError,
+    ConflictError,
+)
 
 from api.models.strategy import (
     Strategy,
@@ -23,7 +27,7 @@ class StrategyService:
     def _require_strategy(self, strategy_id: str) -> dict:
         strategy = self._repo.get_strategy(strategy_id)
         if strategy is None:
-            raise HTTPException(status_code=404, detail=f"Strategy not found: {strategy_id}")
+            raise NotFoundError(f"Strategy not found: {strategy_id}")
         return strategy
 
     def list_strategies(self) -> list[Strategy]:
@@ -42,11 +46,11 @@ class StrategyService:
 
     def create_strategy(self, request: StrategyCreateRequest) -> Strategy:
         if request.id == self._repo.default_strategy_id:
-            raise HTTPException(status_code=400, detail="Cannot create strategy with reserved id 'default'.")
+            raise ValidationError("Cannot create strategy with reserved id 'default'.")
 
         strategies = self._repo.list_strategies()
         if any(s.get("id") == request.id for s in strategies):
-            raise HTTPException(status_code=409, detail=f"Strategy already exists: {request.id}")
+            raise ConflictError(f"Strategy already exists: {request.id}")
 
         ts = self._now_iso()
         payload = request.model_dump()
@@ -76,13 +80,13 @@ class StrategyService:
             self._repo.save_strategies(strategies)
             return updated
 
-        raise HTTPException(status_code=404, detail=f"Strategy not found: {strategy_id}")
+        raise NotFoundError(f"Strategy not found: {strategy_id}")
 
     def delete_strategy(self, strategy_id: str) -> dict:
         strategies = self._repo.list_strategies()
 
         if strategy_id == self._repo.default_strategy_id:
-            raise HTTPException(status_code=400, detail="Default strategy cannot be deleted.")
+            raise ValidationError("Default strategy cannot be deleted.")
 
         active_id = self._repo.get_active_strategy_id()
 
@@ -91,13 +95,13 @@ class StrategyService:
         for strategy in strategies:
             if strategy.get("id") == strategy_id:
                 if strategy.get("is_default"):
-                    raise HTTPException(status_code=400, detail="Default strategy cannot be deleted.")
+                    raise ValidationError("Default strategy cannot be deleted.")
                 removed = True
                 continue
             kept.append(strategy)
 
         if not removed:
-            raise HTTPException(status_code=404, detail=f"Strategy not found: {strategy_id}")
+            raise NotFoundError(f"Strategy not found: {strategy_id}")
 
         self._repo.save_strategies(kept)
 

--- a/api/utils/file_lock.py
+++ b/api/utils/file_lock.py
@@ -7,7 +7,7 @@ import logging
 import re
 from typing import Any, Callable
 
-from fastapi import HTTPException
+from swing_screener.errors import DomainError, NotFoundError, ServiceError, ServiceUnavailableError
 from swing_screener.utils.file_lock import (
     DEFAULT_TIMEOUT,
     FileLockTimeoutError,
@@ -37,37 +37,33 @@ def _normalize_json_text(text: str) -> str:
 def locked_read_json(path: Path, timeout: float = DEFAULT_TIMEOUT) -> dict[str, Any]:
     """Read JSON file with a shared file lock."""
     if not path.exists():
-        raise HTTPException(status_code=404, detail=f"File not found: {path.name}")
+        raise NotFoundError(f"File not found: {path.name}")
 
     try:
         payload = read_json_with_lock(path, timeout=timeout, text_filter=_normalize_json_text)
         if not isinstance(payload, dict):
             logger.error(f"Invalid JSON root type in {path.name}: {type(payload).__name__}")
-            raise HTTPException(
-                status_code=500,
-                detail=f"Invalid JSON in {path.name}",
+            raise ServiceError(
+                f"Invalid JSON in {path.name}",
             )
         return payload
     except FileLockTimeoutError:
         _record_lock_contention()
         logger.error(f"Lock timeout reading {path.name} after {timeout}s")
-        raise HTTPException(
-            status_code=503,
-            detail=f"Service temporarily unavailable - file locked: {path.name}"
+        raise ServiceUnavailableError(
+            f"Service temporarily unavailable - file locked: {path.name}"
         )
     except json.JSONDecodeError as exc:
         logger.error(f"Invalid JSON in {path.name}: {exc}")
-        raise HTTPException(
-            status_code=500,
-            detail=f"Invalid JSON in {path.name}"
+        raise ServiceError(
+            f"Invalid JSON in {path.name}"
         )
-    except HTTPException:
+    except DomainError:
         raise
     except Exception:
         logger.exception(f"Unexpected error reading {path.name}")
-        raise HTTPException(
-            status_code=500,
-            detail=f"Failed to read file: {path.name}"
+        raise ServiceError(
+            f"Failed to read file: {path.name}"
         )
 
 
@@ -82,15 +78,13 @@ def locked_write_json(
     except FileLockTimeoutError:
         _record_lock_contention()
         logger.error(f"Lock timeout writing {path.name} after {timeout}s")
-        raise HTTPException(
-            status_code=503,
-            detail=f"Service temporarily unavailable - file locked: {path.name}"
+        raise ServiceUnavailableError(
+            f"Service temporarily unavailable - file locked: {path.name}"
         )
     except Exception:
         logger.exception(f"Unexpected error writing {path.name}")
-        raise HTTPException(
-            status_code=500,
-            detail=f"Failed to write file: {path.name}"
+        raise ServiceError(
+            f"Failed to write file: {path.name}"
         )
 
 
@@ -101,7 +95,7 @@ def locked_read_modify_write(
 ) -> dict[str, Any]:
     """Atomic read-modify-write operation with one exclusive file lock."""
     if not path.exists():
-        raise HTTPException(status_code=404, detail=f"File not found: {path.name}")
+        raise NotFoundError(f"File not found: {path.name}")
 
     try:
         payload = update_json_with_lock(
@@ -112,29 +106,25 @@ def locked_read_modify_write(
         )
         if not isinstance(payload, dict):
             logger.error(f"Invalid JSON root type in {path.name}: {type(payload).__name__}")
-            raise HTTPException(
-                status_code=500,
-                detail=f"Invalid JSON in {path.name}",
+            raise ServiceError(
+                f"Invalid JSON in {path.name}",
             )
         return payload
     except FileLockTimeoutError:
         _record_lock_contention()
         logger.error(f"Lock timeout updating {path.name} after {timeout}s")
-        raise HTTPException(
-            status_code=503,
-            detail=f"Service temporarily unavailable - file locked: {path.name}"
+        raise ServiceUnavailableError(
+            f"Service temporarily unavailable - file locked: {path.name}"
         )
     except json.JSONDecodeError as exc:
         logger.error(f"Invalid JSON in {path.name}: {exc}")
-        raise HTTPException(
-            status_code=500,
-            detail=f"Invalid JSON in {path.name}"
+        raise ServiceError(
+            f"Invalid JSON in {path.name}"
         )
-    except HTTPException:
+    except DomainError:
         raise
     except Exception:
         logger.exception(f"Unexpected error updating {path.name}")
-        raise HTTPException(
-            status_code=500,
-            detail=f"Failed to update file: {path.name}"
+        raise ServiceError(
+            f"Failed to update file: {path.name}"
         )

--- a/api/utils/files.py
+++ b/api/utils/files.py
@@ -6,19 +6,19 @@ from pathlib import Path
 import json
 import re
 
-from fastapi import HTTPException
+from swing_screener.errors import NotFoundError, ServiceError
 
 
 def read_json_file(path: Path) -> dict:
     """Read and parse JSON file, converting NaN to None."""
     if not path.exists():
-        raise HTTPException(status_code=404, detail=f"File not found: {path.name}")
+        raise NotFoundError(f"File not found: {path.name}")
     try:
         text = path.read_text(encoding="utf-8")
         text = re.sub(r"\bNaN\b", "null", text)
         return json.loads(text)
     except json.JSONDecodeError as exc:
-        raise HTTPException(status_code=500, detail=f"Invalid JSON in {path.name}: {exc}")
+        raise ServiceError(f"Invalid JSON in {path.name}: {exc}")
 
 
 def write_json_file(path: Path, data: dict) -> None:
@@ -27,7 +27,7 @@ def write_json_file(path: Path, data: dict) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
     except Exception as exc:
-        raise HTTPException(status_code=500, detail=f"Failed to write {path.name}: {exc}")
+        raise ServiceError(f"Failed to write {path.name}: {exc}")
 
 
 def get_today_str() -> str:

--- a/docs/engineering/BACKEND_ARCHITECTURE_ASSESSMENT.md
+++ b/docs/engineering/BACKEND_ARCHITECTURE_ASSESSMENT.md
@@ -1,0 +1,224 @@
+# Backend Architecture Assessment
+
+> Status: proposal / draft.
+> Date: 2026-06-16.
+> Scope: Python backend only (`src/swing_screener`, `api`, `agent`). Frontend out of scope.
+> Target architecture: **pragmatic hexagonal** (clean layering, no dogmatic full rewrite).
+> Constraint: behavior change allowed only where current behavior is wrong; each such change flagged.
+
+This document audits the backend now that the major feature surface is in place, and proposes
+a ranked plan to make it more architected, extendible, and easier to reason about. Every finding
+is backed by a concrete measurement taken from the current tree.
+
+---
+
+## 1. Verdict
+
+The backend is in **decent shape structurally** — better than the headline LOC numbers suggest —
+but has **one load-bearing architectural flaw** plus a handful of god-files and naming tangles.
+
+What is already right (do not break):
+
+- **Domain core has no framework leak.** `src/swing_screener` imports `fastapi` **zero** times.
+- **Dependency direction inside the core is sound.** `data` is the most-imported domain (28×) and
+  imports nothing upward (no `data → risk/strategy/portfolio`). Lower layers stay lower.
+- **Ports exist where they matter.** `data/providers/base.py` and `fundamentals/providers/base.py`
+  define provider abstractions; concrete providers (yfinance, alpaca, stooq, sec_edgar, degiro,
+  finnhub) are swappable adapters.
+- **Repositories already isolate persistence.** `api/repositories/*` wrap JSON/SQLite I/O behind
+  classes; services depend on repos, not on file paths.
+- **The fundamentals split is a model to copy.** `fundamentals/service.py` (`FundamentalsAnalysisService`,
+  pure domain: snapshot/compare) vs `api/services/fundamentals_service.py` (`FundamentalsService`,
+  config CRUD + warmup jobs + response models). This is exactly the right two-layer shape — it is
+  **not** duplication.
+
+So this is a tidy-and-tighten job, not a rewrite.
+
+---
+
+## 2. The central flaw: the application layer lives inside the HTTP adapter
+
+`api/services/*` is, in effect, the **application/use-case layer**. But:
+
+1. It physically lives inside the `api` package (the FastAPI adapter).
+2. It is **coupled to HTTP**: services raise `fastapi.HTTPException` directly —
+   `portfolio_service` (29×), `orders_service` (12×), `screener_service` (13×),
+   `strategy_service` (8×), `fundamentals_service` (6×), `daily_review_service` (3×).
+3. The **non-HTTP CLI depends on it**: `agent/cli.py` imports `api.services.PortfolioService`,
+   `api.services.OrdersService`, `api.services.StrategyService` and `api.repositories.*` directly.
+
+Consequence: the CLI runtime path — documented as "Agent CLI → Services → Core, no HTTP hop" —
+**transitively pulls FastAPI into a context that has nothing to do with HTTP**, and any 4xx/5xx
+decision is hard-coded as an `HTTPException` instead of a domain error the CLI could render its own way.
+
+This is the single highest-leverage thing to fix. The pragmatic-hexagonal target:
+
+```
+        ┌─────────────────────────────────────────────┐
+        │  adapters (driving)                           │
+        │   api/  (FastAPI routers + models + DI)        │
+        │   agent/cli.py, swing_screener/cli.py          │
+        └───────────────┬───────────────────────────────┘
+                        │ depends on
+        ┌───────────────▼───────────────────────────────┐
+        │  application layer  (framework-free)            │
+        │   services/  ← MOVED OUT of api/, raises domain  │
+        │   errors, not HTTPException                      │
+        └───────────────┬───────────────────────────────┘
+                        │ depends on
+        ┌───────────────▼───────────────────────────────┐
+        │  domain core   src/swing_screener/*  (pure)     │
+        └─────────────────────────────────────────────────┘
+        repositories/providers = driven adapters behind ports
+```
+
+Minimum viable version of this (low risk): keep services where they are for now, but
+(a) replace `raise HTTPException(status, detail)` with a small domain exception hierarchy
+(`NotFoundError`, `ValidationError`, `ConflictError`, …), and (b) translate those to HTTP in a
+single FastAPI exception handler in `api/main.py`. The CLI then catches the same domain errors.
+This removes the FastAPI coupling without moving a single file.
+
+---
+
+## 3. God-files
+
+| File | LOC | Problem | Action |
+|------|-----|---------|--------|
+| `api/services/screener_service.py` | 1321 | `run_screener` is **one 535-line method** (747→1282). ~30 module-level private helpers (currency resolution, date math, price-history shaping, fundamentals context, decision-summary stitching, ranking, safe-casts) are crammed into the service file but are **pure functions that belong in the core**. | Split (see §5). Highest priority god-file. |
+| `api/services/portfolio_service.py` | 1030 | Single class owns read-model (list/metrics/summary), write-model (create/close/partial-close/stop), pricing, FX, and stop-suggestion. Too many responsibilities. | Split read vs write vs pricing. |
+| `src/swing_screener/recommendation/decision_summary.py` | 900 | One builder with ~20 private formatting/normalization helpers. | Extract a `formatting`/`labels` submodule. |
+| `src/swing_screener/fundamentals/scoring.py` | 951 | Large but cohesive (scoring rules). | Lower priority; review for sub-rule extraction. |
+
+`run_screener` is the worst offender: a 535-line method cannot be unit-tested in pieces, can't be
+reasoned about in one screen, and forces every screener change through the same blast radius.
+
+---
+
+## 4. Domain boundary tangles
+
+### 4.1 "recommendation" is overloaded across four locations
+
+| Location | Produces | Meaning |
+|----------|----------|---------|
+| `recommendation/` (top-level, singular) | `build_decision_summary` → `DecisionSummary` | The unified "what to do / why" decision view (recent feature). |
+| `risk/recommendations/engine.py` | `build_recommendation` → `RecommendationPayload` | Risk/cost/education/checklist-gate payload. |
+| `risk/recommendations/thesis.py` | `TradeThesis`, `calculate_setup_score` | Setup scoring + classification. |
+| `risk/engine.py` | `evaluate_recommendation` | Risk-engine entry point. |
+| `api/models/recommendation.py` | `Recommendation` | API response model. |
+
+These are genuinely different concepts, but the **names collide** and the **top-level
+`recommendation/` vs nested `risk/recommendations/` split is confusing** — both read as "the
+recommendations package". `MODULE_ARCHITECTURE.md` even says canonical recommendations live under
+`risk/recommendations`, while the larger, more-used `decision_summary` lives in top-level
+`recommendation/`. Decide one home and one vocabulary (proposal in §5).
+
+### 4.2 The architecture doc is stale
+
+`docs/engineering/MODULE_ARCHITECTURE.md` lists 10 canonical domains but the tree has **14**.
+Undocumented live domains: `fundamentals`, `integrations`, `recommendation`, `settings`.
+The "canonical module list" is the contract; it currently lies.
+
+### 4.3 Two CLIs with different layering
+
+- `agent/cli.py` → imports `api.services.*` (user workflow CLI: screen/positions/orders/chat).
+- `src/swing_screener/cli.py` → imports core directly (admin CLI: `universes refresh`, reports).
+
+Both are intentional, but the boundary is undocumented and `agent/cli.py`'s dependency on `api`
+is the coupling from §2. After the application layer is extracted, both CLIs depend on
+`services/` + core, never on the FastAPI package.
+
+---
+
+## 5. What to delete / merge / split (explicit)
+
+**Split**
+
+- `screener_service.run_screener` → orchestrator method that calls extracted, individually-tested steps:
+  `resolve_screening_window` (currency/asof/freshness math), `fetch_and_shape_ohlcv`,
+  `build_candidates`, `enrich_with_fundamentals`, `apply_decision_summary`, `rank_and_priority`.
+  Move the ~30 pure helpers **out of the service into core** (`selection/`, `data/`, `recommendation/`).
+- `portfolio_service` → `PortfolioReadService` (list/metrics/summary/concentration) +
+  `PortfolioWriteService` (create/close/partial/stop) + a `pricing` helper (live price + FX).
+- `recommendation/decision_summary.py` → keep the builder, extract its formatting/normalization
+  helpers into `recommendation/formatting.py`.
+
+**Merge / rename (boundary cleanup)**
+
+- The `recommendation/` → `decision/` rename is **deferred** (decision 2026-06-16). The
+  singular-vs-plural collision is documented but not acted on in this round to avoid churn; revisit
+  separately.
+
+**Delete (after verification — do not delete blind)**
+
+- **`db.py`** (orphaned SQLAlchemy ORM, see `CODE_HEALTH.md` §2) is confirmed for deletion
+  (decision 2026-06-16): JSON + `portalocker` is the single source of truth and the ORM is never
+  imported. Remove it and its `CODE_HEALTH.md` entry.
+
+- Run a real dead-code pass (`ruff --select F401,F811` already on; add a `vulture` sweep) before
+  removing anything. The ad-hoc grep used during this audit produced false positives and is **not**
+  a basis for deletion. No confirmed dead modules are claimed here.
+- Known-orphan candidates are already tracked in `CODE_HEALTH.md` (e.g. the unused SQLAlchemy
+  `db.py`, the legacy `data/market_data.py` wrapper). Reconcile that doc with this one rather than
+  re-listing; `CODE_HEALTH.md` is last-reviewed 2026-03-08 and should be refreshed in phase 9.
+
+---
+
+## 6. Error handling & logging
+
+This is **not** a stray-`print` problem — `api/services` has zero stray prints; the 98 `print()`
+matches are almost all in `cli.py` (40, legitimate CLI output) and notebooks/READMEs. The real
+issues:
+
+- **Broad exception handling.** 125 `except Exception` and 19 `except …: pass` (bare swallow) across
+  `src`+`api` (non-test). Silent-failure paths hide provider/data errors.
+- **Warning-heavy, thin logging.** Of 111 log calls, 51 are `logger.warning` vs 15 `info` / 16
+  `exception` — consistent with "catch broadly, log a warning, continue", which produces noisy logs
+  that don't tell you what actually happened.
+- **Inconsistent logger coverage.** 11/14 services use `getLogger`, but only 12/96 core files do.
+
+Target: a thin logging convention (module-level `logger = logging.getLogger(__name__)`; `info` for
+use-case boundaries, `warning` only for recoverable degradation with the reason, `exception` in the
+`except` that owns the failure), and replace bare `except: pass` with either a typed catch + reason
+log or a re-raise. Tie this to §2's domain-error hierarchy.
+
+---
+
+## 7. DI & testability
+
+`api/dependencies.py` is mostly clean hand-rolled FastAPI `Depends` factories — good. Two seams to fix:
+
+- **Test hooks bleed into production code.** Module-global monkeypatch path aliases
+  (`_positions_path`, `_orders_path`) accessed via `import api.dependencies as _self`. Tests redirect
+  I/O by mutating these globals. Replace with overridable settings/env or FastAPI
+  `dependency_overrides` so production code carries no test scaffolding.
+- **Import-time side effect.** The Finnhub client is constructed at module import from
+  `os.environ["FINNHUB_API_KEY"]`. Make it lazy/injected so import order and env presence don't
+  decide wiring.
+
+After the application layer moves out of `api/`, the DI wiring split cleanly: `api/dependencies.py`
+keeps the FastAPI `Depends` graph; a small framework-free factory builds services for the CLI.
+
+---
+
+## 8. Ranked refactor plan
+
+Ordered by value/risk. Decisions taken 2026-06-16: phase 7 **in scope**; recommendation rename
+**dropped**; PRs are **bundled** as noted; logging is allowed to change observable error behavior;
+`db.py` deletion folded into the dead-code phase.
+
+| PR | Phases | Why | Effort | Risk | Behavior change |
+|----|--------|-----|--------|------|-----------------|
+| **A** | **1** domain-error hierarchy + single HTTP translator · **2** refresh `MODULE_ARCHITECTURE.md` (14 domains + two-CLI boundary) · **4** logging convention + kill bare `except: pass` | Removes the §2 HTTP coupling, makes the arch doc honest, and adds observability — all low-risk, and they make the splits below safe. | L | Low | Phase 4 may surface errors previously swallowed (accepted). |
+| **B** | **3** split `run_screener` into orchestrator + extracted core steps; move pure helpers into core | Biggest readability/testability win. | L | Med | None. |
+| **C** | **5** split `portfolio_service` into read/write/pricing · **8** DI seam cleanup (test-path globals, import-time Finnhub) | Second god-file + remove test scaffolding from prod. | M | Med | None. |
+| **D** | **7** extract the application layer out of `api/` into top-level `services/` (CLIs + API depend on it, not on FastAPI) | Completes the hexagon. Depends on PR A (services must be framework-free first). | L | Med | None. |
+| **E** | **9** `vulture` dead-code pass; **delete `db.py`** (confirmed orphan) and refresh `CODE_HEALTH.md` | Shrink surface safely. | S | Low | None. |
+
+Sequencing: **A → B/C (parallel) → D → E.** A must land first because phase 7 (PR D) only makes
+sense once services no longer raise `HTTPException`.
+
+---
+
+## 9. Open questions
+
+(Listed for the user to answer before a plan is written — see chat.)

--- a/docs/engineering/MODULE_ARCHITECTURE.md
+++ b/docs/engineering/MODULE_ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # Module Architecture
 
 > Status: current.
-> Last reviewed: 2026-02-24.
+> Last reviewed: 2026-06-16.
 
 This document is the canonical module layout after the 2026 architecture consolidation.
 
@@ -9,12 +9,16 @@ This document is the canonical module layout after the 2026 architecture consoli
 
 - `src/swing_screener/data`
 - `src/swing_screener/execution`
+- `src/swing_screener/fundamentals`
 - `src/swing_screener/indicators`
+- `src/swing_screener/integrations`
 - `src/swing_screener/intelligence`
 - `src/swing_screener/portfolio`
+- `src/swing_screener/recommendation`
 - `src/swing_screener/reporting`
 - `src/swing_screener/risk`
 - `src/swing_screener/selection`
+- `src/swing_screener/settings`
 - `src/swing_screener/strategy`
 - `src/swing_screener/utils`
 
@@ -27,6 +31,12 @@ This document is the canonical module layout after the 2026 architecture consoli
 5. `execution` owns order state/workflows.
 6. `portfolio` owns position state/metrics.
 7. `data` owns provider access and market-data ingestion.
+8. `fundamentals` owns fundamental data providers, scoring, and snapshot storage.
+9. `intelligence` owns the LLM analysis pipeline, cache, and symbol analyzer.
+10. `recommendation` owns the unified decision summary (what-to-do / why) — distinct from
+    `risk/recommendations`, which owns the risk-side recommendation engine and trade thesis.
+11. `settings` owns settings load/migrate/path resolution.
+12. `integrations` owns third-party brokerage integrations (e.g. degiro).
 
 ## Canonical Import Paths
 
@@ -65,6 +75,24 @@ Refreshing an index universe (`refresh_package_universe(..., apply=True)`, or
 snapshot and appends any newly enriched symbols to
 `data/intelligence/instrument_master.json` (append-only; never overwrites
 existing records).
+
+## CLI Entry Points
+
+Two CLIs exist by design:
+
+- `agent/cli.py` (`python -m agent.cli`) — user trading workflow (screen, positions, orders, chat).
+  Depends on the application services (currently under `api/services`) + core. Must not require a
+  running HTTP server; raises/catches `swing_screener.errors.DomainError`, never `HTTPException`.
+- `swing_screener/cli.py` (`python -m swing_screener.cli`) — data/admin operations (universe refresh,
+  report generation). Depends on the domain core directly.
+
+## Error Boundary
+
+The application layer (`api/services`), persistence (`api/repositories`), and IO helpers
+(`api/utils/file_lock.py`, `api/utils/files.py`) are framework-free: they raise
+`swing_screener.errors.DomainError` subclasses, never `fastapi.HTTPException`. A single handler in
+`api/main.py` (`register_domain_error_handler`) translates `DomainError.http_status` to the HTTP
+response. Enforced by `tests/test_services_no_fastapi.py`.
 
 ## API and Frontend Note
 

--- a/docs/overview/INDEX.md
+++ b/docs/overview/INDEX.md
@@ -16,6 +16,7 @@
 - `/docs/engineering/DATA_SOURCE_AUDIT_AND_PROVIDER_STRATEGY.md`
 - `/docs/engineering/ROADMAP.md`
 - `/docs/engineering/MODULE_ARCHITECTURE.md`
+- `/docs/engineering/BACKEND_ARCHITECTURE_ASSESSMENT.md`
 - `/docs/engineering/DATABASE_MIGRATION.md`
 - `/docs/engineering/OPERATIONAL_GUIDE.md`
 - `/docs/engineering/TROUBLESHOOTING.md`
@@ -59,6 +60,7 @@ Config:
 - `/docs/superpowers/plans/2026-06-12-index-universes-wikipedia.md`
 - `/docs/superpowers/specs/2026-06-14-candlestick-chart-pattern-reader-design.md`
 - `/docs/superpowers/plans/2026-06-14-candlestick-chart-pattern-reader.md`
+- `/docs/superpowers/plans/2026-06-16-backend-pr-a-domain-errors-logging-docs.md`
 
 ## Repo Policy Docs
 - `/.github/BRANCH_PROTECTION.md`

--- a/src/swing_screener/data/providers/yfinance_provider.py
+++ b/src/swing_screener/data/providers/yfinance_provider.py
@@ -112,8 +112,8 @@ class YfinanceProvider(MarketDataProvider):
             logger.warning("Failed to persist OHLCV cache index %s: %s", path, exc)
             try:
                 tmp.unlink(missing_ok=True)
-            except OSError:
-                pass
+            except OSError as rm_exc:
+                logger.debug("Failed to remove temp cache index %s: %s", tmp, rm_exc)
 
     def _store_per_ticker_cache(
         self,
@@ -207,8 +207,8 @@ class YfinanceProvider(MarketDataProvider):
             logger.warning("Failed writing OHLCV cache %s: %s", cache_file, exc)
             try:
                 tmp_file.unlink(missing_ok=True)
-            except Exception:
-                pass
+            except Exception as rm_exc:
+                logger.debug("Failed to remove temp OHLCV cache %s: %s", tmp_file, rm_exc)
 
     def _iter_chunks(self, tickers: list[str], size: int) -> Iterator[list[str]]:
         """Yield fixed-size chunks from a ticker list."""

--- a/src/swing_screener/data/symbol_discovery.py
+++ b/src/swing_screener/data/symbol_discovery.py
@@ -10,6 +10,10 @@ from http.cookiejar import CookieJar
 from urllib.parse import quote, urlencode
 from urllib.request import HTTPCookieProcessor, Request, build_opener, urlopen
 
+from swing_screener.utils.logging_config import get_logger
+
+logger = get_logger(__name__)
+
 
 DiscoveryProvider = Literal["yahoo_predefined", "eodhd_exchange"]
 
@@ -121,7 +125,7 @@ def _fetch_yahoo_custom_json(payload: dict) -> dict:
     try:
         opener.open(Request(YAHOO_COOKIE_URL, headers=headers), timeout=10).read()
     except Exception:
-        pass
+        logger.debug("Yahoo cookie prefetch failed; continuing without cookie", exc_info=True)
     crumb_request = Request(YAHOO_CRUMB_URL, headers=headers)
     with opener.open(crumb_request, timeout=15) as response:
         crumb = response.read().decode("utf-8", errors="ignore").strip()

--- a/src/swing_screener/data/ticker_info.py
+++ b/src/swing_screener/data/ticker_info.py
@@ -64,8 +64,8 @@ def _save_info_cache(path: Path, cache: dict[str, dict]) -> None:
         logger.warning("Failed to persist ticker info cache %s: %s", path, exc)
         try:
             tmp.unlink(missing_ok=True)
-        except OSError:
-            pass
+        except OSError as rm_exc:
+            logger.debug("Failed to remove temp ticker info cache %s: %s", tmp, rm_exc)
 
 
 def get_multiple_ticker_info(

--- a/src/swing_screener/data/universe.py
+++ b/src/swing_screener/data/universe.py
@@ -15,7 +15,9 @@ except Exception:  # pragma: no cover
     import importlib_resources  # type: ignore
 
 from swing_screener.data.universe_sources import refresh_snapshot_from_source
+from swing_screener.utils.logging_config import get_logger
 
+logger = get_logger(__name__)
 
 _TICKER_RE = re.compile(r"^[A-Z0-9.\-]+$")
 _BENCHMARK_RE = re.compile(r"^[A-Z0-9.^\-]+$")
@@ -559,7 +561,7 @@ def get_universe_benchmark(name: str) -> Optional[str]:
         if benchmark:
             return _normalize_benchmark_symbol(str(benchmark))
     except Exception:
-        pass
+        logger.warning("Failed to load snapshot for universe %r; falling back to manifest", name, exc_info=True)
     for entry in _load_registry_manifest():
         if entry.get("id") == name:
             b = entry.get("benchmark")
@@ -626,7 +628,7 @@ def load_universe_from_file(
             if row:
                 raw_items.append(row[0])
     except Exception:
-        pass
+        logger.debug("CSV re-parse of universe file failed; using line-split results", exc_info=True)
 
     tickers = normalize_tickers(raw_items)
     tickers = apply_universe_config(tickers, cfg)

--- a/src/swing_screener/errors.py
+++ b/src/swing_screener/errors.py
@@ -1,0 +1,43 @@
+"""Framework-free domain errors.
+
+Services raise these instead of fastapi.HTTPException. The FastAPI adapter
+(api/main.py) maps each subclass to its HTTP status; non-HTTP callers (the CLI)
+catch DomainError and render it themselves. Nothing here imports a web framework.
+"""
+from __future__ import annotations
+
+
+class DomainError(Exception):
+    """Base for all expected, caller-facing domain failures."""
+
+    http_status: int = 500
+
+    def __init__(self, detail: str) -> None:
+        super().__init__(detail)
+        self.detail = detail
+
+
+class NotFoundError(DomainError):
+    http_status = 404
+
+
+class ValidationError(DomainError):
+    http_status = 400
+
+
+class ConflictError(DomainError):
+    http_status = 409
+
+
+class UnprocessableError(DomainError):
+    http_status = 422
+
+
+class ServiceError(DomainError):
+    http_status = 500
+
+
+class UpstreamError(DomainError):
+    """A dependency (data provider, external API) failed."""
+
+    http_status = 502

--- a/src/swing_screener/errors.py
+++ b/src/swing_screener/errors.py
@@ -41,3 +41,9 @@ class UpstreamError(DomainError):
     """A dependency (data provider, external API) failed."""
 
     http_status = 502
+
+
+class ServiceUnavailableError(DomainError):
+    """A transient condition (e.g. lock contention) prevents serving the request."""
+
+    http_status = 503

--- a/src/swing_screener/fundamentals/earnings_proximity.py
+++ b/src/swing_screener/fundamentals/earnings_proximity.py
@@ -46,8 +46,8 @@ def _save_earnings_cache(path: Path, cache: dict[str, dict]) -> None:
         logger.warning("Failed to persist earnings cache %s: %s", path, exc)
         try:
             tmp.unlink(missing_ok=True)
-        except OSError:
-            pass
+        except OSError as rm_exc:
+            logger.debug("Failed to remove temp earnings cache %s: %s", tmp, rm_exc)
 
 
 def _is_auth_error(exc: Exception) -> bool:

--- a/src/swing_screener/fundamentals/providers/degiro.py
+++ b/src/swing_screener/fundamentals/providers/degiro.py
@@ -85,7 +85,7 @@ def _current_ratio_value(groups: list[dict], ratio_id: str) -> Optional[float]:
                 try:
                     return float(item["value"])
                 except (TypeError, ValueError):
-                    pass
+                    pass  # parse fallback
     return None
 
 
@@ -96,7 +96,7 @@ def _forecast_value(ratios: list[dict], ratio_id: str) -> Optional[float]:
             try:
                 return float(r["value"])
             except (TypeError, ValueError):
-                pass
+                pass  # parse fallback
     return None
 
 
@@ -111,7 +111,7 @@ def _estimate_item(statements: list[dict], stmt_type: str, code: str) -> Optiona
                         try:
                             return float(v)
                         except (TypeError, ValueError):
-                            pass
+                            pass  # parse fallback
     return None
 
 
@@ -172,7 +172,7 @@ class DegiroFundamentalsProvider:
                 info = yf.Ticker(symbol).info
                 isin = info.get("isin") or None
             except Exception:
-                pass
+                logger.warning("yfinance ISIN lookup failed for %r; ISIN unresolved", symbol, exc_info=True)
 
         self._isin_cache[symbol] = isin
         return isin
@@ -197,7 +197,7 @@ class DegiroFundamentalsProvider:
             try:
                 self._client.disconnect()
             except Exception:
-                pass
+                logger.debug("DeGiro client disconnect failed; ignoring", exc_info=True)
             self._client = None
 
     # ------------------------------------------------------------------

--- a/src/swing_screener/intelligence/symbol_analyzer.py
+++ b/src/swing_screener/intelligence/symbol_analyzer.py
@@ -10,6 +10,9 @@ from openai import OpenAI
 from swing_screener.intelligence.cache import write_to_cache
 from swing_screener.intelligence.models import SymbolIntelligence, SymbolIntelligenceRequest
 from swing_screener.settings import get_settings_manager
+from swing_screener.utils.logging_config import get_logger
+
+logger = get_logger(__name__)
 
 _SYSTEM_PROMPT = """\
 You are a swing-trading analyst. Given the technical context below and live web search results, \
@@ -460,5 +463,5 @@ class SymbolAnalyzer:
         try:
             write_to_cache(ticker, result)
         except Exception:
-            pass
+            logger.warning("Failed to write intelligence cache for %r; result will not be cached", ticker, exc_info=True)
         return result

--- a/src/swing_screener/utils/logging_config.py
+++ b/src/swing_screener/utils/logging_config.py
@@ -1,0 +1,16 @@
+"""Logging convention for the backend.
+
+Convention (see docs/engineering/MODULE_ARCHITECTURE.md):
+- One module logger per file: `logger = get_logger(__name__)`.
+- `logger.info`  — use-case boundaries (a screen run started/finished, a position closed).
+- `logger.warning` — recoverable degradation, ALWAYS with the reason and the affected key.
+- `logger.exception` — only inside the `except` that owns/handles the failure.
+- Never `except: pass` silently. Either log a reason at debug/warning, or re-raise.
+"""
+from __future__ import annotations
+
+import logging
+
+
+def get_logger(name: str) -> logging.Logger:
+    return logging.getLogger(name)

--- a/tests/api/test_daily_review_service.py
+++ b/tests/api/test_daily_review_service.py
@@ -2,7 +2,7 @@
 from datetime import date, timedelta
 from unittest.mock import Mock
 import pytest
-from fastapi import HTTPException
+from swing_screener.errors import UpstreamError
 
 from api.models.daily_review import DailyReview, PendingOrderReview
 from api.models.screener import ScreenerResponse, ScreenerCandidate, SameSymbolCandidateContext
@@ -479,12 +479,12 @@ def test_generate_daily_review_survives_stop_suggestion_error(
     mock_portfolio_service,
     tmp_path,
 ):
-    """A single stop-suggestion failure should not fail the whole review."""
+    """A DomainError from suggest_position_stop degrades gracefully (warning branch)."""
     original_side_effect = mock_portfolio_service.suggest_position_stop.side_effect
 
     def side_effect(position_id: str):
         if position_id == "pos2":
-            raise HTTPException(status_code=502, detail="Failed to fetch market data for GOOGL")
+            raise UpstreamError("Failed to fetch market data for GOOGL")
         return original_side_effect(position_id)
 
     mock_portfolio_service.suggest_position_stop.side_effect = side_effect

--- a/tests/api/test_domain_error_translation.py
+++ b/tests/api/test_domain_error_translation.py
@@ -1,0 +1,34 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from swing_screener.errors import NotFoundError, ValidationError, UpstreamError
+from api.main import register_domain_error_handler
+
+
+def _app_raising(exc):
+    app = FastAPI()
+    register_domain_error_handler(app)
+
+    @app.get("/boom")
+    def boom():
+        raise exc
+
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_not_found_maps_to_404():
+    r = _app_raising(NotFoundError("Position not found: P1")).get("/boom")
+    assert r.status_code == 404
+    assert r.json() == {"detail": "Position not found: P1"}
+
+
+def test_validation_maps_to_400():
+    r = _app_raising(ValidationError("bad")).get("/boom")
+    assert r.status_code == 400
+    assert r.json() == {"detail": "bad"}
+
+
+def test_upstream_maps_to_502():
+    r = _app_raising(UpstreamError("provider down")).get("/boom")
+    assert r.status_code == 502
+    assert r.json() == {"detail": "provider down"}

--- a/tests/api/test_partial_close.py
+++ b/tests/api/test_partial_close.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 import pytest
-from fastapi import HTTPException
+from swing_screener.errors import ValidationError
 from api.models.portfolio import (
     PartialCloseRequest,
     PartialCloseEvent,
@@ -125,9 +125,8 @@ def test_partial_close_preserves_initial_risk(tmp_path: Path):
 def test_partial_close_rejects_closing_all_shares(tmp_path):
     svc = _make_service_simple(tmp_path)
     req = PartialCloseRequest(shares_closed=10, price=22.0)
-    with pytest.raises(HTTPException) as exc_info:
+    with pytest.raises(ValidationError):
         svc.partial_close_position("POS-001", req)
-    assert exc_info.value.status_code == 400
 
 
 def test_partial_close_rejects_closed_position(tmp_path):
@@ -138,6 +137,5 @@ def test_partial_close_rejects_closed_position(tmp_path):
     pos_file.write_text(json.dumps({"positions": [pos], "asof": "2026-01-01"}))
     svc = PortfolioService(positions_repo=PositionsRepository(pos_file))
     req = PartialCloseRequest(shares_closed=5, price=22.0)
-    with pytest.raises(HTTPException) as exc_info:
+    with pytest.raises(ValidationError):
         svc.partial_close_position("POS-001", req)
-    assert exc_info.value.status_code == 400

--- a/tests/api/test_partial_close.py
+++ b/tests/api/test_partial_close.py
@@ -125,8 +125,9 @@ def test_partial_close_preserves_initial_risk(tmp_path: Path):
 def test_partial_close_rejects_closing_all_shares(tmp_path):
     svc = _make_service_simple(tmp_path)
     req = PartialCloseRequest(shares_closed=10, price=22.0)
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError) as exc_info:
         svc.partial_close_position("POS-001", req)
+    assert exc_info.value.http_status == 400
 
 
 def test_partial_close_rejects_closed_position(tmp_path):
@@ -137,5 +138,6 @@ def test_partial_close_rejects_closed_position(tmp_path):
     pos_file.write_text(json.dumps({"positions": [pos], "asof": "2026-01-01"}))
     svc = PortfolioService(positions_repo=PositionsRepository(pos_file))
     req = PartialCloseRequest(shares_closed=5, price=22.0)
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError) as exc_info:
         svc.partial_close_position("POS-001", req)
+    assert exc_info.value.http_status == 400

--- a/tests/test_cli_domain_errors.py
+++ b/tests/test_cli_domain_errors.py
@@ -1,0 +1,9 @@
+from swing_screener.errors import NotFoundError
+from agent.cli import render_domain_error
+
+
+def test_render_domain_error_returns_message_and_exit_code(capsys):
+    code = render_domain_error(NotFoundError("Position not found: P1"))
+    out = capsys.readouterr()
+    assert code == 1
+    assert "Position not found: P1" in (out.err + out.out)

--- a/tests/test_cli_domain_errors.py
+++ b/tests/test_cli_domain_errors.py
@@ -1,3 +1,6 @@
+import sys
+from unittest.mock import MagicMock
+
 from swing_screener.errors import NotFoundError
 from agent.cli import render_domain_error
 
@@ -7,3 +10,21 @@ def test_render_domain_error_returns_message_and_exit_code(capsys):
     out = capsys.readouterr()
     assert code == 1
     assert "Position not found: P1" in (out.err + out.out)
+
+
+def test_domain_error_propagates_from_command_to_main(monkeypatch, capsys):
+    """DomainError raised inside a cmd_* handler reaches main()'s handler,
+    exits with code 1, and prints the detail to stderr."""
+    error_detail = "Position not found: TEST-99"
+    mock_service = MagicMock()
+    mock_service.list_positions.side_effect = NotFoundError(error_detail)
+
+    import agent.cli as cli_module
+    monkeypatch.setattr(cli_module, "_portfolio_service", lambda: mock_service)
+    monkeypatch.setattr(sys, "argv", ["cli", "positions", "review"])
+
+    exit_code = cli_module.main()
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert error_detail in captured.err

--- a/tests/test_domain_errors.py
+++ b/tests/test_domain_errors.py
@@ -1,0 +1,29 @@
+import pytest
+from swing_screener.errors import (
+    DomainError, NotFoundError, ValidationError, ConflictError,
+    UnprocessableError, ServiceError, UpstreamError,
+)
+
+
+@pytest.mark.parametrize(
+    "exc_cls, expected_status",
+    [
+        (NotFoundError, 404),
+        (ValidationError, 400),
+        (ConflictError, 409),
+        (UnprocessableError, 422),
+        (ServiceError, 500),
+        (UpstreamError, 502),
+    ],
+)
+def test_each_error_carries_its_http_status(exc_cls, expected_status):
+    err = exc_cls("boom")
+    assert isinstance(err, DomainError)
+    assert err.http_status == expected_status
+    assert err.detail == "boom"
+    assert str(err) == "boom"
+
+
+def test_domain_error_is_not_an_httpexception():
+    err = NotFoundError("x")
+    assert "fastapi" not in type(err).__module__

--- a/tests/test_domain_errors.py
+++ b/tests/test_domain_errors.py
@@ -1,7 +1,7 @@
 import pytest
 from swing_screener.errors import (
     DomainError, NotFoundError, ValidationError, ConflictError,
-    UnprocessableError, ServiceError, UpstreamError,
+    UnprocessableError, ServiceError, UpstreamError, ServiceUnavailableError,
 )
 
 
@@ -14,6 +14,7 @@ from swing_screener.errors import (
         (UnprocessableError, 422),
         (ServiceError, 500),
         (UpstreamError, 502),
+        (ServiceUnavailableError, 503),
     ],
 )
 def test_each_error_carries_its_http_status(exc_cls, expected_status):

--- a/tests/test_file_lock.py
+++ b/tests/test_file_lock.py
@@ -10,9 +10,9 @@ from pathlib import Path
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import pytest
-from fastapi import HTTPException
 
 from api.utils.file_lock import locked_read_json, locked_write_json, locked_read_modify_write
+from swing_screener.errors import NotFoundError, ServiceError, ServiceUnavailableError
 
 
 def _portalocker_timeout_warnings(caught: list[warnings.WarningMessage]) -> list[warnings.WarningMessage]:
@@ -50,24 +50,24 @@ class TestBasicLocking:
         assert not _portalocker_timeout_warnings(caught)
 
     def test_locked_read_nonexistent_file(self, tmp_path):
-        """Test that reading non-existent file raises HTTPException 404."""
+        """Test that reading non-existent file raises NotFoundError 404."""
         test_file = tmp_path / "nonexistent.json"
 
-        with pytest.raises(HTTPException) as exc_info:
+        with pytest.raises(NotFoundError) as exc_info:
             locked_read_json(test_file)
 
-        assert exc_info.value.status_code == 404
+        assert exc_info.value.http_status == 404
         assert "File not found" in exc_info.value.detail
 
     def test_locked_read_invalid_json(self, tmp_path):
-        """Test that invalid JSON raises HTTPException 500."""
+        """Test that invalid JSON raises ServiceError 500."""
         test_file = tmp_path / "invalid.json"
         test_file.write_text("{invalid json}")
 
-        with pytest.raises(HTTPException) as exc_info:
+        with pytest.raises(ServiceError) as exc_info:
             locked_read_json(test_file)
 
-        assert exc_info.value.status_code == 500
+        assert exc_info.value.http_status == 500
         assert "Invalid JSON" in exc_info.value.detail
 
     def test_locked_read_handles_nan(self, tmp_path):
@@ -140,12 +140,9 @@ class TestConcurrentAccess:
                 # Write back
                 locked_write_json(test_file, data)
                 successful_writes.append(thread_id)
-            except HTTPException as e:
-                if e.status_code == 503:
-                    # Lock timeout is acceptable
-                    pass
-                else:
-                    errors.append(e)
+            except ServiceUnavailableError:
+                # Lock timeout is acceptable
+                pass
             except Exception as e:
                 errors.append(e)
 
@@ -178,12 +175,9 @@ class TestConcurrentAccess:
                     return data
 
                 locked_read_modify_write(test_file, modify)
-            except HTTPException as e:
-                if e.status_code == 503:
-                    # Lock timeout acceptable
-                    pass
-                else:
-                    errors.append(e)
+            except ServiceUnavailableError:
+                # Lock timeout acceptable
+                pass
             except Exception as e:
                 errors.append(e)
 
@@ -211,7 +205,7 @@ class TestLockTimeout:
         locked_write_json(test_file, test_data)
 
         results = []
-        
+
         def slow_write():
             """Hold lock for a bit then write."""
             import portalocker
@@ -230,17 +224,16 @@ class TestLockTimeout:
                     json.dump(data, f)
                     f.flush()
             results.append("slow")
-        
+
         def fast_write():
             """Try to write while lock is held."""
             time.sleep(0.1)  # Let slow_write acquire lock first
             try:
                 locked_write_json(test_file, {"fast": "write"}, timeout=2.0)
                 results.append("fast")
-            except HTTPException as e:
-                if e.status_code == 503:
-                    results.append("timeout")
-        
+            except ServiceUnavailableError:
+                results.append("timeout")
+
         # Start both threads
         import concurrent.futures
         with warnings.catch_warnings(record=True) as caught:

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,0 +1,8 @@
+import logging
+from swing_screener.utils.logging_config import get_logger
+
+
+def test_get_logger_returns_namespaced_logger():
+    log = get_logger("swing_screener.demo")
+    assert isinstance(log, logging.Logger)
+    assert log.name == "swing_screener.demo"

--- a/tests/test_services_no_fastapi.py
+++ b/tests/test_services_no_fastapi.py
@@ -1,11 +1,20 @@
 import ast
 import pathlib
 
-SERVICES_DIR = pathlib.Path(__file__).resolve().parents[1] / "api" / "services"
+_ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+_INFRA_DIRS = [
+    _ROOT / "api" / "services",
+    _ROOT / "api" / "repositories",
+    _ROOT / "api" / "utils",
+]
 
 
 def _imports_fastapi(path: pathlib.Path) -> bool:
-    tree = ast.parse(path.read_text())
+    try:
+        tree = ast.parse(path.read_text())
+    except SyntaxError as exc:
+        raise SyntaxError(f"Syntax error in {path}: {exc}") from exc
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             if any(a.name.split(".")[0] == "fastapi" for a in node.names):
@@ -16,6 +25,20 @@ def _imports_fastapi(path: pathlib.Path) -> bool:
     return False
 
 
-def test_no_service_imports_fastapi():
-    offenders = [p.name for p in SERVICES_DIR.glob("*.py") if _imports_fastapi(p)]
-    assert offenders == [], f"services must be framework-free, found fastapi import in: {offenders}"
+def test_infra_layers_have_no_fastapi():
+    existing_dirs = [d for d in _INFRA_DIRS if d.exists()]
+    assert existing_dirs, (
+        "None of the expected infra dirs exist — check that the repo structure hasn't changed: "
+        + str([str(d) for d in _INFRA_DIRS])
+    )
+
+    offenders: list[str] = []
+    for d in existing_dirs:
+        for p in d.rglob("*.py"):
+            if _imports_fastapi(p):
+                offenders.append(str(p.relative_to(_ROOT)))
+
+    assert offenders == [], (
+        "Infra layers (services/repositories/utils) must be framework-free; "
+        f"found fastapi import in: {offenders}"
+    )

--- a/tests/test_services_no_fastapi.py
+++ b/tests/test_services_no_fastapi.py
@@ -1,0 +1,21 @@
+import ast
+import pathlib
+
+SERVICES_DIR = pathlib.Path(__file__).resolve().parents[1] / "api" / "services"
+
+
+def _imports_fastapi(path: pathlib.Path) -> bool:
+    tree = ast.parse(path.read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            if any(a.name.split(".")[0] == "fastapi" for a in node.names):
+                return True
+        elif isinstance(node, ast.ImportFrom):
+            if (node.module or "").split(".")[0] == "fastapi":
+                return True
+    return False
+
+
+def test_no_service_imports_fastapi():
+    offenders = [p.name for p in SERVICES_DIR.glob("*.py") if _imports_fastapi(p)]
+    assert offenders == [], f"services must be framework-free, found fastapi import in: {offenders}"


### PR DESCRIPTION
First PR of the backend architecture refactor described in `docs/engineering/BACKEND_ARCHITECTURE_ASSESSMENT.md`. The application/service layer used to live inside the FastAPI package and raise `fastapi.HTTPException` directly, which coupled it to HTTP and leaked the web framework into the non-HTTP `agent/cli.py` runtime path. This PR breaks that coupling.

The new framework-free `swing_screener.errors` module defines a `DomainError` base plus typed subclasses (`NotFoundError`, `ValidationError`, `ConflictError`, `UnprocessableError`, `ServiceError`, `UpstreamError`, `ServiceUnavailableError`), each carrying its `http_status`. Services now raise these instead of `HTTPException`, and a single handler in `api/main.py` (`register_domain_error_handler`) translates any `DomainError` to the same `{"detail": ...}` JSON response it produced before. HTTP responses stay byte-identical: same status codes, same bodies.

The decoupling goes all the way down: `api/utils/file_lock.py` and `api/utils/files.py` (used by every repository) were also raising `HTTPException`, so their errors used to bypass any domain handling. They now raise `DomainError` too. `grep HTTPException` across `api/services`, `api/repositories` and `api/utils` is empty, and `tests/test_services_no_fastapi.py` enforces that those three layers never import `fastapi` again.

`agent/cli.py` now catches `DomainError` and renders the message to stderr with a non-zero exit code instead of leaking a traceback.

Also in this PR:
- `docs/engineering/MODULE_ARCHITECTURE.md` now documents all real domains (it was missing `fundamentals`, `intelligence`, `recommendation`, `settings`, `integrations`), the two-CLI boundary, and the error boundary.
- A `get_logger` logging convention helper, plus a pass replacing silent `except: pass` swallows with reason logs (legitimate scalar parse-fallbacks were kept, with a comment).

Behavior change worth flagging: a few error paths that were silently swallowed now emit a log line, and the `daily_review` stop-suggestion degradation path now logs at WARNING instead of falling through to a generic ERROR.

Test status: full suite green in CI mode (`pytest -m "not integration"`), 849 passed. The only failing test outside CI mode is `test_finnhub_integration.py`, a live-API integration test that needs a Finnhub key, unrelated to this change.

Not included here, follow-up PRs per the assessment: splitting `run_screener` and `portfolio_service`, moving the service layer out of `api/`, and the `db.py` dead-code removal.