### PR TITLE
Split the run_screener god-method into named pipeline steps and relocate pure helpers to core

### DIFF
--- a/api/services/screener_service.py
+++ b/api/services/screener_service.py
@@ -1383,26 +1383,10 @@ class ScreenerService:
                 combined_priority_cfg=CombinedPriorityConfig(),
             )
             requested_top = self._resolve_universe_and_window(ctx)
-            # Bridge ctx fields back into local names still used by not-yet-extracted code below.
-            warnings = ctx.warnings
-            universe_cfg = ctx.universe_cfg
-            benchmark = ctx.benchmark
-            tickers = ctx.tickers
-            asof_str = ctx.asof_str
-            market_health = ctx.market_health
-            strategy = ctx.strategy
-            combined_priority_cfg = ctx.combined_priority_cfg
 
             self._build_signals_and_fetch_ohlcv(ctx, requested_top)
-            signals_cfg = ctx.signals_cfg
-            ohlcv = ctx.ohlcv
-            last_bar_map = ctx.last_bar_map
-            overall_last_bar = ctx.overall_last_bar
-            data_freshness = ctx.data_freshness
 
             self._build_run_configs(ctx, requested_top)
-            risk_cfg = ctx.risk_cfg
-            universe_cfg = ctx.universe_cfg
 
             results = self._run_daily_report(ctx, requested_top)
             if results is None:
@@ -1415,13 +1399,8 @@ class ScreenerService:
                     same_symbol_suppressed_count=0,
                     same_symbol_add_on_count=0,
                 )
-            # Bridge ctx fields back into local names still used by not-yet-extracted code below.
-            ticker_info = ctx.ticker_info
-            sector_rotation_by_name = ctx.sector_rotation_by_name
 
             candidates = self._build_candidates(ctx, results)
-            benchmark_change_pct = ctx.benchmark_change_pct
-            benchmark_last_bar = ctx.benchmark_last_bar
 
             candidates, same_symbol_suppressed_count, same_symbol_add_on_count = (
                 self._apply_same_symbol_filter(ctx, candidates)
@@ -1432,13 +1411,13 @@ class ScreenerService:
 
             response = ScreenerResponse(
                 candidates=candidates,
-                asof_date=asof_str,
-                total_screened=len(tickers),
-                benchmark_ticker=benchmark,
-                benchmark_change_pct=benchmark_change_pct,
-                benchmark_last_bar=benchmark_last_bar,
-                data_freshness=data_freshness,
-                warnings=warnings,
+                asof_date=ctx.asof_str,
+                total_screened=len(ctx.tickers),
+                benchmark_ticker=ctx.benchmark,
+                benchmark_change_pct=ctx.benchmark_change_pct,
+                benchmark_last_bar=ctx.benchmark_last_bar,
+                data_freshness=ctx.data_freshness,
+                warnings=ctx.warnings,
                 same_symbol_suppressed_count=same_symbol_suppressed_count,
                 same_symbol_add_on_count=same_symbol_add_on_count,
             )

--- a/api/services/screener_service.py
+++ b/api/services/screener_service.py
@@ -1,7 +1,7 @@
 """Screener service."""
 from __future__ import annotations
 
-from dataclasses import replace, asdict
+from dataclasses import replace, asdict, dataclass, field
 from typing import Optional
 import datetime as dt
 from datetime import datetime, timezone, timedelta
@@ -725,6 +725,42 @@ def _safe_list(val):
             return [v.strip() for v in val.split(sep) if v.strip()]
         return [val]
     return [str(val)]
+
+
+@dataclass
+class _RunContext:
+    """Mutable state accumulated across run_screener pipeline steps.
+
+    Holds everything the steps hand to each other so step signatures stay
+    small. Created fresh per run_screener call; never shared across calls.
+    """
+    request: ScreenerRequest
+    strategy: dict
+    warnings: list[str] = field(default_factory=list)
+    # populated by steps as the run progresses
+    universe_cfg: object = None
+    signals_cfg: object = None
+    ranking_cfg: object = None
+    risk_cfg: object = None
+    report_cfg: object = None
+    benchmark: str = ""
+    tickers: list[str] = field(default_factory=list)
+    screening_tickers: list[str] = field(default_factory=list)
+    active_currencies: list[str] = field(default_factory=list)
+    asof_str: str = ""
+    start_date: str = ""
+    end_date: str = ""
+    market_health: dict = field(default_factory=dict)
+    ohlcv: object = None
+    last_bar_map: dict = field(default_factory=dict)
+    overall_last_bar: object = None
+    data_freshness: str = ""
+    ticker_info: dict = field(default_factory=dict)
+    sector_rotation_by_name: dict = field(default_factory=dict)
+    combined_priority_cfg: object = None
+    now_utc: object = None
+    benchmark_change_pct: object = None
+    benchmark_last_bar: object = None
 
 
 class ScreenerService:

--- a/api/services/screener_service.py
+++ b/api/services/screener_service.py
@@ -942,6 +942,57 @@ class ScreenerService:
                     f"{', '.join(missing)}"
                 )
 
+    def _build_run_configs(self, ctx: _RunContext, requested_top: int) -> None:
+        """Apply request filter overrides and build ranking/risk/report configs.
+
+        Mutates ctx.universe_cfg; populates ctx.ranking_cfg, risk_cfg, report_cfg;
+        appends regime-scaling warnings. requested_top sizes the prefilter pool.
+        """
+        fields_set = ctx.request.model_fields_set
+
+        if "min_price" in fields_set or "max_price" in fields_set:
+            filt = ctx.universe_cfg.filt
+            min_price = ctx.request.min_price if ctx.request.min_price is not None else filt.min_price
+            max_price = ctx.request.max_price if ctx.request.max_price is not None else filt.max_price
+            ctx.universe_cfg = replace(ctx.universe_cfg, filt=replace(filt, min_price=min_price, max_price=max_price))
+        if "currencies" in fields_set and ctx.request.currencies is not None:
+            filt = ctx.universe_cfg.filt
+            requested_currencies = [
+                str(code).strip().upper()
+                for code in ctx.request.currencies
+                if str(code).strip()
+            ]
+            if not requested_currencies:
+                requested_currencies = ["USD", "EUR"]
+            ctx.universe_cfg = replace(ctx.universe_cfg, filt=replace(filt, currencies=requested_currencies))
+        if "require_weekly_uptrend" in fields_set and ctx.request.require_weekly_uptrend is not None:
+            filt = ctx.universe_cfg.filt
+            ctx.universe_cfg = replace(ctx.universe_cfg, filt=replace(filt, require_weekly_uptrend=ctx.request.require_weekly_uptrend))
+
+        ctx.ranking_cfg = build_ranking_config(ctx.strategy)
+        # Rank a pool of top * prefilter_multiplier so the combined-priority
+        # stage can re-rank beyond the requested top-N (stage 1 of 2).
+        prefilter_pool = requested_top * ctx.combined_priority_cfg.prefilter_multiplier
+        if ctx.ranking_cfg.top_n < prefilter_pool:
+            ctx.ranking_cfg = replace(ctx.ranking_cfg, top_n=prefilter_pool)
+
+        ctx.risk_cfg = build_risk_config(ctx.strategy)
+        multiplier, regime_meta = compute_regime_risk_multiplier(ctx.ohlcv, ctx.benchmark, ctx.risk_cfg)
+        if multiplier != 1.0:
+            ctx.risk_cfg = replace(ctx.risk_cfg, risk_pct=ctx.risk_cfg.risk_pct * multiplier)
+            if regime_meta.get("reasons"):
+                reasons = ", ".join(regime_meta["reasons"])
+                ctx.warnings.append(f"Risk scaled by {multiplier:.2f}x due to regime: {reasons}")
+            else:
+                ctx.warnings.append(f"Risk scaled by {multiplier:.2f}x due to regime conditions.")
+
+        ctx.report_cfg = ReportConfig(
+            universe=ctx.universe_cfg,
+            ranking=ctx.ranking_cfg,
+            signals=ctx.signals_cfg,
+            risk=ctx.risk_cfg,
+        )
+
     def run_screener(self, request: ScreenerRequest, strategy_override: Optional[dict] = None) -> ScreenerResponse:
         try:
             ctx = _RunContext(
@@ -961,8 +1012,6 @@ class ScreenerService:
             strategy = ctx.strategy
             combined_priority_cfg = ctx.combined_priority_cfg
 
-            fields_set = request.model_fields_set
-
             self._build_signals_and_fetch_ohlcv(ctx, requested_top)
             signals_cfg = ctx.signals_cfg
             ohlcv = ctx.ohlcv
@@ -970,48 +1019,10 @@ class ScreenerService:
             overall_last_bar = ctx.overall_last_bar
             data_freshness = ctx.data_freshness
 
-            if "min_price" in fields_set or "max_price" in fields_set:
-                filt = universe_cfg.filt
-                min_price = request.min_price if request.min_price is not None else filt.min_price
-                max_price = request.max_price if request.max_price is not None else filt.max_price
-                universe_cfg = replace(universe_cfg, filt=replace(filt, min_price=min_price, max_price=max_price))
-            if "currencies" in fields_set and request.currencies is not None:
-                filt = universe_cfg.filt
-                requested_currencies = [
-                    str(code).strip().upper()
-                    for code in request.currencies
-                    if str(code).strip()
-                ]
-                if not requested_currencies:
-                    requested_currencies = ["USD", "EUR"]
-                universe_cfg = replace(universe_cfg, filt=replace(filt, currencies=requested_currencies))
-            if "require_weekly_uptrend" in fields_set and request.require_weekly_uptrend is not None:
-                filt = universe_cfg.filt
-                universe_cfg = replace(universe_cfg, filt=replace(filt, require_weekly_uptrend=request.require_weekly_uptrend))
-
-            ranking_cfg = build_ranking_config(strategy)
-            # Rank a pool of top * prefilter_multiplier so the combined-priority
-            # stage can re-rank beyond the requested top-N (stage 1 of 2).
-            prefilter_pool = requested_top * combined_priority_cfg.prefilter_multiplier
-            if ranking_cfg.top_n < prefilter_pool:
-                ranking_cfg = replace(ranking_cfg, top_n=prefilter_pool)
-
-            risk_cfg = build_risk_config(strategy)
-            multiplier, regime_meta = compute_regime_risk_multiplier(ohlcv, benchmark, risk_cfg)
-            if multiplier != 1.0:
-                risk_cfg = replace(risk_cfg, risk_pct=risk_cfg.risk_pct * multiplier)
-                if regime_meta.get("reasons"):
-                    reasons = ", ".join(regime_meta["reasons"])
-                    warnings.append(f"Risk scaled by {multiplier:.2f}x due to regime: {reasons}")
-                else:
-                    warnings.append(f"Risk scaled by {multiplier:.2f}x due to regime conditions.")
-
-            report_cfg = ReportConfig(
-                universe=universe_cfg,
-                ranking=ranking_cfg,
-                signals=signals_cfg,
-                risk=risk_cfg,
-            )
+            self._build_run_configs(ctx, requested_top)
+            report_cfg = ctx.report_cfg
+            risk_cfg = ctx.risk_cfg
+            universe_cfg = ctx.universe_cfg
 
             ticker_info = get_multiple_ticker_info(screening_tickers) if screening_tickers else {}
             etf_returns = sector_rotation.compute_sector_benchmark_returns(ohlcv)

--- a/api/services/screener_service.py
+++ b/api/services/screener_service.py
@@ -62,6 +62,12 @@ from swing_screener.strategy.config import (
 )
 from swing_screener.risk.regime import compute_regime_risk_multiplier
 from api.utils.converters import to_iso as _to_iso
+from swing_screener.utils.coerce import (
+    is_na_scalar,
+    safe_float,
+    safe_optional_float,
+    safe_optional_int,
+)
 
 # Map of removed universe ids to their replacements (or None if dropped with no replacement).
 _REMOVED_UNIVERSE_IDS: dict[str, str | None] = {
@@ -680,52 +686,6 @@ def _apply_decision_priority_ranking(candidates: list[ScreenerCandidate]) -> lis
 
 
 
-def _is_na_scalar(val) -> bool:
-    if val is None:
-        return True
-    if isinstance(val, (list, tuple, set, dict)):
-        return False
-    try:
-        return bool(pd.isna(val))
-    except (TypeError, ValueError):
-        return False
-
-
-def _safe_float(val, default=0.0):
-    if _is_na_scalar(val):
-        return default
-    return float(val)
-
-
-def _safe_optional_float(val):
-    if _is_na_scalar(val):
-        return None
-    return float(val)
-
-
-def _safe_optional_int(val):
-    if _is_na_scalar(val):
-        return None
-    try:
-        return int(val)
-    except (TypeError, ValueError, OverflowError):
-        return None
-
-
-def _safe_list(val):
-    if _is_na_scalar(val):
-        return []
-    if isinstance(val, list):
-        return [str(v) for v in val if not _is_na_scalar(v)]
-    if isinstance(val, str):
-        if not val.strip():
-            return []
-        sep = ";" if ";" in val else "," if "," in val else None
-        if sep:
-            return [v.strip() for v in val.split(sep) if v.strip()]
-        return [val]
-    return [str(val)]
-
 
 @dataclass
 class _RunContext:
@@ -1082,10 +1042,10 @@ class ScreenerService:
         ma_col = f"ma{signals_cfg.pullback_ma}_level"
         candidates = []
         for idx, row in results.iterrows():
-            sma20 = _safe_float(row.get(ma_col))
-            sma50_dist = _safe_float(row.get("dist_sma50_pct"))
-            sma200_dist = _safe_float(row.get("dist_sma200_pct"))
-            last_price = _safe_float(row.get("last"))
+            sma20 = safe_float(row.get(ma_col))
+            sma50_dist = safe_float(row.get("dist_sma50_pct"))
+            sma200_dist = safe_float(row.get("dist_sma200_pct"))
+            last_price = safe_float(row.get("last"))
 
             sma50 = last_price / (1 + sma50_dist / 100) if last_price and sma50_dist else last_price
             sma200 = last_price / (1 + sma200_dist / 100) if last_price and sma200_dist else last_price
@@ -1102,24 +1062,24 @@ class ScreenerService:
             ).upper()
 
             signal = row.get("signal")
-            entry_val = _safe_optional_float(row.get("entry")) or last_price
-            stop_val = _safe_optional_float(row.get("stop"))
+            entry_val = safe_optional_float(row.get("entry")) or last_price
+            stop_val = safe_optional_float(row.get("stop"))
             if stop_val is None and entry_val:
                 # No explicit stop from the pipeline — derive one from ATR so that
                 # target and R:R can be computed for the order panel.
-                atr_val = _safe_optional_float(row.get(atr_col))
+                atr_val = safe_optional_float(row.get(atr_col))
                 if atr_val and atr_val > 0:
                     stop_val = round(entry_val - 2.0 * atr_val, 4)
-            shares_val = _safe_optional_int(row.get("shares"))
-            position_size = _safe_optional_float(row.get("position_value"))
-            risk_usd = _safe_optional_float(row.get("realized_risk"))
+            shares_val = safe_optional_int(row.get("shares"))
+            position_size = safe_optional_float(row.get("position_value"))
+            risk_usd = safe_optional_float(row.get("realized_risk"))
             risk_pct = (risk_usd / risk_cfg.account_size) if risk_usd and risk_cfg.account_size else None
 
-            rr_target = _safe_float(getattr(risk_cfg, "rr_target", 2.0), default=2.0)
-            commission_pct = _safe_float(getattr(risk_cfg, "commission_pct", 0.0), default=0.0)
+            rr_target = safe_float(getattr(risk_cfg, "rr_target", 2.0), default=2.0)
+            commission_pct = safe_float(getattr(risk_cfg, "commission_pct", 0.0), default=0.0)
 
             rec_payload = evaluate_recommendation(
-                signal=str(signal) if not _is_na_scalar(signal) else None,
+                signal=str(signal) if not is_na_scalar(signal) else None,
                 entry=entry_val,
                 stop=stop_val,
                 shares=shares_val,
@@ -1137,11 +1097,11 @@ class ScreenerService:
                 sma_20=sma20,
                 sma_50=sma50,
                 sma_200=sma200,
-                atr=_safe_float(row.get(atr_col)),
-                momentum_6m=_safe_float(row.get("mom_6m")),
-                    momentum_12m=_safe_float(row.get("mom_12m")),
-                    rel_strength=_safe_float(row.get("rs_6m")),
-                    confidence=_safe_float(row.get("confidence")),
+                atr=safe_float(row.get(atr_col)),
+                momentum_6m=safe_float(row.get("mom_6m")),
+                    momentum_12m=safe_float(row.get("mom_12m")),
+                    rel_strength=safe_float(row.get("rs_6m")),
+                    confidence=safe_float(row.get("confidence")),
             )
             recommendation = Recommendation.model_validate(asdict(rec_payload))
             rec_risk = recommendation.risk
@@ -1171,7 +1131,7 @@ class ScreenerService:
                     ticker=ticker_str,
                     entry=entry_val,
                     current_stop=stop_val,
-                    atr=_safe_optional_float(row.get(atr_col)),
+                    atr=safe_optional_float(row.get(atr_col)),
                     patterns=patterns_map,
                     buffer_atr=exec_cfg.pattern_stop_atr_buffer,
                     min_rr_stop=None,
@@ -1191,42 +1151,42 @@ class ScreenerService:
                     sma_20=sma20,
                     sma_50=sma50,
                     sma_200=sma200,
-                    atr=_safe_float(row.get(atr_col)),
-                    momentum_6m=_safe_float(row.get("mom_6m")),
-                    momentum_12m=_safe_float(row.get("mom_12m")),
-                    rel_strength=_safe_float(row.get("rs_6m")),
-                    sector_rs=_safe_optional_float(row.get("sector_rs_6m")),
-                    score=_safe_float(row.get("score")),
-                    confidence=_safe_float(row.get("confidence")),
+                    atr=safe_float(row.get(atr_col)),
+                    momentum_6m=safe_float(row.get("mom_6m")),
+                    momentum_12m=safe_float(row.get("mom_12m")),
+                    rel_strength=safe_float(row.get("rs_6m")),
+                    sector_rs=safe_optional_float(row.get("sector_rs_6m")),
+                    score=safe_float(row.get("score")),
+                    confidence=safe_float(row.get("confidence")),
                     rank=int(row.get("rank", len(candidates) + 1)),
-                    sma20_slope=_safe_optional_float(row.get("sma20_slope")),
-                    sma50_slope=_safe_optional_float(row.get("sma50_slope")),
-                    consolidation_tightness=_safe_optional_float(row.get("consolidation_tightness")),
-                    close_location_in_range=_safe_optional_float(row.get("close_location_in_range")),
-                    above_breakout_extension=_safe_optional_float(row.get("above_breakout_extension")),
+                    sma20_slope=safe_optional_float(row.get("sma20_slope")),
+                    sma50_slope=safe_optional_float(row.get("sma50_slope")),
+                    consolidation_tightness=safe_optional_float(row.get("consolidation_tightness")),
+                    close_location_in_range=safe_optional_float(row.get("close_location_in_range")),
+                    above_breakout_extension=safe_optional_float(row.get("above_breakout_extension")),
                     breakout_volume_confirmation=(
                         bool(row.get("breakout_volume_confirmation"))
-                        if not _is_na_scalar(row.get("breakout_volume_confirmation"))
+                        if not is_na_scalar(row.get("breakout_volume_confirmation"))
                         else None
                     ),
-                    dist_52w_high_pct=_safe_optional_float(row.get("dist_52w_high_pct")),
+                    dist_52w_high_pct=safe_optional_float(row.get("dist_52w_high_pct")),
                     near_52w_high=(
                         bool(row.get("near_52w_high"))
-                        if not _is_na_scalar(row.get("near_52w_high"))
+                        if not is_na_scalar(row.get("near_52w_high"))
                         else None
                     ),
                     weekly_trend=(
                         str(row.get("weekly_trend"))
-                        if not _is_na_scalar(row.get("weekly_trend"))
+                        if not is_na_scalar(row.get("weekly_trend"))
                         else None
                     ),
-                    volume_ratio=_safe_optional_float(row.get("volume_ratio")),
-                    avg_daily_volume_eur=_safe_optional_float(row.get("avg_daily_volume_eur")),
+                    volume_ratio=safe_optional_float(row.get("volume_ratio")),
+                    avg_daily_volume_eur=safe_optional_float(row.get("avg_daily_volume_eur")),
                     symbol_change_pct=symbol_change_pct,
                     benchmark_outperformance_pct=benchmark_outperformance_pct,
                     sector_rotation_context=sector_rotation_by_name.get(info.get("sector")),
                     data_source_summary={"market_data": market_health},
-                    signal=str(signal) if not _is_na_scalar(signal) else None,
+                    signal=str(signal) if not is_na_scalar(signal) else None,
                     entry=rec_risk.entry,
                     stop=rec_risk.stop if stop_val is not None else None,
                     target=rec_risk.target,
@@ -1243,13 +1203,13 @@ class ScreenerService:
                     pattern_stop_reason=pattern_stop_reason,
                     suggested_order_type=(
                         str(row.get("suggested_order_type"))
-                        if not _is_na_scalar(row.get("suggested_order_type"))
+                        if not is_na_scalar(row.get("suggested_order_type"))
                         else None
                     ),
-                    suggested_order_price=_safe_optional_float(row.get("suggested_order_price")),
+                    suggested_order_price=safe_optional_float(row.get("suggested_order_price")),
                     execution_note=(
                         str(row.get("execution_note"))
-                        if not _is_na_scalar(row.get("execution_note"))
+                        if not is_na_scalar(row.get("execution_note"))
                         else None
                     ),
                 )
@@ -1359,8 +1319,8 @@ class ScreenerService:
         candidates = _rebuild_recommendations_with_decision_action(
             candidates,
             risk_cfg=risk_cfg,
-            rr_target=_safe_float(getattr(risk_cfg, "rr_target", 2.0), default=2.0),
-            commission_pct=_safe_float(getattr(risk_cfg, "commission_pct", 0.0), default=0.0),
+            rr_target=safe_float(getattr(risk_cfg, "rr_target", 2.0), default=2.0),
+            commission_pct=safe_float(getattr(risk_cfg, "commission_pct", 0.0), default=0.0),
         )
         candidates = _apply_decision_priority_ranking(candidates)
         if same_symbol_suppressed_count > 0:

--- a/api/services/screener_service.py
+++ b/api/services/screener_service.py
@@ -1308,6 +1308,73 @@ class ScreenerService:
 
         return filtered_candidates, same_symbol_suppressed_count, same_symbol_add_on_count
 
+    def _enrich_and_rank(
+        self,
+        ctx: _RunContext,
+        candidates: list[ScreenerCandidate],
+        requested_top: int,
+        same_symbol_suppressed_count: int,
+    ) -> list[ScreenerCandidate]:
+        """Enrich candidates (fundamentals, decision summary, earnings) and rank.
+
+        Applies combined-priority re-rank + trim to requested_top, rebuilds
+        recommendations with the decision action, applies decision-priority
+        ranking, and appends suppressed + sector-concentration warnings.
+        Returns the final candidate list.
+        """
+        asof_str = ctx.asof_str
+        combined_priority_cfg = ctx.combined_priority_cfg
+        risk_cfg = ctx.risk_cfg
+        ticker_info = ctx.ticker_info
+        warnings = ctx.warnings
+
+        fundamentals_snapshots = _load_fundamentals_snapshots(candidates)
+        candidates = _apply_cached_fundamentals_context(candidates, snapshots=fundamentals_snapshots)
+        candidates = _apply_decision_summary_context(candidates, snapshots=fundamentals_snapshots)
+
+        finnhub_key = os.environ.get("FINNHUB_API_KEY")
+        earnings_asof_date = dt.date.fromisoformat(asof_str)
+        earnings_days = fetch_next_earnings_days(
+            tickers=[candidate.ticker for candidate in candidates],
+            finnhub_api_key=finnhub_key,
+            asof_date=earnings_asof_date,
+            cache_path=".cache/earnings_days.json",
+        )
+        candidates = [
+            candidate.model_copy(update={"days_to_earnings": earnings_days.get(candidate.ticker)})
+            for candidate in candidates
+        ]
+
+        min_days_to_earnings = _min_days_to_earnings_default()
+        if min_days_to_earnings > 0:
+            candidates = [
+                candidate
+                for candidate in candidates
+                if candidate.days_to_earnings is None or candidate.days_to_earnings >= min_days_to_earnings
+            ]
+
+        # Stage 2: combined priority re-ranks prefilter set and trims to final top-N
+        candidates = compute_combined_priority(candidates, cfg=combined_priority_cfg)
+        candidates = candidates[:requested_top]
+        candidates = _rebuild_recommendations_with_decision_action(
+            candidates,
+            risk_cfg=risk_cfg,
+            rr_target=_safe_float(getattr(risk_cfg, "rr_target", 2.0), default=2.0),
+            commission_pct=_safe_float(getattr(risk_cfg, "commission_pct", 0.0), default=0.0),
+        )
+        candidates = _apply_decision_priority_ranking(candidates)
+        if same_symbol_suppressed_count > 0:
+            warnings.append(
+                f"{same_symbol_suppressed_count} same-symbol candidate"
+                f"{'' if same_symbol_suppressed_count == 1 else 's'} suppressed because they are manage-only."
+            )
+
+        visible_ticker_list = [candidate.ticker for candidate in candidates]
+        sector_map = {t: info.get("sector") for t, info in ticker_info.items()}
+        warnings.extend(sector_concentration_warnings(visible_ticker_list, sector_map))
+
+        return candidates
+
     def run_screener(self, request: ScreenerRequest, strategy_override: Optional[dict] = None) -> ScreenerResponse:
         try:
             ctx = _RunContext(
@@ -1359,50 +1426,9 @@ class ScreenerService:
             candidates, same_symbol_suppressed_count, same_symbol_add_on_count = (
                 self._apply_same_symbol_filter(ctx, candidates)
             )
-            fundamentals_snapshots = _load_fundamentals_snapshots(candidates)
-            candidates = _apply_cached_fundamentals_context(candidates, snapshots=fundamentals_snapshots)
-            candidates = _apply_decision_summary_context(candidates, snapshots=fundamentals_snapshots)
-
-            finnhub_key = os.environ.get("FINNHUB_API_KEY")
-            earnings_asof_date = dt.date.fromisoformat(asof_str)
-            earnings_days = fetch_next_earnings_days(
-                tickers=[candidate.ticker for candidate in candidates],
-                finnhub_api_key=finnhub_key,
-                asof_date=earnings_asof_date,
-                cache_path=".cache/earnings_days.json",
+            candidates = self._enrich_and_rank(
+                ctx, candidates, requested_top, same_symbol_suppressed_count
             )
-            candidates = [
-                candidate.model_copy(update={"days_to_earnings": earnings_days.get(candidate.ticker)})
-                for candidate in candidates
-            ]
-
-            min_days_to_earnings = _min_days_to_earnings_default()
-            if min_days_to_earnings > 0:
-                candidates = [
-                    candidate
-                    for candidate in candidates
-                    if candidate.days_to_earnings is None or candidate.days_to_earnings >= min_days_to_earnings
-                ]
-
-            # Stage 2: combined priority re-ranks prefilter set and trims to final top-N
-            candidates = compute_combined_priority(candidates, cfg=combined_priority_cfg)
-            candidates = candidates[:requested_top]
-            candidates = _rebuild_recommendations_with_decision_action(
-                candidates,
-                risk_cfg=risk_cfg,
-                rr_target=_safe_float(getattr(risk_cfg, "rr_target", 2.0), default=2.0),
-                commission_pct=_safe_float(getattr(risk_cfg, "commission_pct", 0.0), default=0.0),
-            )
-            candidates = _apply_decision_priority_ranking(candidates)
-            if same_symbol_suppressed_count > 0:
-                warnings.append(
-                    f"{same_symbol_suppressed_count} same-symbol candidate"
-                    f"{'' if same_symbol_suppressed_count == 1 else 's'} suppressed because they are manage-only."
-                )
-
-            visible_ticker_list = [candidate.ticker for candidate in candidates]
-            sector_map = {t: info.get("sector") for t, info in ticker_info.items()}
-            warnings.extend(sector_concentration_warnings(visible_ticker_list, sector_map))
 
             response = ScreenerResponse(
                 candidates=candidates,

--- a/api/services/screener_service.py
+++ b/api/services/screener_service.py
@@ -1050,6 +1050,215 @@ class ScreenerService:
 
         return results
 
+    def _build_candidates(self, ctx: _RunContext, results: "pd.DataFrame") -> list[ScreenerCandidate]:
+        """Construct ScreenerCandidate objects for each ranked result row.
+
+        Reads ctx.ohlcv, ticker_info, benchmark, last_bar_map, overall_last_bar,
+        market_health, risk_cfg, universe_cfg, signals_cfg, sector_rotation_by_name.
+        Returns the candidate list (pre same-symbol filtering).
+        """
+        ohlcv = ctx.ohlcv
+        ticker_info = ctx.ticker_info
+        benchmark = ctx.benchmark
+        last_bar_map = ctx.last_bar_map
+        overall_last_bar = ctx.overall_last_bar
+        market_health = ctx.market_health
+        risk_cfg = ctx.risk_cfg
+        universe_cfg = ctx.universe_cfg
+        signals_cfg = ctx.signals_cfg
+        sector_rotation_by_name = ctx.sector_rotation_by_name
+
+        ticker_list = [str(idx) for idx in results.index]
+
+        # Build price history only for candidate tickers to improve performance
+        price_history_map = _price_history_map(ohlcv, tickers=ticker_list)
+        patterns_map = detect_patterns(ohlcv, tickers=ticker_list, cfg=CandleConfig())
+        exec_cfg = ExecutionConfig()
+        benchmark_history = _price_history_map(ohlcv, tickers=[benchmark]).get(benchmark, [])
+        benchmark_change_pct = _price_history_change_pct(benchmark_history)
+        benchmark_last_bar = last_bar_map.get(benchmark) or overall_last_bar
+
+        atr_col = f"atr{universe_cfg.vol.atr_window}"
+        ma_col = f"ma{signals_cfg.pullback_ma}_level"
+        candidates = []
+        for idx, row in results.iterrows():
+            sma20 = _safe_float(row.get(ma_col))
+            sma50_dist = _safe_float(row.get("dist_sma50_pct"))
+            sma200_dist = _safe_float(row.get("dist_sma200_pct"))
+            last_price = _safe_float(row.get("last"))
+
+            sma50 = last_price / (1 + sma50_dist / 100) if last_price and sma50_dist else last_price
+            sma200 = last_price / (1 + sma200_dist / 100) if last_price and sma200_dist else last_price
+
+            ticker_str = str(idx)
+            info = ticker_info.get(ticker_str, {})
+            instrument = get_instrument_record(ticker_str) or {}
+            last_bar = last_bar_map.get(ticker_str) or overall_last_bar
+            currency = str(
+                info.get("currency")
+                or row.get("currency")
+                or instrument.get("currency")
+                or detect_currency(ticker_str)
+            ).upper()
+
+            signal = row.get("signal")
+            entry_val = _safe_optional_float(row.get("entry")) or last_price
+            stop_val = _safe_optional_float(row.get("stop"))
+            if stop_val is None and entry_val:
+                # No explicit stop from the pipeline — derive one from ATR so that
+                # target and R:R can be computed for the order panel.
+                atr_val = _safe_optional_float(row.get(atr_col))
+                if atr_val and atr_val > 0:
+                    stop_val = round(entry_val - 2.0 * atr_val, 4)
+            shares_val = _safe_optional_int(row.get("shares"))
+            position_size = _safe_optional_float(row.get("position_value"))
+            risk_usd = _safe_optional_float(row.get("realized_risk"))
+            risk_pct = (risk_usd / risk_cfg.account_size) if risk_usd and risk_cfg.account_size else None
+
+            rr_target = _safe_float(getattr(risk_cfg, "rr_target", 2.0), default=2.0)
+            commission_pct = _safe_float(getattr(risk_cfg, "commission_pct", 0.0), default=0.0)
+
+            rec_payload = evaluate_recommendation(
+                signal=str(signal) if not _is_na_scalar(signal) else None,
+                entry=entry_val,
+                stop=stop_val,
+                shares=shares_val,
+                risk_cfg=risk_cfg,
+                rr_target=rr_target,
+                costs=RiskEngineConfig(
+                    commission_pct=commission_pct,
+                    slippage_bps=5.0,
+                    fx_estimate_pct=0.0,
+                ),
+                # Pass candidate data for Trade Thesis
+                ticker=ticker_str,
+                strategy="Momentum",
+                close=last_price,
+                sma_20=sma20,
+                sma_50=sma50,
+                sma_200=sma200,
+                atr=_safe_float(row.get(atr_col)),
+                momentum_6m=_safe_float(row.get("mom_6m")),
+                    momentum_12m=_safe_float(row.get("mom_12m")),
+                    rel_strength=_safe_float(row.get("rs_6m")),
+                    confidence=_safe_float(row.get("confidence")),
+            )
+            recommendation = Recommendation.model_validate(asdict(rec_payload))
+            rec_risk = recommendation.risk
+            candidate_history = price_history_map.get(ticker_str, [])
+            symbol_change_pct = _price_history_change_pct(candidate_history)
+            benchmark_price_history = _aligned_benchmark_price_history(candidate_history, benchmark_history)
+            benchmark_outperformance_pct = (
+                symbol_change_pct - benchmark_change_pct
+                if symbol_change_pct is not None and benchmark_change_pct is not None
+                else None
+            )
+
+            cand_patterns = [
+                CandlePatternOut(
+                    bar_index=p.bar_index,
+                    date=p.date,
+                    name=p.name,
+                    direction=p.direction,
+                    key_level=p.key_level,
+                    context=p.context,
+                )
+                for p in patterns_map.get(ticker_str, [])
+            ]
+            pattern_stop_val, pattern_stop_reason = (None, None)
+            if exec_cfg.pattern_stop_enabled and entry_val:
+                pattern_stop_val, pattern_stop_reason = apply_pattern_stop(
+                    ticker=ticker_str,
+                    entry=entry_val,
+                    current_stop=stop_val,
+                    atr=_safe_optional_float(row.get(atr_col)),
+                    patterns=patterns_map,
+                    buffer_atr=exec_cfg.pattern_stop_atr_buffer,
+                    min_rr_stop=None,
+                )
+
+            candidates.append(
+                ScreenerCandidate(
+                    ticker=ticker_str,
+                    currency=currency,
+                    exchange_mic=str(instrument.get("exchange_mic") or "").upper() or None,
+                    instrument_type=str(instrument.get("instrument_type") or "").lower() or None,
+                    is_otc=str(instrument.get("exchange_mic") or "").upper() == "XOTC",
+                    name=info.get("name"),
+                    sector=info.get("sector"),
+                    last_bar=last_bar,
+                    close=last_price,
+                    sma_20=sma20,
+                    sma_50=sma50,
+                    sma_200=sma200,
+                    atr=_safe_float(row.get(atr_col)),
+                    momentum_6m=_safe_float(row.get("mom_6m")),
+                    momentum_12m=_safe_float(row.get("mom_12m")),
+                    rel_strength=_safe_float(row.get("rs_6m")),
+                    sector_rs=_safe_optional_float(row.get("sector_rs_6m")),
+                    score=_safe_float(row.get("score")),
+                    confidence=_safe_float(row.get("confidence")),
+                    rank=int(row.get("rank", len(candidates) + 1)),
+                    sma20_slope=_safe_optional_float(row.get("sma20_slope")),
+                    sma50_slope=_safe_optional_float(row.get("sma50_slope")),
+                    consolidation_tightness=_safe_optional_float(row.get("consolidation_tightness")),
+                    close_location_in_range=_safe_optional_float(row.get("close_location_in_range")),
+                    above_breakout_extension=_safe_optional_float(row.get("above_breakout_extension")),
+                    breakout_volume_confirmation=(
+                        bool(row.get("breakout_volume_confirmation"))
+                        if not _is_na_scalar(row.get("breakout_volume_confirmation"))
+                        else None
+                    ),
+                    dist_52w_high_pct=_safe_optional_float(row.get("dist_52w_high_pct")),
+                    near_52w_high=(
+                        bool(row.get("near_52w_high"))
+                        if not _is_na_scalar(row.get("near_52w_high"))
+                        else None
+                    ),
+                    weekly_trend=(
+                        str(row.get("weekly_trend"))
+                        if not _is_na_scalar(row.get("weekly_trend"))
+                        else None
+                    ),
+                    volume_ratio=_safe_optional_float(row.get("volume_ratio")),
+                    avg_daily_volume_eur=_safe_optional_float(row.get("avg_daily_volume_eur")),
+                    symbol_change_pct=symbol_change_pct,
+                    benchmark_outperformance_pct=benchmark_outperformance_pct,
+                    sector_rotation_context=sector_rotation_by_name.get(info.get("sector")),
+                    data_source_summary={"market_data": market_health},
+                    signal=str(signal) if not _is_na_scalar(signal) else None,
+                    entry=rec_risk.entry,
+                    stop=rec_risk.stop if stop_val is not None else None,
+                    target=rec_risk.target,
+                    rr=rec_risk.rr,
+                    shares=shares_val if shares_val is not None else rec_risk.shares,
+                    position_size_usd=position_size if position_size is not None else rec_risk.position_size,
+                    risk_usd=risk_usd if risk_usd is not None else rec_risk.risk_amount,
+                    risk_pct=risk_pct if risk_pct is not None else rec_risk.risk_pct,
+                    recommendation=recommendation,
+                    price_history=price_history_map.get(ticker_str, []),
+                    benchmark_price_history=benchmark_price_history,
+                    patterns=cand_patterns,
+                    pattern_stop=pattern_stop_val,
+                    pattern_stop_reason=pattern_stop_reason,
+                    suggested_order_type=(
+                        str(row.get("suggested_order_type"))
+                        if not _is_na_scalar(row.get("suggested_order_type"))
+                        else None
+                    ),
+                    suggested_order_price=_safe_optional_float(row.get("suggested_order_price")),
+                    execution_note=(
+                        str(row.get("execution_note"))
+                        if not _is_na_scalar(row.get("execution_note"))
+                        else None
+                    ),
+                )
+            )
+
+        ctx.benchmark_change_pct = benchmark_change_pct
+        ctx.benchmark_last_bar = benchmark_last_bar
+        return candidates
+
     def run_screener(self, request: ScreenerRequest, strategy_override: Optional[dict] = None) -> ScreenerResponse:
         try:
             ctx = _RunContext(
@@ -1094,192 +1303,9 @@ class ScreenerService:
             ticker_info = ctx.ticker_info
             sector_rotation_by_name = ctx.sector_rotation_by_name
 
-            ticker_list = [str(idx) for idx in results.index]
-            
-            # Build price history only for candidate tickers to improve performance
-            price_history_map = _price_history_map(ohlcv, tickers=ticker_list)
-            patterns_map = detect_patterns(ohlcv, tickers=ticker_list, cfg=CandleConfig())
-            exec_cfg = ExecutionConfig()
-            benchmark_history = _price_history_map(ohlcv, tickers=[benchmark]).get(benchmark, [])
-            benchmark_change_pct = _price_history_change_pct(benchmark_history)
-            benchmark_last_bar = last_bar_map.get(benchmark) or overall_last_bar
-
-            atr_col = f"atr{universe_cfg.vol.atr_window}"
-            ma_col = f"ma{signals_cfg.pullback_ma}_level"
-            candidates = []
-            for idx, row in results.iterrows():
-                sma20 = _safe_float(row.get(ma_col))
-                sma50_dist = _safe_float(row.get("dist_sma50_pct"))
-                sma200_dist = _safe_float(row.get("dist_sma200_pct"))
-                last_price = _safe_float(row.get("last"))
-
-                sma50 = last_price / (1 + sma50_dist / 100) if last_price and sma50_dist else last_price
-                sma200 = last_price / (1 + sma200_dist / 100) if last_price and sma200_dist else last_price
-
-                ticker_str = str(idx)
-                info = ticker_info.get(ticker_str, {})
-                instrument = get_instrument_record(ticker_str) or {}
-                last_bar = last_bar_map.get(ticker_str) or overall_last_bar
-                currency = str(
-                    info.get("currency")
-                    or row.get("currency")
-                    or instrument.get("currency")
-                    or detect_currency(ticker_str)
-                ).upper()
-
-                signal = row.get("signal")
-                entry_val = _safe_optional_float(row.get("entry")) or last_price
-                stop_val = _safe_optional_float(row.get("stop"))
-                if stop_val is None and entry_val:
-                    # No explicit stop from the pipeline — derive one from ATR so that
-                    # target and R:R can be computed for the order panel.
-                    atr_val = _safe_optional_float(row.get(atr_col))
-                    if atr_val and atr_val > 0:
-                        stop_val = round(entry_val - 2.0 * atr_val, 4)
-                shares_val = _safe_optional_int(row.get("shares"))
-                position_size = _safe_optional_float(row.get("position_value"))
-                risk_usd = _safe_optional_float(row.get("realized_risk"))
-                risk_pct = (risk_usd / risk_cfg.account_size) if risk_usd and risk_cfg.account_size else None
-
-                rr_target = _safe_float(getattr(risk_cfg, "rr_target", 2.0), default=2.0)
-                commission_pct = _safe_float(getattr(risk_cfg, "commission_pct", 0.0), default=0.0)
-
-                rec_payload = evaluate_recommendation(
-                    signal=str(signal) if not _is_na_scalar(signal) else None,
-                    entry=entry_val,
-                    stop=stop_val,
-                    shares=shares_val,
-                    risk_cfg=risk_cfg,
-                    rr_target=rr_target,
-                    costs=RiskEngineConfig(
-                        commission_pct=commission_pct,
-                        slippage_bps=5.0,
-                        fx_estimate_pct=0.0,
-                    ),
-                    # Pass candidate data for Trade Thesis
-                    ticker=ticker_str,
-                    strategy="Momentum",
-                    close=last_price,
-                    sma_20=sma20,
-                    sma_50=sma50,
-                    sma_200=sma200,
-                    atr=_safe_float(row.get(atr_col)),
-                    momentum_6m=_safe_float(row.get("mom_6m")),
-                        momentum_12m=_safe_float(row.get("mom_12m")),
-                        rel_strength=_safe_float(row.get("rs_6m")),
-                        confidence=_safe_float(row.get("confidence")),
-                )
-                recommendation = Recommendation.model_validate(asdict(rec_payload))
-                rec_risk = recommendation.risk
-                candidate_history = price_history_map.get(ticker_str, [])
-                symbol_change_pct = _price_history_change_pct(candidate_history)
-                benchmark_price_history = _aligned_benchmark_price_history(candidate_history, benchmark_history)
-                benchmark_outperformance_pct = (
-                    symbol_change_pct - benchmark_change_pct
-                    if symbol_change_pct is not None and benchmark_change_pct is not None
-                    else None
-                )
-
-                cand_patterns = [
-                    CandlePatternOut(
-                        bar_index=p.bar_index,
-                        date=p.date,
-                        name=p.name,
-                        direction=p.direction,
-                        key_level=p.key_level,
-                        context=p.context,
-                    )
-                    for p in patterns_map.get(ticker_str, [])
-                ]
-                pattern_stop_val, pattern_stop_reason = (None, None)
-                if exec_cfg.pattern_stop_enabled and entry_val:
-                    pattern_stop_val, pattern_stop_reason = apply_pattern_stop(
-                        ticker=ticker_str,
-                        entry=entry_val,
-                        current_stop=stop_val,
-                        atr=_safe_optional_float(row.get(atr_col)),
-                        patterns=patterns_map,
-                        buffer_atr=exec_cfg.pattern_stop_atr_buffer,
-                        min_rr_stop=None,
-                    )
-
-                candidates.append(
-                    ScreenerCandidate(
-                        ticker=ticker_str,
-                        currency=currency,
-                        exchange_mic=str(instrument.get("exchange_mic") or "").upper() or None,
-                        instrument_type=str(instrument.get("instrument_type") or "").lower() or None,
-                        is_otc=str(instrument.get("exchange_mic") or "").upper() == "XOTC",
-                        name=info.get("name"),
-                        sector=info.get("sector"),
-                        last_bar=last_bar,
-                        close=last_price,
-                        sma_20=sma20,
-                        sma_50=sma50,
-                        sma_200=sma200,
-                        atr=_safe_float(row.get(atr_col)),
-                        momentum_6m=_safe_float(row.get("mom_6m")),
-                        momentum_12m=_safe_float(row.get("mom_12m")),
-                        rel_strength=_safe_float(row.get("rs_6m")),
-                        sector_rs=_safe_optional_float(row.get("sector_rs_6m")),
-                        score=_safe_float(row.get("score")),
-                        confidence=_safe_float(row.get("confidence")),
-                        rank=int(row.get("rank", len(candidates) + 1)),
-                        sma20_slope=_safe_optional_float(row.get("sma20_slope")),
-                        sma50_slope=_safe_optional_float(row.get("sma50_slope")),
-                        consolidation_tightness=_safe_optional_float(row.get("consolidation_tightness")),
-                        close_location_in_range=_safe_optional_float(row.get("close_location_in_range")),
-                        above_breakout_extension=_safe_optional_float(row.get("above_breakout_extension")),
-                        breakout_volume_confirmation=(
-                            bool(row.get("breakout_volume_confirmation"))
-                            if not _is_na_scalar(row.get("breakout_volume_confirmation"))
-                            else None
-                        ),
-                        dist_52w_high_pct=_safe_optional_float(row.get("dist_52w_high_pct")),
-                        near_52w_high=(
-                            bool(row.get("near_52w_high"))
-                            if not _is_na_scalar(row.get("near_52w_high"))
-                            else None
-                        ),
-                        weekly_trend=(
-                            str(row.get("weekly_trend"))
-                            if not _is_na_scalar(row.get("weekly_trend"))
-                            else None
-                        ),
-                        volume_ratio=_safe_optional_float(row.get("volume_ratio")),
-                        avg_daily_volume_eur=_safe_optional_float(row.get("avg_daily_volume_eur")),
-                        symbol_change_pct=symbol_change_pct,
-                        benchmark_outperformance_pct=benchmark_outperformance_pct,
-                        sector_rotation_context=sector_rotation_by_name.get(info.get("sector")),
-                        data_source_summary={"market_data": market_health},
-                        signal=str(signal) if not _is_na_scalar(signal) else None,
-                        entry=rec_risk.entry,
-                        stop=rec_risk.stop if stop_val is not None else None,
-                        target=rec_risk.target,
-                        rr=rec_risk.rr,
-                        shares=shares_val if shares_val is not None else rec_risk.shares,
-                        position_size_usd=position_size if position_size is not None else rec_risk.position_size,
-                        risk_usd=risk_usd if risk_usd is not None else rec_risk.risk_amount,
-                        risk_pct=risk_pct if risk_pct is not None else rec_risk.risk_pct,
-                        recommendation=recommendation,
-                        price_history=price_history_map.get(ticker_str, []),
-                        benchmark_price_history=benchmark_price_history,
-                        patterns=cand_patterns,
-                        pattern_stop=pattern_stop_val,
-                        pattern_stop_reason=pattern_stop_reason,
-                        suggested_order_type=(
-                            str(row.get("suggested_order_type"))
-                            if not _is_na_scalar(row.get("suggested_order_type"))
-                            else None
-                        ),
-                        suggested_order_price=_safe_optional_float(row.get("suggested_order_price")),
-                        execution_note=(
-                            str(row.get("execution_note"))
-                            if not _is_na_scalar(row.get("execution_note"))
-                            else None
-                        ),
-                    )
-                )
+            candidates = self._build_candidates(ctx, results)
+            benchmark_change_pct = ctx.benchmark_change_pct
+            benchmark_last_bar = ctx.benchmark_last_bar
 
             portfolio_positions = self._portfolio_service.list_positions(status="open").positions
             portfolio_closed = self._portfolio_service.list_positions(status="closed").positions

--- a/api/services/screener_service.py
+++ b/api/services/screener_service.py
@@ -870,6 +870,78 @@ class ScreenerService:
 
         return requested_top
 
+    def _build_signals_and_fetch_ohlcv(self, ctx: _RunContext, requested_top: int) -> None:
+        """Build signals config, fetch and shape OHLCV, compute freshness + last-bar maps.
+
+        Populates ctx.signals_cfg, start_date, end_date, ohlcv, last_bar_map,
+        overall_last_bar, data_freshness, warnings. Raises NotFoundError on empty
+        OHLCV and ServiceError on missing benchmark, exactly as before.
+        """
+        fields_set = ctx.request.model_fields_set
+
+        ctx.signals_cfg = build_entry_config(ctx.strategy)
+        if "breakout_lookback" in fields_set and ctx.request.breakout_lookback is not None:
+            ctx.signals_cfg = replace(ctx.signals_cfg, breakout_lookback=ctx.request.breakout_lookback)
+        if "pullback_ma" in fields_set and ctx.request.pullback_ma is not None:
+            ctx.signals_cfg = replace(ctx.signals_cfg, pullback_ma=ctx.request.pullback_ma)
+        if "min_history" in fields_set and ctx.request.min_history is not None:
+            ctx.signals_cfg = replace(ctx.signals_cfg, min_history=ctx.request.min_history)
+
+        ctx.start_date = _resolve_fetch_start_date(ctx.asof_str, ctx.signals_cfg.min_history)
+        ctx.end_date = ctx.asof_str
+        sector_context_tickers = ["SPY", *sector_rotation.SECTOR_ETFS.keys()]
+        sector_ohlcv = pd.DataFrame()
+        try:
+            sector_ohlcv = self._provider.fetch_ohlcv(
+                sector_context_tickers,
+                start_date=ctx.start_date,
+                end_date=ctx.end_date,
+            )
+        except Exception as exc:
+            logger.warning("Sector ETF OHLCV fetch failed: %s", exc)
+
+        logger.info(
+            "Screener run: universe=%s top=%s tickers=%s provider=%s",
+            ctx.request.universe or "broad_market_stocks",
+            requested_top,
+            len(ctx.tickers),
+            self._provider.get_provider_name(),
+        )
+
+        if len(ctx.tickers) > 120:
+            ctx.ohlcv = _fetch_ohlcv_chunked(self._provider, ctx.tickers, ctx.start_date, ctx.end_date, chunk_size=100)
+        else:
+            ctx.ohlcv = self._provider.fetch_ohlcv(ctx.tickers, start_date=ctx.start_date, end_date=ctx.end_date)
+
+        if ctx.ohlcv is None or ctx.ohlcv.empty:
+            logger.error("OHLCV fetch returned empty data (tickers=%s)", len(ctx.tickers))
+            raise NotFoundError("No market data found for requested tickers")
+
+        ctx.ohlcv = _merge_ohlcv(ctx.ohlcv, sector_ohlcv)
+
+        if "Close" not in ctx.ohlcv.columns.get_level_values(0) or ctx.benchmark not in ctx.ohlcv["Close"].columns:
+            logger.warning("Benchmark %s missing from OHLCV; fetching separately.", ctx.benchmark)
+            bench_df = self._provider.fetch_ohlcv([ctx.benchmark], start_date=ctx.start_date, end_date=ctx.end_date)
+            ctx.ohlcv = _merge_ohlcv(ctx.ohlcv, bench_df)
+            if "Close" not in ctx.ohlcv.columns.get_level_values(0) or ctx.benchmark not in ctx.ohlcv["Close"].columns:
+                raise ServiceError("Benchmark data missing; cannot compute momentum.")
+
+        ctx.last_bar_map = _last_bar_map(ctx.ohlcv)
+        ctx.overall_last_bar = _to_iso(ctx.ohlcv.index.max())
+        ctx.data_freshness = _resolve_data_freshness(ctx.asof_str, ctx.now_utc, ctx.active_currencies)
+
+        # Detect tickers that failed to download and surface them as warnings
+        if "Close" in ctx.ohlcv.columns.get_level_values(0):
+            present = set(ctx.ohlcv["Close"].columns.tolist())
+            requested_set = set(ctx.tickers) - {ctx.benchmark}
+            missing = sorted(requested_set - present)
+            if missing:
+                ctx.warnings.append(
+                    f"{len(missing)} ticker{'s' if len(missing) != 1 else ''} could not be downloaded "
+                    f"and were excluded from screening (possibly delisted or renamed): "
+                    f"{', '.join(missing)}"
+                )
+
     def run_screener(self, request: ScreenerRequest, strategy_override: Optional[dict] = None) -> ScreenerResponse:
         try:
             ctx = _RunContext(
@@ -884,77 +956,19 @@ class ScreenerService:
             benchmark = ctx.benchmark
             tickers = ctx.tickers
             screening_tickers = ctx.screening_tickers
-            active_currencies = ctx.active_currencies
             asof_str = ctx.asof_str
             market_health = ctx.market_health
-            now_utc = ctx.now_utc
             strategy = ctx.strategy
             combined_priority_cfg = ctx.combined_priority_cfg
 
             fields_set = request.model_fields_set
 
-            signals_cfg = build_entry_config(strategy)
-            if "breakout_lookback" in fields_set and request.breakout_lookback is not None:
-                signals_cfg = replace(signals_cfg, breakout_lookback=request.breakout_lookback)
-            if "pullback_ma" in fields_set and request.pullback_ma is not None:
-                signals_cfg = replace(signals_cfg, pullback_ma=request.pullback_ma)
-            if "min_history" in fields_set and request.min_history is not None:
-                signals_cfg = replace(signals_cfg, min_history=request.min_history)
-
-            start_date = _resolve_fetch_start_date(asof_str, signals_cfg.min_history)
-            end_date = asof_str
-            sector_context_tickers = ["SPY", *sector_rotation.SECTOR_ETFS.keys()]
-            sector_ohlcv = pd.DataFrame()
-            try:
-                sector_ohlcv = self._provider.fetch_ohlcv(
-                    sector_context_tickers,
-                    start_date=start_date,
-                    end_date=end_date,
-                )
-            except Exception as exc:
-                logger.warning("Sector ETF OHLCV fetch failed: %s", exc)
-
-            logger.info(
-                "Screener run: universe=%s top=%s tickers=%s provider=%s",
-                request.universe or "broad_market_stocks",
-                requested_top,
-                len(tickers),
-                self._provider.get_provider_name(),
-            )
-
-            if len(tickers) > 120:
-                ohlcv = _fetch_ohlcv_chunked(self._provider, tickers, start_date, end_date, chunk_size=100)
-            else:
-                ohlcv = self._provider.fetch_ohlcv(tickers, start_date=start_date, end_date=end_date)
-
-            if ohlcv is None or ohlcv.empty:
-                logger.error("OHLCV fetch returned empty data (tickers=%s)", len(tickers))
-                raise NotFoundError("No market data found for requested tickers")
-
-            ohlcv = _merge_ohlcv(ohlcv, sector_ohlcv)
-
-            if "Close" not in ohlcv.columns.get_level_values(0) or benchmark not in ohlcv["Close"].columns:
-                logger.warning("Benchmark %s missing from OHLCV; fetching separately.", benchmark)
-                bench_df = self._provider.fetch_ohlcv([benchmark], start_date=start_date, end_date=end_date)
-                ohlcv = _merge_ohlcv(ohlcv, bench_df)
-                if "Close" not in ohlcv.columns.get_level_values(0) or benchmark not in ohlcv["Close"].columns:
-                    raise ServiceError("Benchmark data missing; cannot compute momentum.")
-
-            last_bar_map = _last_bar_map(ohlcv)
-            overall_last_bar = _to_iso(ohlcv.index.max())
-            data_freshness = _resolve_data_freshness(asof_str, now_utc, active_currencies)
-
-            # Detect tickers that failed to download and surface them as warnings
-            if "Close" in ohlcv.columns.get_level_values(0):
-                present = set(ohlcv["Close"].columns.tolist())
-                requested_set = set(tickers) - {benchmark}
-                missing = sorted(requested_set - present)
-                if missing:
-                    warnings.append(
-                        f"{len(missing)} ticker{'s' if len(missing) != 1 else ''} could not be downloaded "
-                        f"and were excluded from screening (possibly delisted or renamed): "
-                        f"{', '.join(missing)}"
-                    )
+            self._build_signals_and_fetch_ohlcv(ctx, requested_top)
+            signals_cfg = ctx.signals_cfg
+            ohlcv = ctx.ohlcv
+            last_bar_map = ctx.last_bar_map
+            overall_last_bar = ctx.overall_last_bar
+            data_freshness = ctx.data_freshness
 
             if "min_price" in fields_set or "max_price" in fields_set:
                 filt = universe_cfg.filt

--- a/api/services/screener_service.py
+++ b/api/services/screener_service.py
@@ -786,85 +786,112 @@ class ScreenerService:
             return strategy
         return self._strategy_repo.get_active_strategy()
 
+    def _resolve_universe_and_window(self, ctx: _RunContext) -> int:
+        """Resolve strategy, universe, benchmark, ticker list and screening window.
+
+        Returns requested_top. Populates ctx.universe_cfg, benchmark, tickers,
+        screening_tickers, active_currencies, asof_str, market_health, now_utc,
+        warnings. Raises UnprocessableError/NotFoundError exactly as before.
+        """
+        request = ctx.request
+        requested_top = request.top or 20
+        if requested_top <= 0:
+            raise UnprocessableError("top must be >= 1")
+
+        ctx.universe_cfg = build_universe_config(ctx.strategy)
+        ctx.now_utc = dt.datetime.now(dt.timezone.utc)
+        ctx.benchmark = ctx.universe_cfg.mom.benchmark
+        if request.universe:
+            valid_ids = set(list_package_universes())
+            if request.universe not in valid_ids:
+                replacement = _REMOVED_UNIVERSE_IDS.get(request.universe)
+                if replacement:
+                    detail = (
+                        f"Universe '{request.universe}' was removed. "
+                        f"Use '{replacement}' instead."
+                    )
+                else:
+                    detail = (
+                        f"Universe '{request.universe}' is not available. "
+                        f"Available universes: {sorted(valid_ids)}"
+                    )
+                raise UnprocessableError(detail)
+            uni_benchmark = get_universe_benchmark(request.universe)
+            if uni_benchmark and uni_benchmark != ctx.benchmark:
+                ctx.universe_cfg = replace(
+                    ctx.universe_cfg,
+                    mom=replace(ctx.universe_cfg.mom, benchmark=uni_benchmark),
+                )
+                ctx.benchmark = uni_benchmark
+
+        if request.tickers:
+            ctx.tickers = [t.upper() for t in request.tickers]
+            if ctx.benchmark not in ctx.tickers:
+                ctx.tickers.append(ctx.benchmark)
+        elif request.universe:
+            universe_cap = max(500, requested_top * 2)
+            ucfg = DataUniverseConfig(benchmark=ctx.benchmark, ensure_benchmark=True, max_tickers=universe_cap)
+            ctx.tickers = load_universe_from_package(request.universe, ucfg)
+        else:
+            universe_cap = max(500, requested_top * 2)
+            ucfg = DataUniverseConfig(benchmark=ctx.benchmark, ensure_benchmark=True, max_tickers=universe_cap)
+            ctx.tickers = load_universe_from_package("broad_market_stocks", ucfg)
+
+        filtered_tickers = filter_tickers_by_metadata(
+            ctx.tickers,
+            currencies=request.currencies,
+            exchange_mics=request.exchange_mics,
+            include_otc=request.include_otc if request.include_otc is not None else True,
+            instrument_types=request.instrument_types,
+        )
+        if ctx.benchmark not in filtered_tickers:
+            filtered_tickers.append(ctx.benchmark)
+        if len(filtered_tickers) < len(ctx.tickers):
+            ctx.warnings.append(
+                f"Universe filters reduced the working list from {len(ctx.tickers)} to {len(filtered_tickers)} tickers."
+            )
+        ctx.tickers = filtered_tickers
+        ctx.market_health = self._provider.get_source_health().to_dict()
+
+        ctx.screening_tickers = [ticker for ticker in ctx.tickers if ticker != ctx.benchmark]
+        ctx.active_currencies = _resolve_screening_currencies(
+            request,
+            strategy_currencies=ctx.universe_cfg.filt.currencies,
+            tickers=ctx.screening_tickers,
+            universe_id=request.universe,
+        )
+        if request.asof_date:
+            ctx.asof_str = request.asof_date
+        else:
+            ctx.asof_str = _resolve_default_asof_date(ctx.now_utc, ctx.active_currencies).isoformat()
+
+        if len(ctx.tickers) <= 1 and ctx.benchmark in ctx.tickers:
+            raise NotFoundError("No tickers left after applying screener filters")
+
+        return requested_top
+
     def run_screener(self, request: ScreenerRequest, strategy_override: Optional[dict] = None) -> ScreenerResponse:
         try:
-            requested_top = request.top or 20
-            if requested_top <= 0:
-                raise UnprocessableError("top must be >= 1")
-            combined_priority_cfg = CombinedPriorityConfig()
-            warnings: list[str] = []
+            ctx = _RunContext(
+                request=request,
+                strategy=self._resolve_strategy(request.strategy_id, strategy_override),
+                combined_priority_cfg=CombinedPriorityConfig(),
+            )
+            requested_top = self._resolve_universe_and_window(ctx)
+            # Bridge ctx fields back into local names still used by not-yet-extracted code below.
+            warnings = ctx.warnings
+            universe_cfg = ctx.universe_cfg
+            benchmark = ctx.benchmark
+            tickers = ctx.tickers
+            screening_tickers = ctx.screening_tickers
+            active_currencies = ctx.active_currencies
+            asof_str = ctx.asof_str
+            market_health = ctx.market_health
+            now_utc = ctx.now_utc
+            strategy = ctx.strategy
+            combined_priority_cfg = ctx.combined_priority_cfg
 
             fields_set = request.model_fields_set
-            strategy = self._resolve_strategy(request.strategy_id, strategy_override)
-            universe_cfg = build_universe_config(strategy)
-            now_utc = dt.datetime.now(dt.timezone.utc)
-            benchmark = universe_cfg.mom.benchmark
-            if request.universe:
-                valid_ids = set(list_package_universes())
-                if request.universe not in valid_ids:
-                    replacement = _REMOVED_UNIVERSE_IDS.get(request.universe)
-                    if replacement:
-                        detail = (
-                            f"Universe '{request.universe}' was removed. "
-                            f"Use '{replacement}' instead."
-                        )
-                    else:
-                        detail = (
-                            f"Universe '{request.universe}' is not available. "
-                            f"Available universes: {sorted(valid_ids)}"
-                        )
-                    raise UnprocessableError(detail)
-                uni_benchmark = get_universe_benchmark(request.universe)
-                if uni_benchmark and uni_benchmark != benchmark:
-                    universe_cfg = replace(
-                        universe_cfg,
-                        mom=replace(universe_cfg.mom, benchmark=uni_benchmark),
-                    )
-                    benchmark = uni_benchmark
-
-            if request.tickers:
-                tickers = [t.upper() for t in request.tickers]
-                if benchmark not in tickers:
-                    tickers.append(benchmark)
-            elif request.universe:
-                universe_cap = max(500, requested_top * 2)
-                ucfg = DataUniverseConfig(benchmark=benchmark, ensure_benchmark=True, max_tickers=universe_cap)
-                tickers = load_universe_from_package(request.universe, ucfg)
-            else:
-                universe_cap = max(500, requested_top * 2)
-                ucfg = DataUniverseConfig(benchmark=benchmark, ensure_benchmark=True, max_tickers=universe_cap)
-                tickers = load_universe_from_package("broad_market_stocks", ucfg)
-
-            filtered_tickers = filter_tickers_by_metadata(
-                tickers,
-                currencies=request.currencies,
-                exchange_mics=request.exchange_mics,
-                include_otc=request.include_otc if request.include_otc is not None else True,
-                instrument_types=request.instrument_types,
-            )
-            if benchmark not in filtered_tickers:
-                filtered_tickers.append(benchmark)
-            if len(filtered_tickers) < len(tickers):
-                warnings.append(
-                    f"Universe filters reduced the working list from {len(tickers)} to {len(filtered_tickers)} tickers."
-                )
-            tickers = filtered_tickers
-            market_health = self._provider.get_source_health().to_dict()
-
-            screening_tickers = [ticker for ticker in tickers if ticker != benchmark]
-            active_currencies = _resolve_screening_currencies(
-                request,
-                strategy_currencies=universe_cfg.filt.currencies,
-                tickers=screening_tickers,
-                universe_id=request.universe,
-            )
-            if request.asof_date:
-                asof_str = request.asof_date
-            else:
-                asof_str = _resolve_default_asof_date(now_utc, active_currencies).isoformat()
-
-            if len(tickers) <= 1 and benchmark in tickers:
-                raise NotFoundError("No tickers left after applying screener filters")
 
             signals_cfg = build_entry_config(strategy)
             if "breakout_lookback" in fields_set and request.breakout_lookback is not None:

--- a/api/services/screener_service.py
+++ b/api/services/screener_service.py
@@ -993,6 +993,63 @@ class ScreenerService:
             risk=ctx.risk_cfg,
         )
 
+    def _run_daily_report(self, ctx: _RunContext, requested_top: int) -> "pd.DataFrame | None":
+        """Build sector context and run the daily report.
+
+        Returns the ranked results DataFrame, or None when there are no
+        candidates (orchestrator then returns the empty ScreenerResponse).
+        Populates ctx.ticker_info and ctx.sector_rotation_by_name.
+        """
+        ticker_info = get_multiple_ticker_info(ctx.screening_tickers) if ctx.screening_tickers else {}
+        etf_returns = sector_rotation.compute_sector_benchmark_returns(ctx.ohlcv)
+        rotation_scores = sector_rotation.compute_sector_rotation_scores(ctx.ohlcv)
+        ticker_sectors = {
+            ticker: (ticker_info.get(ticker) or {}).get("sector")
+            for ticker in ctx.screening_tickers
+        }
+        sector_benchmark_returns = sector_rotation.build_ticker_sector_returns(
+            ticker_sectors,
+            etf_returns,
+        )
+        sector_rotation_by_name = {
+            sector_name: rotation_scores[etf]
+            for etf, sector_name in sector_rotation.SECTOR_ETFS.items()
+            if etf in rotation_scores
+        }
+
+        ctx.ticker_info = ticker_info
+        ctx.sector_rotation_by_name = sector_rotation_by_name
+
+        results = build_daily_report(
+            ctx.ohlcv,
+            cfg=ctx.report_cfg,
+            exclude_tickers=sector_rotation.SECTOR_ETFS.keys(),
+            sector_benchmark_returns=sector_benchmark_returns,
+        )
+        if results is None or results.empty:
+            logger.warning(
+                "Screener returned no candidates (top=%s, tickers=%s).",
+                requested_top,
+                len(ctx.tickers),
+            )
+            ctx.warnings.append("No candidates found for the current screener filters.")
+            return None
+
+        if not results.empty and "confidence" in results.columns:
+            results = results.sort_values("confidence", ascending=False)
+            if ctx.request.top:
+                # Stage 1: widen prefilter to allow combined priority stage to re-rank
+                prefilter_n = ctx.request.top * ctx.combined_priority_cfg.prefilter_multiplier
+                results = results.head(prefilter_n)
+            results["rank"] = range(1, len(results) + 1)
+
+        if len(results) < requested_top:
+            message = f"Only {len(results)} candidates found for top {requested_top}."
+            ctx.warnings.append(message)
+            logger.warning(message)
+
+        return results
+
     def run_screener(self, request: ScreenerRequest, strategy_override: Optional[dict] = None) -> ScreenerResponse:
         try:
             ctx = _RunContext(
@@ -1006,7 +1063,6 @@ class ScreenerService:
             universe_cfg = ctx.universe_cfg
             benchmark = ctx.benchmark
             tickers = ctx.tickers
-            screening_tickers = ctx.screening_tickers
             asof_str = ctx.asof_str
             market_health = ctx.market_health
             strategy = ctx.strategy
@@ -1020,62 +1076,23 @@ class ScreenerService:
             data_freshness = ctx.data_freshness
 
             self._build_run_configs(ctx, requested_top)
-            report_cfg = ctx.report_cfg
             risk_cfg = ctx.risk_cfg
             universe_cfg = ctx.universe_cfg
 
-            ticker_info = get_multiple_ticker_info(screening_tickers) if screening_tickers else {}
-            etf_returns = sector_rotation.compute_sector_benchmark_returns(ohlcv)
-            rotation_scores = sector_rotation.compute_sector_rotation_scores(ohlcv)
-            ticker_sectors = {
-                ticker: (ticker_info.get(ticker) or {}).get("sector")
-                for ticker in screening_tickers
-            }
-            sector_benchmark_returns = sector_rotation.build_ticker_sector_returns(
-                ticker_sectors,
-                etf_returns,
-            )
-            sector_rotation_by_name = {
-                sector_name: rotation_scores[etf]
-                for etf, sector_name in sector_rotation.SECTOR_ETFS.items()
-                if etf in rotation_scores
-            }
-
-            results = build_daily_report(
-                ohlcv,
-                cfg=report_cfg,
-                exclude_tickers=sector_rotation.SECTOR_ETFS.keys(),
-                sector_benchmark_returns=sector_benchmark_returns,
-            )
-            if results is None or results.empty:
-                logger.warning(
-                    "Screener returned no candidates (top=%s, tickers=%s).",
-                    requested_top,
-                    len(tickers),
-                )
-                warnings.append("No candidates found for the current screener filters.")
+            results = self._run_daily_report(ctx, requested_top)
+            if results is None:
                 return ScreenerResponse(
                     candidates=[],
-                    asof_date=asof_str,
-                    total_screened=len(tickers),
-                    data_freshness=data_freshness,
-                    warnings=warnings,
+                    asof_date=ctx.asof_str,
+                    total_screened=len(ctx.tickers),
+                    data_freshness=ctx.data_freshness,
+                    warnings=ctx.warnings,
                     same_symbol_suppressed_count=0,
                     same_symbol_add_on_count=0,
                 )
-
-            if not results.empty and "confidence" in results.columns:
-                results = results.sort_values("confidence", ascending=False)
-                if request.top:
-                    # Stage 1: widen prefilter to allow combined priority stage to re-rank
-                    prefilter_n = request.top * combined_priority_cfg.prefilter_multiplier
-                    results = results.head(prefilter_n)
-                results["rank"] = range(1, len(results) + 1)
-
-            if len(results) < requested_top:
-                message = f"Only {len(results)} candidates found for top {requested_top}."
-                warnings.append(message)
-                logger.warning(message)
+            # Bridge ctx fields back into local names still used by not-yet-extracted code below.
+            ticker_info = ctx.ticker_info
+            sector_rotation_by_name = ctx.sector_rotation_by_name
 
             ticker_list = [str(idx) for idx in results.index]
             

--- a/api/services/screener_service.py
+++ b/api/services/screener_service.py
@@ -1259,6 +1259,55 @@ class ScreenerService:
         ctx.benchmark_last_bar = benchmark_last_bar
         return candidates
 
+    def _apply_same_symbol_filter(
+        self, ctx: _RunContext, candidates: list[ScreenerCandidate]
+    ) -> tuple[list[ScreenerCandidate], int, int]:
+        """Run the same-symbol re-entry evaluator over candidates.
+
+        Returns (filtered_candidates, suppressed_count, add_on_count). Reads
+        portfolio/orders services and ctx.strategy / ctx.risk_cfg.
+        """
+        strategy = ctx.strategy
+        risk_cfg = ctx.risk_cfg
+
+        portfolio_positions = self._portfolio_service.list_positions(status="open").positions
+        portfolio_closed = self._portfolio_service.list_positions(status="closed").positions
+        portfolio_orders: list = []
+        if self._orders_service is not None:
+            try:
+                portfolio_orders = self._orders_service.list_local_orders().get("orders", [])
+            except Exception as exc:
+                logger.warning("Failed to load orders for same-symbol evaluation: %s", exc)
+        same_symbol_evaluator = SameSymbolReentryEvaluator(self._portfolio_service)
+        same_symbol_suppressed_count = 0
+        same_symbol_add_on_count = 0
+        filtered_candidates: list[ScreenerCandidate] = []
+        manage_cfg = strategy.get("manage", {}) if isinstance(strategy, dict) else {}
+        reentry_lookback = int(manage_cfg.get("reentry_lookback_days", 30))
+        for candidate in candidates:
+            enriched_candidate, same_symbol = same_symbol_evaluator.evaluate(
+                candidate,
+                positions=portfolio_positions,
+                orders=portfolio_orders,
+                account_size=float(risk_cfg.account_size),
+                risk_pct_target=float(risk_cfg.risk_pct),
+                max_position_pct=float(risk_cfg.max_position_pct),
+                min_shares=int(risk_cfg.min_shares),
+                closed_positions=portfolio_closed,
+                reentry_lookback_days=reentry_lookback,
+            )
+            if same_symbol.mode in ("ADD_ON", "SCALE_BACK"):
+                same_symbol_add_on_count += 1
+            if same_symbol.mode == "MANAGE_ONLY":
+                if enriched_candidate is None:
+                    same_symbol_suppressed_count += 1
+                    continue
+                # Recommended but add-on conditions not met: show with MANAGE_ONLY flag
+            if enriched_candidate is not None:
+                filtered_candidates.append(enriched_candidate)
+
+        return filtered_candidates, same_symbol_suppressed_count, same_symbol_add_on_count
+
     def run_screener(self, request: ScreenerRequest, strategy_override: Optional[dict] = None) -> ScreenerResponse:
         try:
             ctx = _RunContext(
@@ -1307,43 +1356,9 @@ class ScreenerService:
             benchmark_change_pct = ctx.benchmark_change_pct
             benchmark_last_bar = ctx.benchmark_last_bar
 
-            portfolio_positions = self._portfolio_service.list_positions(status="open").positions
-            portfolio_closed = self._portfolio_service.list_positions(status="closed").positions
-            portfolio_orders: list = []
-            if self._orders_service is not None:
-                try:
-                    portfolio_orders = self._orders_service.list_local_orders().get("orders", [])
-                except Exception as exc:
-                    logger.warning("Failed to load orders for same-symbol evaluation: %s", exc)
-            same_symbol_evaluator = SameSymbolReentryEvaluator(self._portfolio_service)
-            same_symbol_suppressed_count = 0
-            same_symbol_add_on_count = 0
-            filtered_candidates: list[ScreenerCandidate] = []
-            manage_cfg = strategy.get("manage", {}) if isinstance(strategy, dict) else {}
-            reentry_lookback = int(manage_cfg.get("reentry_lookback_days", 30))
-            for candidate in candidates:
-                enriched_candidate, same_symbol = same_symbol_evaluator.evaluate(
-                    candidate,
-                    positions=portfolio_positions,
-                    orders=portfolio_orders,
-                    account_size=float(risk_cfg.account_size),
-                    risk_pct_target=float(risk_cfg.risk_pct),
-                    max_position_pct=float(risk_cfg.max_position_pct),
-                    min_shares=int(risk_cfg.min_shares),
-                    closed_positions=portfolio_closed,
-                    reentry_lookback_days=reentry_lookback,
-                )
-                if same_symbol.mode in ("ADD_ON", "SCALE_BACK"):
-                    same_symbol_add_on_count += 1
-                if same_symbol.mode == "MANAGE_ONLY":
-                    if enriched_candidate is None:
-                        same_symbol_suppressed_count += 1
-                        continue
-                    # Recommended but add-on conditions not met: show with MANAGE_ONLY flag
-                if enriched_candidate is not None:
-                    filtered_candidates.append(enriched_candidate)
-
-            candidates = filtered_candidates
+            candidates, same_symbol_suppressed_count, same_symbol_add_on_count = (
+                self._apply_same_symbol_filter(ctx, candidates)
+            )
             fundamentals_snapshots = _load_fundamentals_snapshots(candidates)
             candidates = _apply_cached_fundamentals_context(candidates, snapshots=fundamentals_snapshots)
             candidates = _apply_decision_summary_context(candidates, snapshots=fundamentals_snapshots)

--- a/api/services/screener_service.py
+++ b/api/services/screener_service.py
@@ -62,6 +62,13 @@ from swing_screener.strategy.config import (
 )
 from swing_screener.risk.regime import compute_regime_risk_multiplier
 from api.utils.converters import to_iso as _to_iso
+from swing_screener.data.price_history import (
+    merge_ohlcv,
+    last_bar_map,
+    price_history_map,
+    price_history_change_pct,
+    aligned_benchmark_price_history,
+)
 from swing_screener.utils.coerce import (
     is_na_scalar,
     safe_float,
@@ -115,7 +122,6 @@ _REMOVED_UNIVERSE_IDS: dict[str, str | None] = {
 from api.services.screener_run_manager import get_screener_run_manager
 
 logger = logging.getLogger(__name__)
-PRICE_HISTORY_MAX_BARS = 252
 SUPPORTED_CURRENCIES = {"USD", "EUR"}
 DECISION_ACTION_PRIORITY = {
     "BUY_NOW": 6,
@@ -164,16 +170,6 @@ def _is_stale(opportunity: object | None) -> bool:
         return True
 
 
-def _merge_ohlcv(base: pd.DataFrame, extra: pd.DataFrame) -> pd.DataFrame:
-    if base is None or base.empty:
-        return extra
-    if extra is None or extra.empty:
-        return base
-    merged = pd.concat([base, extra], axis=1)
-    merged = merged.loc[:, ~merged.columns.duplicated()]
-    return merged.sort_index(axis=1)
-
-
 def _fetch_ohlcv_chunked(
     provider: MarketDataProvider,
     tickers: list[str], 
@@ -194,7 +190,7 @@ def _fetch_ohlcv_chunked(
         return pd.DataFrame()
     out = frames[0]
     for df in frames[1:]:
-        out = _merge_ohlcv(out, df)
+        out = merge_ohlcv(out, df)
     return out
 
 
@@ -319,164 +315,6 @@ def _resolve_fetch_start_date(asof_date: str, min_history: int) -> str:
     bars_needed = max(int(min_history), _FETCH_MIN_BARS)
     calendar_days = math.ceil(bars_needed * _FETCH_TRADING_TO_CALENDAR) + _FETCH_WINDOW_BUFFER_DAYS
     return (asof - dt.timedelta(days=calendar_days)).isoformat()
-
-
-def _to_date_iso(ts) -> Optional[str]:
-    if ts is None or pd.isna(ts):
-        return None
-    if isinstance(ts, pd.Timestamp):
-        return ts.date().isoformat()
-    if isinstance(ts, dt.datetime):
-        return ts.date().isoformat()
-    if isinstance(ts, dt.date):
-        return ts.isoformat()
-    return str(ts)
-
-
-def _last_bar_map(ohlcv: pd.DataFrame) -> dict[str, str]:
-    out: dict[str, str] = {}
-    if ohlcv is None or ohlcv.empty:
-        return out
-    if "Close" not in ohlcv.columns.get_level_values(0):
-        return out
-    close = ohlcv["Close"]
-    for t in close.columns:
-        series = close[t].dropna()
-        if series.empty:
-            continue
-        ts = series.index[-1]
-        iso = _to_iso(ts)
-        if iso:
-            out[str(t)] = iso
-    return out
-
-
-def _price_history_map(
-    ohlcv: pd.DataFrame,
-    tickers: list[str] | None = None,
-    max_bars: int = PRICE_HISTORY_MAX_BARS,
-) -> dict[str, list[dict]]:
-    """Build price history map for specified tickers only.
-    
-    Args:
-        ohlcv: OHLCV DataFrame with MultiIndex columns
-        tickers: List of tickers to process. If None, processes all tickers.
-        max_bars: Maximum number of bars to include per ticker
-        
-    Returns:
-        Dict mapping ticker to list of {date, close} points. Each point also
-        carries open/high/low/volume when those fields exist in *ohlcv*
-        (optional, for candlestick rendering); absent fields are omitted.
-    """
-    out: dict[str, list[dict]] = {}
-    if ohlcv is None or ohlcv.empty:
-        return out
-    levels = ohlcv.columns.get_level_values(0)
-    if "Close" not in levels:
-        return out
-
-    def _sub(field: str):
-        return ohlcv[field] if field in levels else None
-
-    close = ohlcv["Close"]
-    open_ = _sub("Open")
-    high = _sub("High")
-    low = _sub("Low")
-    vol = _sub("Volume")
-    columns_to_process = close.columns if tickers is None else [t for t in tickers if t in close.columns]
-
-    for ticker in columns_to_process:
-        series = close[ticker].dropna()
-        if series.empty:
-            continue
-        if max_bars > 0 and len(series) > max_bars:
-            series = series.iloc[-max_bars:]
-        points = []
-        for ts, px in series.items():
-            date = _to_date_iso(ts)
-            if date is None:
-                continue
-            point = {"date": date, "close": float(px)}
-            for key, frame in (("open", open_), ("high", high), ("low", low), ("volume", vol)):
-                if frame is not None and ticker in frame.columns:
-                    val = frame[ticker].get(ts)
-                    if val is not None and pd.notna(val):
-                        point[key] = float(val)
-            points.append(point)
-        if points:
-            out[str(ticker)] = points
-    return out
-
-
-def _price_history_change_pct(history: list[dict]) -> Optional[float]:
-    if len(history) < 2:
-        return None
-    try:
-        start = float(history[0]["close"])
-        end = float(history[-1]["close"])
-    except (KeyError, TypeError, ValueError):
-        return None
-    if not math.isfinite(start) or not math.isfinite(end) or start <= 0:
-        return None
-    return ((end - start) / start) * 100.0
-
-
-def _aligned_benchmark_price_history(
-    candidate_history: list[dict],
-    benchmark_history: list[dict],
-) -> list[dict]:
-    """Return benchmark closes aligned to the candidate timeline and normalized to the symbol's start price."""
-    if len(candidate_history) < 2 or len(benchmark_history) < 1:
-        return []
-
-    candidate_dates: list[pd.Timestamp] = []
-    candidate_closes: list[float] = []
-    for point in candidate_history:
-        try:
-            ts = pd.Timestamp(str(point["date"]))
-            close = float(point["close"])
-        except (KeyError, TypeError, ValueError):
-            continue
-        if pd.isna(ts) or not math.isfinite(close) or close <= 0:
-            continue
-        candidate_dates.append(ts)
-        candidate_closes.append(close)
-
-    benchmark_points: list[tuple[pd.Timestamp, float]] = []
-    for point in benchmark_history:
-        try:
-            ts = pd.Timestamp(str(point["date"]))
-            close = float(point["close"])
-        except (KeyError, TypeError, ValueError):
-            continue
-        if pd.isna(ts) or not math.isfinite(close) or close <= 0:
-            continue
-        benchmark_points.append((ts, close))
-
-    if len(candidate_dates) < 2 or not benchmark_points:
-        return []
-
-    benchmark_series = pd.Series(
-        {ts: close for ts, close in benchmark_points},
-        dtype=float,
-    ).sort_index()
-    aligned = benchmark_series.reindex(pd.DatetimeIndex(candidate_dates)).ffill().bfill()
-    if aligned.isna().any():
-        return []
-
-    symbol_start = candidate_closes[0]
-    benchmark_start = float(aligned.iloc[0])
-    if symbol_start <= 0 or benchmark_start <= 0:
-        return []
-
-    scale = symbol_start / benchmark_start
-    return [
-        {
-            "date": _to_date_iso(ts) or str(ts),
-            "close": float(close * scale),
-        }
-        for ts, close in zip(candidate_dates, aligned.tolist())
-    ]
 
 
 def _fundamentals_summary(snapshot) -> str | None:
@@ -877,16 +715,16 @@ class ScreenerService:
             logger.error("OHLCV fetch returned empty data (tickers=%s)", len(ctx.tickers))
             raise NotFoundError("No market data found for requested tickers")
 
-        ctx.ohlcv = _merge_ohlcv(ctx.ohlcv, sector_ohlcv)
+        ctx.ohlcv = merge_ohlcv(ctx.ohlcv, sector_ohlcv)
 
         if "Close" not in ctx.ohlcv.columns.get_level_values(0) or ctx.benchmark not in ctx.ohlcv["Close"].columns:
             logger.warning("Benchmark %s missing from OHLCV; fetching separately.", ctx.benchmark)
             bench_df = self._provider.fetch_ohlcv([ctx.benchmark], start_date=ctx.start_date, end_date=ctx.end_date)
-            ctx.ohlcv = _merge_ohlcv(ctx.ohlcv, bench_df)
+            ctx.ohlcv = merge_ohlcv(ctx.ohlcv, bench_df)
             if "Close" not in ctx.ohlcv.columns.get_level_values(0) or ctx.benchmark not in ctx.ohlcv["Close"].columns:
                 raise ServiceError("Benchmark data missing; cannot compute momentum.")
 
-        ctx.last_bar_map = _last_bar_map(ctx.ohlcv)
+        ctx.last_bar_map = last_bar_map(ctx.ohlcv)
         ctx.overall_last_bar = _to_iso(ctx.ohlcv.index.max())
         ctx.data_freshness = _resolve_data_freshness(ctx.asof_str, ctx.now_utc, ctx.active_currencies)
 
@@ -1031,11 +869,11 @@ class ScreenerService:
         ticker_list = [str(idx) for idx in results.index]
 
         # Build price history only for candidate tickers to improve performance
-        price_history_map = _price_history_map(ohlcv, tickers=ticker_list)
+        price_history_by_ticker = price_history_map(ohlcv, tickers=ticker_list)
         patterns_map = detect_patterns(ohlcv, tickers=ticker_list, cfg=CandleConfig())
         exec_cfg = ExecutionConfig()
-        benchmark_history = _price_history_map(ohlcv, tickers=[benchmark]).get(benchmark, [])
-        benchmark_change_pct = _price_history_change_pct(benchmark_history)
+        benchmark_history = price_history_map(ohlcv, tickers=[benchmark]).get(benchmark, [])
+        benchmark_change_pct = price_history_change_pct(benchmark_history)
         benchmark_last_bar = last_bar_map.get(benchmark) or overall_last_bar
 
         atr_col = f"atr{universe_cfg.vol.atr_window}"
@@ -1105,9 +943,9 @@ class ScreenerService:
             )
             recommendation = Recommendation.model_validate(asdict(rec_payload))
             rec_risk = recommendation.risk
-            candidate_history = price_history_map.get(ticker_str, [])
-            symbol_change_pct = _price_history_change_pct(candidate_history)
-            benchmark_price_history = _aligned_benchmark_price_history(candidate_history, benchmark_history)
+            candidate_history = price_history_by_ticker.get(ticker_str, [])
+            symbol_change_pct = price_history_change_pct(candidate_history)
+            benchmark_price_history = aligned_benchmark_price_history(candidate_history, benchmark_history)
             benchmark_outperformance_pct = (
                 symbol_change_pct - benchmark_change_pct
                 if symbol_change_pct is not None and benchmark_change_pct is not None
@@ -1196,7 +1034,7 @@ class ScreenerService:
                     risk_usd=risk_usd if risk_usd is not None else rec_risk.risk_amount,
                     risk_pct=risk_pct if risk_pct is not None else rec_risk.risk_pct,
                     recommendation=recommendation,
-                    price_history=price_history_map.get(ticker_str, []),
+                    price_history=price_history_by_ticker.get(ticker_str, []),
                     benchmark_price_history=benchmark_price_history,
                     patterns=cand_patterns,
                     pattern_stop=pattern_stop_val,

--- a/docs/engineering/MODULE_ARCHITECTURE.md
+++ b/docs/engineering/MODULE_ARCHITECTURE.md
@@ -47,6 +47,27 @@ Use these paths for new code:
 - Selection pipeline: `swing_screener.selection.*`
 - Recommendations: `swing_screener.risk.recommendations.*`
 - Report config: `swing_screener.strategy.report_config.ReportConfig`
+- Scalar coercion helpers: `swing_screener.utils.coerce.*` (`is_na_scalar`, `safe_float`, `safe_optional_float`, `safe_optional_int`, `safe_list`)
+- Price-history / OHLCV shaping: `swing_screener.data.price_history.*` (`merge_ohlcv`, `to_date_iso`, `last_bar_map`, `price_history_map`, `price_history_change_pct`, `aligned_benchmark_price_history`)
+
+## Screener Pipeline
+
+`ScreenerService.run_screener` (`api/services/screener_service.py`) is a thin orchestrator
+that builds a `_RunContext` and calls seven private pipeline steps in order, then constructs
+the `ScreenerResponse` from the context:
+
+1. `_resolve_universe_and_window`
+2. `_build_signals_and_fetch_ohlcv`
+3. `_build_run_configs`
+4. `_run_daily_report` (returns `None` when there are no candidates)
+5. `_build_candidates`
+6. `_apply_same_symbol_filter`
+7. `_enrich_and_rank`
+
+Each step reads/writes `_RunContext`; the orchestrator owns response construction. The pure,
+side-effect-free helpers it relies on live in core: scalar coercion in
+`swing_screener.utils.coerce` and price-history shaping in `swing_screener.data.price_history`.
+The I/O-coupled `_fetch_ohlcv_chunked` and fundamentals-coupled `_is_stale` remain in the service.
 
 ## Removed Legacy Packages
 

--- a/docs/overview/INDEX.md
+++ b/docs/overview/INDEX.md
@@ -61,6 +61,7 @@ Config:
 - `/docs/superpowers/specs/2026-06-14-candlestick-chart-pattern-reader-design.md`
 - `/docs/superpowers/plans/2026-06-14-candlestick-chart-pattern-reader.md`
 - `/docs/superpowers/plans/2026-06-16-backend-pr-a-domain-errors-logging-docs.md`
+- `/docs/superpowers/plans/2026-06-16-backend-pr-b-split-run-screener.md`
 
 ## Repo Policy Docs
 - `/.github/BRANCH_PROTECTION.md`

--- a/src/swing_screener/data/price_history.py
+++ b/src/swing_screener/data/price_history.py
@@ -1,0 +1,192 @@
+"""Pure OHLCV / price-history shaping helpers."""
+from __future__ import annotations
+
+import datetime as dt
+import math
+from typing import Optional
+
+import pandas as pd
+
+# Maximum bars returned per ticker by price_history_map when no override is given.
+PRICE_HISTORY_MAX_BARS = 252
+
+
+def _to_iso(ts) -> Optional[str]:
+    """Shared timestamp → full ISO string (mirrors api.utils.converters.to_iso)."""
+    if ts is None or pd.isna(ts):
+        return None
+    if isinstance(ts, pd.Timestamp):
+        ts = ts.to_pydatetime()
+    if isinstance(ts, dt.datetime):
+        return ts.isoformat()
+    if isinstance(ts, dt.date):
+        return dt.datetime.combine(ts, dt.time()).isoformat()
+    return str(ts)
+
+
+def merge_ohlcv(base: pd.DataFrame, extra: pd.DataFrame) -> pd.DataFrame:
+    if base is None or base.empty:
+        return extra
+    if extra is None or extra.empty:
+        return base
+    merged = pd.concat([base, extra], axis=1)
+    merged = merged.loc[:, ~merged.columns.duplicated()]
+    return merged.sort_index(axis=1)
+
+
+def to_date_iso(ts) -> Optional[str]:
+    if ts is None or pd.isna(ts):
+        return None
+    if isinstance(ts, pd.Timestamp):
+        return ts.date().isoformat()
+    if isinstance(ts, dt.datetime):
+        return ts.date().isoformat()
+    if isinstance(ts, dt.date):
+        return ts.isoformat()
+    return str(ts)
+
+
+def last_bar_map(ohlcv: pd.DataFrame) -> dict[str, str]:
+    out: dict[str, str] = {}
+    if ohlcv is None or ohlcv.empty:
+        return out
+    if "Close" not in ohlcv.columns.get_level_values(0):
+        return out
+    close = ohlcv["Close"]
+    for t in close.columns:
+        series = close[t].dropna()
+        if series.empty:
+            continue
+        ts = series.index[-1]
+        iso = _to_iso(ts)
+        if iso:
+            out[str(t)] = iso
+    return out
+
+
+def price_history_map(
+    ohlcv: pd.DataFrame,
+    tickers: list[str] | None = None,
+    max_bars: int = PRICE_HISTORY_MAX_BARS,
+) -> dict[str, list[dict]]:
+    """Build price history map for specified tickers only.
+
+    Args:
+        ohlcv: OHLCV DataFrame with MultiIndex columns
+        tickers: List of tickers to process. If None, processes all tickers.
+        max_bars: Maximum number of bars to include per ticker
+
+    Returns:
+        Dict mapping ticker to list of {date, close} points. Each point also
+        carries open/high/low/volume when those fields exist in *ohlcv*
+        (optional, for candlestick rendering); absent fields are omitted.
+    """
+    out: dict[str, list[dict]] = {}
+    if ohlcv is None or ohlcv.empty:
+        return out
+    levels = ohlcv.columns.get_level_values(0)
+    if "Close" not in levels:
+        return out
+
+    def _sub(field: str):
+        return ohlcv[field] if field in levels else None
+
+    close = ohlcv["Close"]
+    open_ = _sub("Open")
+    high = _sub("High")
+    low = _sub("Low")
+    vol = _sub("Volume")
+    columns_to_process = close.columns if tickers is None else [t for t in tickers if t in close.columns]
+
+    for ticker in columns_to_process:
+        series = close[ticker].dropna()
+        if series.empty:
+            continue
+        if max_bars > 0 and len(series) > max_bars:
+            series = series.iloc[-max_bars:]
+        points = []
+        for ts, px in series.items():
+            date = to_date_iso(ts)
+            if date is None:
+                continue
+            point = {"date": date, "close": float(px)}
+            for key, frame in (("open", open_), ("high", high), ("low", low), ("volume", vol)):
+                if frame is not None and ticker in frame.columns:
+                    val = frame[ticker].get(ts)
+                    if val is not None and pd.notna(val):
+                        point[key] = float(val)
+            points.append(point)
+        if points:
+            out[str(ticker)] = points
+    return out
+
+
+def price_history_change_pct(history: list[dict]) -> Optional[float]:
+    if len(history) < 2:
+        return None
+    try:
+        start = float(history[0]["close"])
+        end = float(history[-1]["close"])
+    except (KeyError, TypeError, ValueError):
+        return None
+    if not math.isfinite(start) or not math.isfinite(end) or start <= 0:
+        return None
+    return ((end - start) / start) * 100.0
+
+
+def aligned_benchmark_price_history(
+    candidate_history: list[dict],
+    benchmark_history: list[dict],
+) -> list[dict]:
+    """Return benchmark closes aligned to the candidate timeline and normalized to the symbol's start price."""
+    if len(candidate_history) < 2 or len(benchmark_history) < 1:
+        return []
+
+    candidate_dates: list[pd.Timestamp] = []
+    candidate_closes: list[float] = []
+    for point in candidate_history:
+        try:
+            ts = pd.Timestamp(str(point["date"]))
+            close = float(point["close"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        if pd.isna(ts) or not math.isfinite(close) or close <= 0:
+            continue
+        candidate_dates.append(ts)
+        candidate_closes.append(close)
+
+    benchmark_points: list[tuple[pd.Timestamp, float]] = []
+    for point in benchmark_history:
+        try:
+            ts = pd.Timestamp(str(point["date"]))
+            close = float(point["close"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        if pd.isna(ts) or not math.isfinite(close) or close <= 0:
+            continue
+        benchmark_points.append((ts, close))
+
+    if len(candidate_dates) < 2 or not benchmark_points:
+        return []
+
+    benchmark_series = pd.Series(
+        {ts: close for ts, close in benchmark_points},
+        dtype=float,
+    ).sort_index()
+    aligned = benchmark_series.reindex(pd.DatetimeIndex(candidate_dates)).ffill().bfill()
+    if aligned.isna().any():
+        return []
+
+    symbol_start = candidate_closes[0]
+    benchmark_start = float(aligned.iloc[0])
+    if symbol_start <= 0 or benchmark_start <= 0:
+        return []
+
+    scale = symbol_start / benchmark_start
+    return [
+        {
+            "date": to_date_iso(ts) or str(ts),
+            "close": float(close * scale),
+        }
+        for ts, close in zip(candidate_dates, aligned.tolist())
+    ]

--- a/src/swing_screener/utils/coerce.py
+++ b/src/swing_screener/utils/coerce.py
@@ -1,0 +1,48 @@
+import pandas as pd
+
+
+def is_na_scalar(val) -> bool:
+    if val is None:
+        return True
+    if isinstance(val, (list, tuple, set, dict)):
+        return False
+    try:
+        return bool(pd.isna(val))
+    except (TypeError, ValueError):
+        return False
+
+
+def safe_float(val, default=0.0):
+    if is_na_scalar(val):
+        return default
+    return float(val)
+
+
+def safe_optional_float(val):
+    if is_na_scalar(val):
+        return None
+    return float(val)
+
+
+def safe_optional_int(val):
+    if is_na_scalar(val):
+        return None
+    try:
+        return int(val)
+    except (TypeError, ValueError, OverflowError):
+        return None
+
+
+def safe_list(val):
+    if is_na_scalar(val):
+        return []
+    if isinstance(val, list):
+        return [str(v) for v in val if not is_na_scalar(v)]
+    if isinstance(val, str):
+        if not val.strip():
+            return []
+        sep = ";" if ";" in val else "," if "," in val else None
+        if sep:
+            return [v.strip() for v in val.split(sep) if v.strip()]
+        return [val]
+    return [str(val)]

--- a/tests/test_coerce.py
+++ b/tests/test_coerce.py
@@ -1,0 +1,32 @@
+import math
+import pandas as pd
+from swing_screener.utils.coerce import (
+    is_na_scalar, safe_float, safe_optional_float, safe_optional_int, safe_list,
+)
+
+
+def test_is_na_scalar_detects_none_and_nan():
+    assert is_na_scalar(None) is True
+    assert is_na_scalar(float("nan")) is True
+    assert is_na_scalar(1.5) is False
+
+
+def test_safe_float_defaults_on_na():
+    assert safe_float(None) == 0.0
+    assert safe_float(float("nan")) == 0.0
+    assert safe_float("2.5") == 2.5
+
+
+def test_safe_optional_float_returns_none_on_na():
+    assert safe_optional_float(None) is None
+    assert safe_optional_float(3) == 3.0
+
+
+def test_safe_optional_int_returns_none_on_na():
+    assert safe_optional_int(None) is None
+    assert safe_optional_int(4.0) == 4
+
+
+def test_safe_list_wraps_and_filters():
+    assert safe_list(None) == []
+    assert safe_list([1, 2]) == ["1", "2"]

--- a/tests/test_price_history.py
+++ b/tests/test_price_history.py
@@ -1,0 +1,36 @@
+import pandas as pd
+from swing_screener.data.price_history import (
+    merge_ohlcv,
+    price_history_map,
+    price_history_change_pct,
+)
+
+
+def _frame(ticker, closes, dates):
+    cols = pd.MultiIndex.from_tuples([("Close", ticker), ("Volume", ticker)])
+    data = [[c, 1000] for c in closes]
+    return pd.DataFrame(data, index=pd.to_datetime(dates), columns=cols)
+
+
+def test_merge_ohlcv_unions_columns():
+    a = _frame("AAA", [1, 2], ["2024-01-01", "2024-01-02"])
+    b = _frame("BBB", [3, 4], ["2024-01-01", "2024-01-02"])
+    merged = merge_ohlcv(a, b)
+    assert ("Close", "AAA") in merged.columns
+    assert ("Close", "BBB") in merged.columns
+
+
+def test_price_history_change_pct_computes_first_to_last():
+    history = [{"close": 100.0}, {"close": 110.0}]
+    assert price_history_change_pct(history) == 10.0
+
+
+def test_price_history_change_pct_handles_empty():
+    assert price_history_change_pct([]) is None
+
+
+def test_price_history_map_returns_close_points():
+    a = _frame("AAA", [10.0, 20.0], ["2024-01-01", "2024-01-02"])
+    result = price_history_map(a, tickers=["AAA"])
+    assert "AAA" in result
+    assert result["AAA"][0]["close"] == 10.0

--- a/tests/test_screener_service.py
+++ b/tests/test_screener_service.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from api.services.screener_service import _price_history_map
+from swing_screener.data.price_history import price_history_map
 
 
 def _ohlcv():
@@ -27,7 +27,7 @@ def _ohlcv():
 
 
 def test_price_history_map_includes_ohlcv():
-    out = _price_history_map(_ohlcv(), tickers=["AAA"])
+    out = price_history_map(_ohlcv(), tickers=["AAA"])
     point = out["AAA"][0]
     assert point["close"] == 10.0
     assert point["open"] == 9.5
@@ -40,7 +40,7 @@ def test_price_history_map_close_only_when_ohlc_absent():
     idx = pd.date_range("2024-01-01", periods=2, freq="B")
     cols = pd.MultiIndex.from_tuples([("Close", "AAA")], names=["field", "ticker"])
     df = pd.DataFrame([[10.0], [10.5]], index=idx, columns=cols)
-    out = _price_history_map(df, tickers=["AAA"])
+    out = price_history_map(df, tickers=["AAA"])
     point = out["AAA"][0]
     assert point["close"] == 10.0
     assert "open" not in point and "volume" not in point


### PR DESCRIPTION
  `ScreenerService.run_screener` had grown into a ~535-line god-method that resolved the universe, fetched OHLCV, built configs, ran the daily report, constructed candidates, applied same-symbol re-entry filtering, and enriched/ranked, all
  inline. This splits it into a thin orchestrator over seven named, individually-reviewable pipeline steps that read and write a `_RunContext` state object, and relocates the genuinely-pure helpers out of the service into the core library.

  Phase 1: the orchestrator is now ~61 lines. It builds a `_RunContext`, then calls `_resolve_universe_and_window`, `_build_signals_and_fetch_ohlcv`, `_build_run_configs`, `_run_daily_report`, `_build_candidates`, `_apply_same_symbol_filter`,
  `_enrich_and_rank`, and finally builds the `ScreenerResponse` from the context. No behavior change: each step was extracted one commit at a time with the screener suite staying green, and the response now reads from `ctx` directly instead of
  leftover bridge locals.

  Phase 2: the side-effect-free helpers moved to core, each with unit tests.

  - scalar coercion (`is_na_scalar`, `safe_float`, `safe_optional_float`, `safe_optional_int`, `safe_list`) to `swing_screener.utils.coerce`
  - price-history / OHLCV shaping (`merge_ohlcv`, `to_date_iso`, `last_bar_map`, `price_history_map`, `price_history_change_pct`, `aligned_benchmark_price_history`) to `swing_screener.data.price_history`

  The I/O-coupled `_fetch_ohlcv_chunked` and the fundamentals-coupled `_is_stale` stay in the service. The 5 service-coupled decision-context/fundamentals helpers are intentionally left for a follow-up (PR B-2).

  Testing: `pytest -m "not integration"` green (858 passed, 1 skipped). `ruff check --select F` shows no new errors vs the `main` baseline (the 3 remaining are pre-existing). The pipeline decomposition is documented in
  `docs/engineering/MODULE_ARCHITECTURE.md`.