### PR TITLE
Explain why a held position moved since entry in the LLM analysis

### DIFF
--- a/api/routers/intelligence.py
+++ b/api/routers/intelligence.py
@@ -126,6 +126,7 @@ def analyze_position(
         signal=stop.action,
         entry_price=float(pos.entry_price),
         entry=float(pos.entry_price),
+        entry_date=str(pos.entry_date) if pos.entry_date is not None else None,
         stop=float(pos.stop_price),
         r_now=float(pos.r_now),
         days_open=int(pos.days_open),

--- a/src/swing_screener/intelligence/README.md
+++ b/src/swing_screener/intelligence/README.md
@@ -76,3 +76,13 @@ Results stored as JSON under `data/intelligence/<ticker>_analysis.json`. TTL is 
 - `BUY_ON_PULLBACK` — waiting for price to pull back to planned entry level
 - `MANAGE_ONLY` — position already held; narrative is position-management focused
 - `SKIP` — no actionable signal
+
+## Open-position fields
+
+When the request carries position context (`entry_price`, `entry_date`, `r_now`, `days_open`), the
+result also populates:
+- `position_signal` — HOLD / TRIM / EXIT call
+- `position_outlook` — forward holding plan (expected hold, thesis status, invalidation signals, …)
+- `position_move_explanation` — backward look: why price moved from entry to now (`direction`
+  up/down/flat, `summary`, and `drivers[]` of `{label, detail}` grounded in news since the entry
+  date), explaining the sign and size of the current R. `null` outside position context.

--- a/src/swing_screener/intelligence/models.py
+++ b/src/swing_screener/intelligence/models.py
@@ -44,6 +44,17 @@ class PositionSignal(BaseModel):
     re_entry_zone: dict | None = None
 
 
+class PriceMoveDriver(BaseModel):
+    label: str
+    detail: str
+
+
+class PositionMoveExplanation(BaseModel):
+    direction: Literal["up", "down", "flat"]
+    summary: str
+    drivers: list[PriceMoveDriver] = Field(default_factory=list)
+
+
 class KeyNumber(BaseModel):
     label: str
     value: str
@@ -85,6 +96,7 @@ class SymbolIntelligenceRequest(BaseModel):
     sector: str | None = None
     currency: str = "USD"
     entry_price: float | None = None
+    entry_date: str | None = None
     r_now: float | None = None
     days_open: int | None = None
     # Extended context — decision summary + chart quality + fundamentals
@@ -140,6 +152,7 @@ class SymbolIntelligence(BaseModel):
     upcoming_events: list[IntelligenceEvent] = []
     position_signal: PositionSignal | None = None
     position_outlook: PositionOutlook | None = None
+    position_move_explanation: PositionMoveExplanation | None = None
     sources: list[str] = []
     inputs_used: dict = Field(default_factory=dict)
     price_hook: str | None = None

--- a/src/swing_screener/intelligence/symbol_analyzer.py
+++ b/src/swing_screener/intelligence/symbol_analyzer.py
@@ -37,6 +37,9 @@ In that case you MUST:
   • Write the narrative from a position-management perspective — do NOT suggest initiating an entry.
   • Frame **What to do:** around holding, trimming, or exiting the current position.
   • Frame **Watch for:** around signals that would change your hold/trim/exit recommendation.
+  • Set position_move_explanation: explain why the price moved from the entry to now over the
+    holding window, citing live news / earnings / sector moves since the entry date, and account
+    for the sign and size of the current P&L (R).
 
 Return ONLY a JSON block (fenced with ```json) with exactly these fields:
 - action: one of BUY_NOW | BUY_ON_PULLBACK | WAIT_FOR_BREAKOUT | WATCH | TACTICAL_ONLY | AVOID | MANAGE_ONLY
@@ -62,6 +65,12 @@ Return ONLY a JSON block (fenced with ```json) with exactly these fields:
   HOLD = thesis intact, no change needed
   TRIM = take partial profit or reduce risk, thesis weakening
   EXIT = thesis broken or clearly better use of capital
+- position_move_explanation: null unless position context is provided — then an object with:
+  direction: up | down | flat (how price moved from entry to now)
+  summary: one sentence — net reason the price is where it is versus the entry, consistent with the P&L sign
+  drivers: array of 1-4 objects {label, detail}, most material first. label = short tag
+    (e.g. "Q1 earnings beat", "sector selloff", "guidance cut"); detail = one sentence.
+    Ground drivers in news/events since the entry date, not generic commentary.
 - position_outlook: null unless position context is provided — then an object with:
   expected_holding_period: days | 1-2_weeks | 2-6_weeks | unknown
   hold_until: plain-English condition for staying in the trade, not a guaranteed date
@@ -144,13 +153,17 @@ def _build_user_prompt(ticker: str, req: SymbolIntelligenceRequest, past_positio
         lines += [
             "⚠️  OPEN POSITION — the user already holds this stock. Do NOT suggest initiating.",
             f"  Filled entry:  {fmt(req.entry_price)} {req.currency}",
+            f"  Entry date:    {req.entry_date or 'N/A'}",
             f"  Current price: {fmt(req.close)} {req.currency}",
             f"  Current P&L:   {r_sign}{req.r_now:.2f}R",
             f"  Days held:     {req.days_open}",
             f"  Current stop:  {fmt(req.stop)} {req.currency}",
             "",
             "Focus on whether to HOLD, TRIM, or EXIT. Set action = MANAGE_ONLY.",
-            "Include position_signal and position_outlook in your JSON output.",
+            "Explain why the price moved from the entry to now over the holding window: "
+            "use live news, earnings and sector moves since the entry date to account for the "
+            "sign and size of the current P&L (R). Put this in position_move_explanation.",
+            "Include position_signal, position_outlook and position_move_explanation in your JSON output.",
         ]
     else:
         currency = req.currency or ""
@@ -452,6 +465,7 @@ class SymbolAnalyzer:
             upcoming_events=raw.get("upcoming_events", []),
             position_signal=raw.get("position_signal"),
             position_outlook=raw.get("position_outlook"),
+            position_move_explanation=raw.get("position_move_explanation"),
             sources=raw.get("sources", []),
             price_hook=raw.get("price_hook"),
             key_numbers=raw.get("key_numbers", []),

--- a/tests/test_intelligence_prompt.py
+++ b/tests/test_intelligence_prompt.py
@@ -55,3 +55,56 @@ def test_user_prompt_search_instruction_is_multi_hop():
     req = SymbolIntelligenceRequest(close=100.0, signal="breakout")
     prompt = _build_user_prompt("AAPL", req).lower()
     assert "follow" in prompt and "catalyst" in prompt
+
+
+def _open_position_request() -> SymbolIntelligenceRequest:
+    return SymbolIntelligenceRequest(
+        close=110.0,
+        signal="MANAGE_ONLY",
+        entry_price=100.0,
+        entry_date="2026-05-01",
+        stop=95.0,
+        r_now=2.0,
+        days_open=46,
+    )
+
+
+def test_open_position_prompt_includes_entry_date_and_move_explanation():
+    prompt = _build_user_prompt("AAPL", _open_position_request())
+    assert "Entry date:    2026-05-01" in prompt
+    assert "position_move_explanation" in prompt
+    assert "moved from the entry to now" in prompt
+
+
+def test_move_explanation_omitted_without_position_context():
+    prompt = _build_user_prompt("AAPL", SymbolIntelligenceRequest(close=110.0, signal="breakout"))
+    assert "position_move_explanation" not in prompt
+    assert "Entry date:" not in prompt
+
+
+def test_system_prompt_documents_move_explanation_schema():
+    assert "position_move_explanation" in _SYSTEM_PROMPT
+    assert "up | down | flat" in _SYSTEM_PROMPT
+
+
+def test_symbol_intelligence_parses_position_move_explanation():
+    from swing_screener.intelligence.models import SymbolIntelligence
+
+    result = SymbolIntelligence.model_validate(
+        {
+            "symbol": "AAPL",
+            "generated_at": "2026-06-16T00:00:00+00:00",
+            "action": "MANAGE_ONLY",
+            "conviction": "medium",
+            "summary_line": "Holding into earnings.",
+            "narrative": "What to do: hold.",
+            "position_move_explanation": {
+                "direction": "up",
+                "summary": "Up since entry on a strong Q1 beat.",
+                "drivers": [{"label": "Q1 earnings beat", "detail": "Revenue topped guidance."}],
+            },
+        }
+    )
+    assert result.position_move_explanation is not None
+    assert result.position_move_explanation.direction == "up"
+    assert result.position_move_explanation.drivers[0].label == "Q1 earnings beat"

--- a/web-ui/src/components/domain/workspace/IntelligenceCard.test.tsx
+++ b/web-ui/src/components/domain/workspace/IntelligenceCard.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import IntelligenceCard from './IntelligenceCard';
+import { t } from '@/i18n/t';
 import type {
   SymbolIntelligence,
   IntelligenceEvent,
@@ -115,5 +116,32 @@ describe('IntelligenceCard', () => {
     expect(screen.getByText('Hold while price remains above SMA20.')).toBeInTheDocument();
     expect(screen.getByText('Reassess after earnings.')).toBeInTheDocument();
     expect(screen.getByText('Close below SMA20')).toBeInTheDocument();
+  });
+
+  it('renders position move explanation when present', () => {
+    render(
+      <IntelligenceCard
+        intelligence={{
+          ...baseIntelExtended,
+          positionMoveExplanation: {
+            direction: 'up',
+            summary: 'Up since entry on a strong Q1 beat.',
+            drivers: [{ label: 'Q1 earnings beat', detail: 'Revenue topped guidance.' }],
+          },
+        }}
+      />,
+    );
+    expect(
+      screen.getByText(t('workspacePage.panels.analysis.intelligence.positionMove.title')),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Up since entry on a strong Q1 beat.')).toBeInTheDocument();
+    expect(screen.getByText(/Revenue topped guidance\./)).toBeInTheDocument();
+  });
+
+  it('does not render position move explanation when null', () => {
+    render(<IntelligenceCard intelligence={{ ...baseIntelExtended, positionMoveExplanation: null }} />);
+    expect(
+      screen.queryByText(t('workspacePage.panels.analysis.intelligence.positionMove.title')),
+    ).toBeNull();
   });
 });

--- a/web-ui/src/components/domain/workspace/IntelligenceCard.tsx
+++ b/web-ui/src/components/domain/workspace/IntelligenceCard.tsx
@@ -1,6 +1,7 @@
 import type {
   CatalystUrgency,
   PositionSignalAction,
+  PriceMoveDirection,
   SymbolIntelligence,
 } from '@/features/intelligence/types';
 import { t } from '@/i18n/t';
@@ -34,6 +35,24 @@ function humanizeToken(value: string): string {
   return value.replace(/_/g, ' ');
 }
 
+function moveDirectionClass(direction: PriceMoveDirection): string {
+  switch (direction) {
+    case 'up': return 'bg-emerald-50 border-emerald-200 text-emerald-800';
+    case 'down': return 'bg-rose-50 border-rose-200 text-rose-800';
+    default: return 'bg-slate-50 border-slate-200 text-slate-700';
+  }
+}
+
+const MOVE_DIRECTION_ARROW: Record<PriceMoveDirection, string> = {
+  up: '↑',
+  down: '↓',
+  flat: '→',
+};
+
+function moveDirectionLabel(direction: PriceMoveDirection): string {
+  return t(`workspacePage.panels.analysis.intelligence.positionMove.direction.${direction}`);
+}
+
 const DIRECTION_ARROW: Record<string, string> = {
   bullish: '↑',
   bearish: '↓',
@@ -46,14 +65,16 @@ interface IntelligenceCardProps {
 
 export default function IntelligenceCard({ intelligence }: IntelligenceCardProps) {
   const {
-    catalystUrgency, upcomingEvents, positionSignal, positionOutlook, sources,
+    catalystUrgency, upcomingEvents, positionSignal, positionOutlook,
+    positionMoveExplanation, sources,
   } = intelligence;
   const hasUrgency = catalystUrgency !== 'none';
   const hasEvents = upcomingEvents.length > 0;
   const hasSources = sources.length > 0;
   const hasPositionOutlook = Boolean(positionOutlook);
+  const hasMoveExplanation = Boolean(positionMoveExplanation);
 
-  if (!hasUrgency && !positionSignal && !hasPositionOutlook && !hasEvents && !hasSources) {
+  if (!hasUrgency && !positionSignal && !hasMoveExplanation && !hasPositionOutlook && !hasEvents && !hasSources) {
     return null;
   }
 
@@ -77,6 +98,32 @@ export default function IntelligenceCard({ intelligence }: IntelligenceCardProps
               {positionSignalLabel(positionSignal.action)}
             </span>
             <span className="text-sm">{positionSignal.reason}</span>
+          </div>
+        </>
+      )}
+
+      {positionMoveExplanation && (
+        <>
+          <hr className="border-slate-100" />
+          <div className={`rounded-lg border px-3 py-2 ${moveDirectionClass(positionMoveExplanation.direction)}`}>
+            <div className="flex items-center gap-2">
+              <span className="text-xs font-semibold uppercase tracking-wide">
+                {t('workspacePage.panels.analysis.intelligence.positionMove.title')}
+              </span>
+              <span className="text-sm font-semibold">
+                {MOVE_DIRECTION_ARROW[positionMoveExplanation.direction]} {moveDirectionLabel(positionMoveExplanation.direction)}
+              </span>
+            </div>
+            <p className="text-sm mt-1">{positionMoveExplanation.summary}</p>
+            {positionMoveExplanation.drivers.length > 0 && (
+              <ul className="mt-2 space-y-1 text-sm list-disc list-inside">
+                {positionMoveExplanation.drivers.map((driver, index) => (
+                  <li key={`${driver.label}-${index}`}>
+                    <span className="font-medium">{driver.label}:</span> {driver.detail}
+                  </li>
+                ))}
+              </ul>
+            )}
           </div>
         </>
       )}

--- a/web-ui/src/components/domain/workspace/NarrativeAnalysisCard.test.tsx
+++ b/web-ui/src/components/domain/workspace/NarrativeAnalysisCard.test.tsx
@@ -241,4 +241,31 @@ describe('NarrativeAnalysisCard — new structured fields', () => {
     expect(screen.queryByText(/Prediction/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/Past trades on/i)).not.toBeInTheDocument();
   });
+
+  it('renders the position move explanation when present', () => {
+    render(
+      <NarrativeAnalysisCard
+        intelligence={{
+          ...baseIntelligence,
+          positionMoveExplanation: {
+            direction: 'down',
+            summary: 'Down since entry on a sector selloff.',
+            drivers: [{ label: 'Sector selloff', detail: 'Semis sold off on rate fears.' }],
+          },
+        }}
+      />,
+    );
+    expect(
+      screen.getByText(t('workspacePage.panels.analysis.intelligence.positionMove.title')),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Down since entry on a sector selloff.')).toBeInTheDocument();
+    expect(screen.getByText(/Semis sold off on rate fears\./)).toBeInTheDocument();
+  });
+
+  it('does not render the position move explanation when absent', () => {
+    render(<NarrativeAnalysisCard intelligence={baseIntelligence} />);
+    expect(
+      screen.queryByText(t('workspacePage.panels.analysis.intelligence.positionMove.title')),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/web-ui/src/components/domain/workspace/NarrativeAnalysisCard.tsx
+++ b/web-ui/src/components/domain/workspace/NarrativeAnalysisCard.tsx
@@ -1,6 +1,6 @@
 import ReactMarkdown from 'react-markdown';
 import Badge from '@/components/common/Badge';
-import type { SymbolIntelligence, DecisionAction, DecisionConviction, KeyNumber, PredictionBullet } from '@/features/intelligence/types';
+import type { SymbolIntelligence, DecisionAction, DecisionConviction, KeyNumber, PredictionBullet, PriceMoveDirection } from '@/features/intelligence/types';
 import type { DecisionCatalystLabel, DecisionSignalLabel, DecisionValuationLabel } from '@/features/screener/types';
 import type { SymbolAnalysisCandidate } from '@/components/domain/workspace/types';
 import { t } from '@/i18n/t';
@@ -89,6 +89,20 @@ function directionClass(direction: PredictionBullet['direction']): string {
   }
 }
 
+const MOVE_DIRECTION_ARROW: Record<PriceMoveDirection, string> = {
+  up: '↑',
+  down: '↓',
+  flat: '→',
+};
+
+function moveDirectionClass(direction: PriceMoveDirection): string {
+  switch (direction) {
+    case 'up': return 'border-emerald-200 bg-emerald-50 text-emerald-800';
+    case 'down': return 'border-rose-200 bg-rose-50 text-rose-800';
+    default: return 'border-slate-200 bg-slate-50 text-slate-700';
+  }
+}
+
 export default function NarrativeAnalysisCard({
   intelligence,
   candidate,
@@ -102,6 +116,7 @@ export default function NarrativeAnalysisCard({
   const hasPrediction = (intelligence.predictionBullets?.length ?? 0) > 0;
   const hasRisks = (intelligence.riskFactors?.length ?? 0) > 0;
   const hasPastTrades = Boolean(intelligence.pastTradesContext);
+  const moveExplanation = intelligence.positionMoveExplanation ?? null;
 
   const decisionHighlights = [
     { label: t('workspacePage.panels.analysis.intelligence.whyNow'), value: summary?.whyNow },
@@ -146,6 +161,31 @@ export default function NarrativeAnalysisCard({
             </dl>
           )}
         </div>
+
+        {/* Why it moved since entry (open positions) */}
+        {moveExplanation && (
+          <div className={`rounded-md border p-3 ${moveDirectionClass(moveExplanation.direction)}`}>
+            <div className="flex items-center gap-2">
+              <span className="text-xs font-semibold uppercase tracking-wide">
+                {t('workspacePage.panels.analysis.intelligence.positionMove.title')}
+              </span>
+              <span className="text-sm font-semibold">
+                {MOVE_DIRECTION_ARROW[moveExplanation.direction]}{' '}
+                {t(`workspacePage.panels.analysis.intelligence.positionMove.direction.${moveExplanation.direction}`)}
+              </span>
+            </div>
+            <p className="mt-1 text-sm">{moveExplanation.summary}</p>
+            {moveExplanation.drivers.length > 0 && (
+              <ul className="mt-2 space-y-1 text-sm list-disc list-inside">
+                {moveExplanation.drivers.map((driver, index) => (
+                  <li key={`${driver.label}-${index}`}>
+                    <span className="font-medium">{driver.label}:</span> {driver.detail}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
 
         {/* Warnings */}
         {warnings.length > 0 && (

--- a/web-ui/src/components/domain/workspace/SymbolAnalysisContent.tsx
+++ b/web-ui/src/components/domain/workspace/SymbolAnalysisContent.tsx
@@ -286,6 +286,13 @@ export default function SymbolAnalysisContent({
                     {new Date(displayedIntelligence.generatedAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
                   </span>
                 )}
+                {intelligenceMutation.isError && (
+                  <span className="text-xs text-rose-600">
+                    {intelligenceMutation.error instanceof Error
+                      ? intelligenceMutation.error.message
+                      : t('workspacePage.panels.analysis.intelligence.analyzeError')}
+                  </span>
+                )}
               </div>
             )}
           </>

--- a/web-ui/src/features/intelligence/api.test.ts
+++ b/web-ui/src/features/intelligence/api.test.ts
@@ -14,6 +14,42 @@ describe('candidateToPayload', () => {
     expect(candidateToPayload({ ticker: 'AAPL' })).toBeNull();
   });
 
+  it('builds a position-only payload for a held symbol with no candidate', () => {
+    const position = {
+      entryPrice: 100,
+      stopPrice: 95,
+      currentPrice: 110,
+      rNow: 2,
+      daysOpen: 46,
+      entryDate: '2026-05-01',
+    } as PositionWithMetrics;
+    const payload = candidateToPayload(undefined, position);
+    expect(payload).not.toBeNull();
+    expect(payload!.close).toBe(110);
+    expect(payload!.signal).toBe('MANAGE_ONLY');
+    expect(payload!.entry_price).toBe(100);
+    expect(payload!.entry_date).toBe('2026-05-01');
+    expect(payload!.r_now).toBe(2);
+    expect(payload!.days_open).toBe(46);
+  });
+
+  it('falls back to entry price when the position has no current price', () => {
+    const position = { entryPrice: 100, rNow: 0, daysOpen: 1, entryDate: '2026-05-01' } as PositionWithMetrics;
+    const payload = candidateToPayload(undefined, position);
+    expect(payload!.close).toBe(100);
+  });
+
+  it('passes entry_date through when a candidate and position are both present', () => {
+    const position = {
+      entryPrice: 140,
+      rNow: 1.5,
+      daysOpen: 12,
+      entryDate: '2026-04-10',
+    } as PositionWithMetrics;
+    const payload = candidateToPayload(baseCandidate, position);
+    expect(payload!.entry_date).toBe('2026-04-10');
+  });
+
   it('maps candidate fields to API payload', () => {
     const payload = candidateToPayload({
       ...baseCandidate,

--- a/web-ui/src/features/intelligence/api.ts
+++ b/web-ui/src/features/intelligence/api.ts
@@ -16,6 +16,7 @@ export interface IntelligenceRequestPayload {
   sector?: string | null;
   currency?: string;
   entry_price?: number;
+  entry_date?: string | null;
   r_now?: number;
   days_open?: number;
   rr?: number | null;
@@ -44,41 +45,54 @@ export function candidateToPayload(
   candidate: SymbolAnalysisCandidate | null | undefined,
   position?: PositionWithMetrics | null,
 ): IntelligenceRequestPayload | null {
-  if (!candidate?.close) return null;
-  const payload: IntelligenceRequestPayload = {
-    close: candidate.close,
-    signal: candidate.signal ?? 'unknown',
-    entry: candidate.suggestedOrderPrice ?? candidate.entry ?? null,
-    stop: candidate.stop ?? null,
-    sma_20: candidate.sma20 ?? null,
-    sma_50: candidate.sma50 ?? null,
-    sma_200: candidate.sma200 ?? null,
-    momentum_6m: candidate.momentum6m ?? null,
-    momentum_12m: candidate.momentum12m ?? null,
-    sector: candidate.sector ?? null,
-    currency: candidate.currency ?? 'USD',
-  };
-  payload.rr = candidate.rr ?? null;
-  payload.rel_strength = candidate.relStrength ?? null;
-  payload.sector_rs = candidate.sectorRs ?? null;
-  payload.sector_rotation_context = candidate.sectorRotationContext ?? null;
-  payload.dist_52w_high_pct = candidate.dist52wHighPct ?? null;
-  payload.near_52w_high = candidate.near52wHigh ?? null;
-  payload.atr = candidate.atr ?? null;
-  payload.target = candidate.decisionSummary?.tradePlan?.target ?? null;
-  payload.fair_value_low = candidate.decisionSummary?.valuationContext?.fairValueLow ?? null;
-  payload.fair_value_base = candidate.decisionSummary?.valuationContext?.fairValueBase ?? null;
-  payload.fair_value_high = candidate.decisionSummary?.valuationContext?.fairValueHigh ?? null;
-  payload.valuation_label = candidate.decisionSummary?.valuationLabel ?? null;
-  payload.decision_action = candidate.decisionSummary?.action ?? null;
-  payload.decision_conviction = candidate.decisionSummary?.conviction ?? null;
-  payload.technical_label = candidate.decisionSummary?.technicalLabel ?? null;
-  payload.fundamentals_label = candidate.decisionSummary?.fundamentalsLabel ?? null;
-  payload.catalyst_summary = candidate.decisionSummary?.catalystSummary ?? null;
-  payload.days_to_earnings = candidate.daysToEarnings ?? null;
-  payload.recent_patterns = candidate.patterns?.length
-    ? candidate.patterns.map((p) => `${p.name}@${p.context}`)
-    : null;
+  // A held position with no screener candidate (close it from the live position price)
+  // must still be analyzable — fall back to a position-only payload.
+  const positionPrice = position?.currentPrice ?? position?.entryPrice ?? null;
+  if (!candidate?.close && positionPrice == null) return null;
+
+  let payload: IntelligenceRequestPayload;
+  if (candidate?.close) {
+    payload = {
+      close: candidate.close,
+      signal: candidate.signal ?? 'unknown',
+      entry: candidate.suggestedOrderPrice ?? candidate.entry ?? null,
+      stop: candidate.stop ?? null,
+      sma_20: candidate.sma20 ?? null,
+      sma_50: candidate.sma50 ?? null,
+      sma_200: candidate.sma200 ?? null,
+      momentum_6m: candidate.momentum6m ?? null,
+      momentum_12m: candidate.momentum12m ?? null,
+      sector: candidate.sector ?? null,
+      currency: candidate.currency ?? 'USD',
+    };
+    payload.rr = candidate.rr ?? null;
+    payload.rel_strength = candidate.relStrength ?? null;
+    payload.sector_rs = candidate.sectorRs ?? null;
+    payload.sector_rotation_context = candidate.sectorRotationContext ?? null;
+    payload.dist_52w_high_pct = candidate.dist52wHighPct ?? null;
+    payload.near_52w_high = candidate.near52wHigh ?? null;
+    payload.atr = candidate.atr ?? null;
+    payload.target = candidate.decisionSummary?.tradePlan?.target ?? null;
+    payload.fair_value_low = candidate.decisionSummary?.valuationContext?.fairValueLow ?? null;
+    payload.fair_value_base = candidate.decisionSummary?.valuationContext?.fairValueBase ?? null;
+    payload.fair_value_high = candidate.decisionSummary?.valuationContext?.fairValueHigh ?? null;
+    payload.valuation_label = candidate.decisionSummary?.valuationLabel ?? null;
+    payload.decision_action = candidate.decisionSummary?.action ?? null;
+    payload.decision_conviction = candidate.decisionSummary?.conviction ?? null;
+    payload.technical_label = candidate.decisionSummary?.technicalLabel ?? null;
+    payload.fundamentals_label = candidate.decisionSummary?.fundamentalsLabel ?? null;
+    payload.catalyst_summary = candidate.decisionSummary?.catalystSummary ?? null;
+    payload.days_to_earnings = candidate.daysToEarnings ?? null;
+    payload.recent_patterns = candidate.patterns?.length
+      ? candidate.patterns.map((p) => `${p.name}@${p.context}`)
+      : null;
+  } else {
+    payload = {
+      close: positionPrice as number,
+      signal: 'MANAGE_ONLY',
+      currency: 'USD',
+    };
+  }
   if (position != null) {
     payload.entry_price = position.entryPrice;
     payload.entry = position.entryPrice;
@@ -87,6 +101,7 @@ export function candidateToPayload(
     }
     payload.r_now = position.rNow;
     payload.days_open = position.daysOpen;
+    payload.entry_date = position.entryDate ?? null;
   }
   return payload;
 }

--- a/web-ui/src/features/intelligence/types.ts
+++ b/web-ui/src/features/intelligence/types.ts
@@ -58,6 +58,19 @@ export interface PositionOutlook {
   confidenceDecay: string;
 }
 
+export type PriceMoveDirection = 'up' | 'down' | 'flat';
+
+export interface PriceMoveDriver {
+  label: string;
+  detail: string;
+}
+
+export interface PositionMoveExplanation {
+  direction: PriceMoveDirection;
+  summary: string;
+  drivers: PriceMoveDriver[];
+}
+
 export interface SymbolIntelligenceAPI {
   symbol: string;
   generated_at: string;
@@ -69,6 +82,7 @@ export interface SymbolIntelligenceAPI {
   upcoming_events: IntelligenceEvent[];
   position_signal: PositionSignal | null;
   position_outlook?: PositionOutlookAPI | null;
+  position_move_explanation?: PositionMoveExplanation | null;
   sources: string[];
   inputs_used?: Record<string, Record<string, unknown>>;
   price_hook?: string | null;
@@ -89,6 +103,7 @@ export interface SymbolIntelligence {
   upcomingEvents: IntelligenceEvent[];
   positionSignal: PositionSignal | null;
   positionOutlook?: PositionOutlook | null;
+  positionMoveExplanation?: PositionMoveExplanation | null;
   sources: string[];
   inputsUsed?: Record<string, Record<string, unknown>>;
   priceHook?: string | null;
@@ -124,6 +139,7 @@ export function transformIntelligence(api: SymbolIntelligenceAPI): SymbolIntelli
     upcomingEvents: api.upcoming_events ?? [],
     positionSignal: api.position_signal ?? null,
     positionOutlook: transformPositionOutlook(api.position_outlook),
+    positionMoveExplanation: api.position_move_explanation ?? null,
     sources: api.sources ?? [],
     inputsUsed: api.inputs_used ?? {},
     priceHook: api.price_hook ?? null,

--- a/web-ui/src/i18n/messages.en.ts
+++ b/web-ui/src/i18n/messages.en.ts
@@ -637,6 +637,14 @@ export const messagesEn = {
             trim: 'Trim',
             exit: 'Exit',
           },
+          positionMove: {
+            title: 'Why it moved',
+            direction: {
+              up: 'Up since entry',
+              down: 'Down since entry',
+              flat: 'Flat since entry',
+            },
+          },
           positionOutlook: {
             title: 'Position Outlook',
             expectedHoldingPeriod: 'Expected hold',


### PR DESCRIPTION
When analyzing a symbol the user already holds, the LLM now explains why the price moved from the entry to now: the root cause of the current gain/loss. The held-position analysis was forward-framed only (hold/trim/exit, upcoming catalysts)
  and never accounted for the move that produced the current `r_now`.

  Adds a `position_move_explanation` field to `SymbolIntelligence`, populated only in OPEN POSITION mode (mirrors the existing `position_signal` / `position_outlook` pattern):
  - `direction`: up | down | flat
  - `summary`: one sentence, net reason vs entry, consistent with the P&L sign
  - `drivers`: 1-4 `{label, detail}` grounded in news/events since the entry date

  `entry_date` now flows into `SymbolIntelligenceRequest` and the prompt so the model scopes its live-news lookback to the holding window. `analyze_position` populates it from `pos.entry_date`. No new endpoint and no extra external calls, the
  analyzer already runs the live-news pass.

  UI renders the explanation in `IntelligenceCard`, beside the existing R badge and position signal, colored by direction. The R win/loss badge itself is unchanged (already present on both the positions table and the analysis panel). Field is
  optional and nullable, so the block hides when absent and the analysis never fails on a missing explanation.

  Scope: backward explanation only, the forward catalyst/upcoming-events pass is untouched. Metric stays R-multiple, no new $/% P&L. Core model field, prompt/parse, router wiring and the web-ui type + render land together per the API/Web-UI
  same-PR rule.