### PR TITLE
Add auto-curated universe pipeline, API endpoint, UI client support, and docs

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -49,6 +49,7 @@ Candle data (screener candidates and watchlist items): `PriceHistoryPoint` now c
 Universes (`/api/universes`):
 - `GET /api/universes`
 - `GET /api/universes/{universe_id}`
+- `POST /api/universes/auto-refresh`
 - `POST /api/universes/{universe_id}/refresh`
 - `POST /api/universes/{universe_id}/benchmark`
 

--- a/api/routers/universes.py
+++ b/api/routers/universes.py
@@ -9,6 +9,11 @@ from swing_screener.data.symbol_discovery import (
     SymbolDiscoveryQuery,
     discover_symbols,
 )
+from swing_screener.data.auto_universe import (
+    AutoUniverseFilter,
+    AutoUniverseRequest,
+    materialize_auto_universe,
+)
 from swing_screener.data.universe import (
     get_package_universe_detail,
     list_package_universe_entries,
@@ -39,6 +44,17 @@ class SymbolDiscoveryRequest(BaseModel):
     limit: int = 100
     min_market_cap: int | None = None
     min_volume: int | None = None
+
+
+class AutoUniverseRefreshRequest(SymbolDiscoveryRequest):
+    universe_id: str = "auto_liquid_supported"
+    description: str = "Auto-curated liquid supported symbols"
+    benchmark: str = "SPY"
+    apply: bool = False
+    min_price: float | None = None
+    max_price: float | None = None
+    exclude_symbols: list[str] = Field(default_factory=list)
+    pinned_symbols: list[str] = Field(default_factory=list)
 
 
 @router.get("")
@@ -77,6 +93,44 @@ def discover_universe_symbols(request: SymbolDiscoveryRequest):
         raise HTTPException(status_code=422, detail=str(exc)) from exc
     except Exception as exc:
         raise HTTPException(status_code=500, detail="Failed to discover symbols") from exc
+
+
+@router.post("/auto-refresh")
+def refresh_auto_universe(request: AutoUniverseRefreshRequest):
+    try:
+        query = SymbolDiscoveryQuery(
+            provider=request.provider,
+            screens=tuple(request.screens),
+            exchanges=tuple(request.exchanges),
+            currencies=tuple(request.currencies),
+            exchange_mics=tuple(request.exchange_mics),
+            quote_types=tuple(request.quote_types),
+            limit=request.limit,
+            min_market_cap=request.min_market_cap,
+            min_volume=request.min_volume,
+        )
+        auto_request = AutoUniverseRequest(
+            universe_id=request.universe_id,
+            description=request.description,
+            benchmark=request.benchmark,
+            discovery=query,
+            filters=AutoUniverseFilter(
+                currencies=tuple(request.currencies),
+                exchange_mics=tuple(request.exchange_mics),
+                instrument_types=tuple(request.quote_types),
+                min_price=request.min_price,
+                max_price=request.max_price,
+                min_volume=request.min_volume,
+                min_market_cap=request.min_market_cap,
+                exclude_symbols=tuple(request.exclude_symbols),
+                pinned_symbols=tuple(request.pinned_symbols),
+            ),
+        )
+        return materialize_auto_universe(auto_request, apply=request.apply)
+    except (ValueError, SymbolDiscoveryError) as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail="Failed to refresh auto universe") from exc
 
 
 @router.get("/{universe_id}")

--- a/docs/overview/INDEX.md
+++ b/docs/overview/INDEX.md
@@ -27,6 +27,7 @@
 ## Product
 - `/docs/product/COMBINED_ANALYSIS_REASONING.md`
 - `/docs/product/DAILY_USAGE_GUIDE.md`
+- `/docs/product/SCALABLE_UNIVERSE_AUTOMATION.md`
 
 ## Education
 - `/docs/education/RECOMMENDED_LOGIC_BEGINNER_GUIDE.md`

--- a/docs/product/SCALABLE_UNIVERSE_AUTOMATION.md
+++ b/docs/product/SCALABLE_UNIVERSE_AUTOMATION.md
@@ -1,0 +1,103 @@
+# Scalable Universe Automation Proposal
+
+> Status: proposal.  
+> Last reviewed: 2026-06-16.
+
+## Problem
+
+Changing the screener universe manually before every run does not scale: the user must know which market, index, sector, liquidity profile, and currency set is relevant before the system has collected the basic facts needed to make that choice.
+
+The screener already accepts either a named `universe` or an explicit `tickers` list, and the web API already exposes universe-management endpoints for listing, discovering, refreshing, and benchmarking universes. The scalable solution should therefore automate universe creation and maintenance upstream, while keeping the screener deterministic and focused on ranking tradable candidates.
+
+## Proposed solution: an auto-curated universe pipeline
+
+Introduce an `auto_universe` pipeline that builds and refreshes symbol sets in three stages:
+
+1. **Discover** a broad candidate set from configured sources.
+   - Examples: exchange listings, index constituents, sector ETFs, existing watchlist, portfolio holdings, and manually pinned symbols.
+   - Output: raw symbols with source attribution and retrieval timestamp.
+2. **Enrich** every symbol with basic metadata needed before screening.
+   - Required fields: normalized ticker, exchange, currency, asset type, country, sector/industry, market cap bucket, average volume, last close, data-provider availability, delisting/suspension flag, and optional benchmark mapping.
+   - Output: a cached symbol metadata table so repeated screener runs do not refetch the same facts.
+3. **Filter and materialize** only relevant symbols into named universes.
+   - Hard filters: supported asset type, supported currency, minimum price, minimum liquidity, data availability, non-delisted status.
+   - Strategy filters: region, sector inclusion/exclusion, market cap bucket, volatility bounds, benchmark, and strategy-specific price range.
+   - Output: stable named universes such as `auto_us_liquid`, `auto_eu_liquid`, `auto_semiconductors`, and `auto_watchlist_plus_candidates`.
+
+The screener should consume these materialized universes exactly like any other named universe. This keeps screening reproducible: a run references a universe version, a strategy id, and an as-of date.
+
+## Why this is better than manual switching
+
+- **Less operator work:** the user chooses a goal, not a hand-maintained ticker list.
+- **Deterministic runs:** each universe has a cached version and source metadata.
+- **Better coverage:** new index constituents and watchlist-adjacent symbols enter automatically after refresh.
+- **Safer filtering:** illiquid, unsupported, delisted, or wrong-currency symbols are removed before expensive analysis.
+- **Scalable intelligence:** enrichment and AI analysis can be queued only for symbols that pass cheap eligibility filters.
+
+## Minimal architecture
+
+```text
+Configured sources
+  -> symbol discovery
+  -> metadata enrichment cache
+  -> eligibility filters
+  -> versioned symbol sets
+  -> screener run
+  -> top candidates + optional intelligence
+```
+
+### Data model additions
+
+Add a persisted symbol registry and versioned universe manifests:
+
+- `symbol_registry`: one row per normalized symbol/provider mapping.
+- `symbol_metadata_snapshot`: cached basic facts with `asof_date`, `provider`, and `quality_flags`.
+- `universe_manifest`: universe id, filter definition hash, source list, refresh timestamp, benchmark, and symbol count.
+- `universe_membership`: universe version id plus ordered symbols and inclusion reasons.
+
+A JSON-backed implementation is enough for a first iteration if it follows the same shape; SQLite is preferable once refresh history and metadata quality checks become important.
+
+## Refresh policy
+
+Use different refresh frequencies for different costs:
+
+| Layer | Suggested cadence | Notes |
+| --- | --- | --- |
+| Source membership | Daily or weekly | Index constituents and exchange listings change slowly. |
+| Static metadata | Weekly | Exchange, sector, country, and asset type rarely change. |
+| Liquidity and last close | Daily after close | Needed for filters before the final screener run. |
+| Fundamentals snapshot | On demand or weekly | Run only after cheap technical/liquidity filters. |
+| AI intelligence | On demand for top candidates | Avoid analyzing thousands of symbols. |
+
+## Operator workflow
+
+1. User configures high-level goals, for example `regions: [US, EU]`, `currencies: [USD, EUR]`, `min_avg_volume`, `min_price`, and excluded sectors.
+2. System refreshes configured symbol sources.
+3. System enriches and filters symbols into versioned universes.
+4. User picks an auto universe once, or the strategy defaults to a configured auto universe.
+5. Daily screener runs against the latest eligible version and returns ranked candidates.
+
+## Implementation phases
+
+### Phase 1 — Practical MVP
+
+- Add a backend `UniverseRefreshService` that reuses current universe endpoints and writes versioned manifests.
+- Store symbol metadata in the existing runtime data area.
+- Support one default generated universe, for example `auto_liquid_supported`.
+- Add filters for price, currency, asset type, average volume, and provider availability.
+- Add a UI label that shows universe source, last refresh, and symbol count.
+
+### Phase 2 — Strategy-aware universes
+
+- Let each strategy declare a default `auto_universe` profile in YAML configuration.
+- Materialize strategy-specific universes from the same registry without duplicating discovery.
+- Record the universe version id in screener job history for reproducibility.
+
+### Phase 3 — Intelligent prioritization
+
+- Add scoring before the screener for cheap metadata-only prioritization: liquidity, sector strength proxy, earnings proximity availability, and watchlist/portfolio adjacency.
+- Queue expensive fundamentals or AI enrichment only for candidates that pass the deterministic screener or are pinned by the user.
+
+## Recommendation
+
+Build this as a universe-preparation layer, not as additional screener branching. The screener should continue to receive `universe` or `tickers`; the new layer should make sure the named universe is always fresh, relevant, versioned, and explainable.

--- a/src/swing_screener/data/README.md
+++ b/src/swing_screener/data/README.md
@@ -38,7 +38,8 @@ currency = detect_currency("ASML.AS")  # EUR
 
 | File | Purpose |
 |------|---------|
-| `universe.py` | `load_universe_from_package()`, `load_universe_from_file()`, `apply_universe_filters()`, registry refresh + `instrument_master.json` merge |
+| `universe.py` | `load_universe_from_package()`, `load_universe_from_file()`, `apply_universe_filters()`, registry refresh + `instrument_master.json` merge; also exposes generated auto-universes |
+| `auto_universe.py` | Materialize discovered symbols into versioned runtime universes backed by `data/intelligence/auto_universes.json` |
 | `universe_sources.py` | Source-adapter dispatch (`refresh_snapshot_from_source`): Euronext AEX-family and `wikipedia_index_review` |
 | `wikipedia_sources.py` | Fetch + parse index constituent tables from Wikipedia; normalize tickers to Yahoo symbols |
 | `instrument_enrichment.py` | Resolve a Yahoo symbol to an instrument-master record via yfinance `.info` (MIC, currency, country, timezone, type) |
@@ -95,6 +96,11 @@ tickers = load_universe_from_file("my_custom_list.csv")
 ```
 
 Universe names follow the pattern `{currency}_{category}_{scope}`. Aliases are defined in `universes/manifest.json`. See `universes/README.md` for the full naming convention and available universes.
+
+Generated auto-universes are stored outside the packaged registry in
+`data/intelligence/auto_universes.json` (or `SWING_SCREENER_AUTO_UNIVERSES_FILE`).
+They are listed by the same universe APIs and can be passed to the screener like
+packaged universe ids after `POST /api/universes/auto-refresh` materializes them.
 
 ## Index universe refresh
 

--- a/src/swing_screener/data/auto_universe.py
+++ b/src/swing_screener/data/auto_universe.py
@@ -1,0 +1,287 @@
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import json
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+from swing_screener.data.symbol_discovery import SymbolDiscoveryQuery, SymbolDiscoveryResult, discover_symbols
+from swing_screener.data.universe import normalize_tickers
+
+_AUTO_STORE_PATH_OVERRIDE: str | None = None
+
+
+def _auto_store_path() -> Path:
+    if _AUTO_STORE_PATH_OVERRIDE:
+        return Path(_AUTO_STORE_PATH_OVERRIDE).resolve()
+    return Path(os.getenv("SWING_SCREENER_AUTO_UNIVERSES_FILE", "data/intelligence/auto_universes.json")).resolve()
+
+
+def _empty_store() -> dict:
+    return {"schema_version": 1, "universes": {}, "symbol_registry": {}}
+
+
+def load_auto_universe_store() -> dict:
+    path = _auto_store_path()
+    if not path.exists():
+        return _empty_store()
+    with path.open(encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, dict):
+        raise ValueError(f"Auto-universe store must be a JSON object: {path}")
+    payload.setdefault("schema_version", 1)
+    payload.setdefault("universes", {})
+    payload.setdefault("symbol_registry", {})
+    return payload
+
+
+def _write_auto_universe_store(payload: dict) -> None:
+    path = _auto_store_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+
+def _normalize_str_set(values: Iterable[str] | None) -> set[str]:
+    return {str(value).strip().upper() for value in (values or []) if str(value).strip()}
+
+
+@dataclass(frozen=True)
+class AutoUniverseFilter:
+    currencies: tuple[str, ...] = ()
+    exchange_mics: tuple[str, ...] = ()
+    instrument_types: tuple[str, ...] = ("EQUITY",)
+    min_price: float | None = None
+    max_price: float | None = None
+    min_volume: int | None = None
+    min_market_cap: int | None = None
+    exclude_symbols: tuple[str, ...] = ()
+    pinned_symbols: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class AutoUniverseRequest:
+    universe_id: str = "auto_liquid_supported"
+    description: str = "Auto-curated liquid supported symbols"
+    benchmark: str = "SPY"
+    discovery: SymbolDiscoveryQuery = field(default_factory=SymbolDiscoveryQuery)
+    filters: AutoUniverseFilter = field(default_factory=AutoUniverseFilter)
+
+
+def _slug(value: str) -> str:
+    out = "".join(ch.lower() if ch.isalnum() else "_" for ch in str(value).strip())
+    out = "_".join(part for part in out.split("_") if part)
+    if not out:
+        raise ValueError("universe_id cannot be empty")
+    return out
+
+
+def _coerce_float(value: object) -> float | None:
+    try:
+        if value in (None, ""):
+            return None
+        return float(str(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _coerce_int(value: object) -> int | None:
+    try:
+        if value in (None, ""):
+            return None
+        return int(float(str(value)))
+    except (TypeError, ValueError):
+        return None
+
+
+def _passes_auto_filters(symbol: dict, filters: AutoUniverseFilter) -> tuple[bool, list[str]]:
+    reasons: list[str] = []
+    currencies = _normalize_str_set(filters.currencies)
+    exchange_mics = _normalize_str_set(filters.exchange_mics)
+    instrument_types = _normalize_str_set(filters.instrument_types)
+    excluded = _normalize_str_set(filters.exclude_symbols)
+
+    ticker = str(symbol.get("symbol") or "").strip().upper()
+    if not ticker or ticker in excluded:
+        return False, reasons
+
+    currency = str(symbol.get("currency") or "").strip().upper()
+    if currencies and currency not in currencies:
+        return False, reasons
+    if currencies:
+        reasons.append(f"currency:{currency}")
+
+    exchange_mic = str(symbol.get("exchange_mic") or "").strip().upper()
+    if exchange_mics and exchange_mic not in exchange_mics:
+        return False, reasons
+    if exchange_mics:
+        reasons.append(f"exchange_mic:{exchange_mic}")
+
+    instrument_type = str(symbol.get("instrument_type") or "").strip().upper()
+    if instrument_types and instrument_type not in instrument_types:
+        return False, reasons
+    if instrument_types:
+        reasons.append(f"instrument_type:{instrument_type}")
+
+    price = _coerce_float(symbol.get("last_price") or symbol.get("regular_market_price"))
+    if filters.min_price is not None and (price is None or price < filters.min_price):
+        return False, reasons
+    if filters.max_price is not None and (price is None or price > filters.max_price):
+        return False, reasons
+    if price is not None:
+        reasons.append("price_range")
+
+    volume = _coerce_int(symbol.get("volume"))
+    if filters.min_volume is not None and (volume is None or volume < filters.min_volume):
+        return False, reasons
+    if filters.min_volume is not None:
+        reasons.append("min_volume")
+
+    market_cap = _coerce_int(symbol.get("market_cap"))
+    if filters.min_market_cap is not None and (market_cap is None or market_cap < filters.min_market_cap):
+        return False, reasons
+    if filters.min_market_cap is not None:
+        reasons.append("min_market_cap")
+
+    return True, reasons or ["discovered"]
+
+
+def _filter_definition_hash(request: AutoUniverseRequest) -> str:
+    payload = {
+        "discovery": request.discovery.__dict__,
+        "filters": request.filters.__dict__,
+        "benchmark": request.benchmark,
+    }
+    return hashlib.sha256(json.dumps(payload, sort_keys=True, default=list).encode("utf-8")).hexdigest()[:16]
+
+
+def materialize_auto_universe(
+    request: AutoUniverseRequest,
+    *,
+    discovery_result: SymbolDiscoveryResult | None = None,
+    apply: bool = False,
+) -> dict:
+    universe_id = _slug(request.universe_id)
+    result = discovery_result or discover_symbols(request.discovery)
+    pinned = normalize_tickers(request.filters.pinned_symbols) if request.filters.pinned_symbols else []
+    pinned_set = set(pinned)
+    members: list[dict] = []
+    registry_updates: dict[str, dict] = {}
+    seen: set[str] = set()
+
+    for item in result.symbols:
+        symbol = str(item.get("symbol") or "").strip().upper()
+        if not symbol or symbol in seen:
+            continue
+        passed, reasons = _passes_auto_filters(item, request.filters)
+        if not passed and symbol not in pinned_set:
+            continue
+        seen.add(symbol)
+        registry_updates[symbol] = {**item, "last_seen_at": dt.date.today().isoformat(), "provider": result.provider}
+        members.append(
+            {
+                "symbol": symbol,
+                "source": item.get("source") or result.provider,
+                "source_rank": item.get("discovery_rank"),
+                "inclusion_reasons": ["pinned"] if symbol in pinned_set else reasons,
+                "currency": item.get("currency"),
+                "exchange_mic": item.get("exchange_mic"),
+                "instrument_type": item.get("instrument_type"),
+            }
+        )
+
+    for symbol in pinned:
+        if symbol not in seen:
+            members.append({"symbol": symbol, "source": "pinned", "inclusion_reasons": ["pinned"]})
+            registry_updates.setdefault(symbol, {"symbol": symbol, "last_seen_at": dt.date.today().isoformat(), "provider": "pinned"})
+
+    if not members:
+        raise ValueError("Auto-universe materialization produced no symbols after filtering.")
+
+    symbols = [member["symbol"] for member in members]
+    version_id = f"{universe_id}:{result.source_asof}:{_filter_definition_hash(request)}"
+    manifest = {
+        "id": universe_id,
+        "version_id": version_id,
+        "kind": "auto",
+        "description": request.description,
+        "benchmark": request.benchmark.strip().upper(),
+        "source": result.provider,
+        "source_asof": result.source_asof,
+        "source_documents": result.source_documents,
+        "last_reviewed_at": dt.date.today().isoformat(),
+        "member_count": len(members),
+        "filter_definition_hash": _filter_definition_hash(request),
+        "filters": {**result.filters, "auto_filters": request.filters.__dict__},
+        "symbols": symbols,
+        "members": members,
+        "taxonomy": result.taxonomy,
+        "notes": result.notes,
+    }
+
+    changed = True
+    if apply:
+        store = load_auto_universe_store()
+        current = store["universes"].get(universe_id)
+        changed = current != manifest
+        store["universes"][universe_id] = manifest
+        store["symbol_registry"].update(registry_updates)
+        _write_auto_universe_store(store)
+    else:
+        store = load_auto_universe_store()
+        current = store["universes"].get(universe_id)
+        changed = current != manifest
+
+    return {"universe": manifest, "applied": apply, "changed": changed, "notes": result.notes}
+
+
+def list_auto_universe_entries() -> list[dict]:
+    store = load_auto_universe_store()
+    entries = []
+    for item in store.get("universes", {}).values():
+        entries.append(
+            {
+                "id": item.get("id"),
+                "kind": "auto",
+                "description": item.get("description"),
+                "benchmark": item.get("benchmark"),
+                "source": item.get("source"),
+                "source_asof": item.get("source_asof"),
+                "last_reviewed_at": item.get("last_reviewed_at"),
+                "member_count": item.get("member_count", len(item.get("symbols") or [])),
+                "currencies": sorted({str(m.get("currency")).upper() for m in item.get("members", []) if m.get("currency")}),
+                "exchange_mics": sorted({str(m.get("exchange_mic")).upper() for m in item.get("members", []) if m.get("exchange_mic")}),
+                "source_adapter": "auto_universe",
+                "source_documents": item.get("source_documents", []),
+                "refreshable": True,
+                "freshness_status": "fresh",
+                "is_stale": False,
+            }
+        )
+    return sorted(entries, key=lambda item: str(item.get("id", "")))
+
+
+def get_auto_universe_detail(universe_id: str) -> dict | None:
+    item = load_auto_universe_store().get("universes", {}).get(_slug(universe_id))
+    if not item:
+        return None
+    return {**item, "constituents": item.get("members", [])}
+
+
+def list_auto_universes() -> list[str]:
+    return sorted(load_auto_universe_store().get("universes", {}).keys())
+
+
+def load_auto_universe_symbols(universe_id: str) -> list[str]:
+    item = get_auto_universe_detail(universe_id)
+    if not item:
+        raise ValueError(f"Unknown auto universe id: '{universe_id}'")
+    return normalize_tickers(item.get("symbols") or [m.get("symbol") for m in item.get("members", [])])
+
+
+def get_auto_universe_benchmark(universe_id: str) -> str | None:
+    item = get_auto_universe_detail(universe_id)
+    benchmark = (item or {}).get("benchmark")
+    return str(benchmark).strip().upper() if benchmark else None

--- a/src/swing_screener/data/symbol_discovery.py
+++ b/src/swing_screener/data/symbol_discovery.py
@@ -209,6 +209,7 @@ def _yahoo_symbol_from_quote(quote: dict, *, screen: str, rank: int) -> dict:
         "exchange_name": quote.get("fullExchangeName"),
         "market_cap": _coerce_int(quote.get("marketCap") or quote.get("intradaymarketcap")),
         "volume": _coerce_int(quote.get("regularMarketVolume") or quote.get("averageDailyVolume3Month")),
+        "last_price": quote.get("regularMarketPrice"),
         "sector": quote.get("sector"),
         "industry": quote.get("industry"),
         "source": "yahoo_predefined",

--- a/src/swing_screener/data/universe.py
+++ b/src/swing_screener/data/universe.py
@@ -361,15 +361,37 @@ def _normalize_benchmark_symbol(value: str) -> str:
 
 def list_package_universe_entries() -> list[dict]:
     """Return manifest entries enriched with lightweight snapshot metadata."""
+    from swing_screener.data.auto_universe import list_auto_universe_entries
+
     entries = []
     for entry in _load_registry_manifest():
         snapshot = _load_snapshot(entry["id"])
         item = _summary_from_entry(entry, snapshot)
         entries.append(item)
+    entries.extend(list_auto_universe_entries())
     return sorted(entries, key=lambda item: str(item.get("id", "")))
 
 
 def get_package_universe_entry(universe_id: str) -> dict:
+    from swing_screener.data.auto_universe import get_auto_universe_detail
+
+    auto = get_auto_universe_detail(universe_id)
+    if auto:
+        return {
+            "id": auto.get("id"),
+            "kind": "auto",
+            "description": auto.get("description"),
+            "benchmark": auto.get("benchmark"),
+            "source": auto.get("source"),
+            "source_asof": auto.get("source_asof"),
+            "last_reviewed_at": auto.get("last_reviewed_at"),
+            "member_count": auto.get("member_count", len(auto.get("symbols") or [])),
+            "source_adapter": "auto_universe",
+            "source_documents": auto.get("source_documents", []),
+            "refreshable": True,
+            "freshness_status": "fresh",
+            "is_stale": False,
+        }
     entry = get_universe_meta(universe_id)
     if not entry:
         raise ValueError(f"Unknown universe id: '{universe_id}'")
@@ -378,6 +400,11 @@ def get_package_universe_entry(universe_id: str) -> dict:
 
 
 def get_package_universe_detail(universe_id: str) -> dict:
+    from swing_screener.data.auto_universe import get_auto_universe_detail
+
+    auto = get_auto_universe_detail(universe_id)
+    if auto:
+        return auto
     entry = get_package_universe_entry(universe_id)
     snapshot = _load_snapshot(universe_id)
     errors = validate_universe_snapshot(universe_id)
@@ -534,13 +561,22 @@ def filter_tickers_by_metadata(
 
 def list_package_universes() -> list[str]:
     """Return universe ids from registry manifest, sorted."""
-    return sorted(e["id"] for e in _load_registry_manifest())
+    from swing_screener.data.auto_universe import list_auto_universes
+
+    return sorted([e["id"] for e in _load_registry_manifest()] + list_auto_universes())
 
 
 def load_universe_from_package(
     name: str, cfg: UniverseConfig = UniverseConfig()
 ) -> list[str]:
     """Load tickers from a registry snapshot. Fails on unknown id or stale index."""
+    from swing_screener.data.auto_universe import (
+        list_auto_universes,
+        load_auto_universe_symbols,
+    )
+
+    if name in set(list_auto_universes()):
+        return apply_universe_config(load_auto_universe_symbols(name), cfg)
     manifest_ids = {e["id"] for e in _load_registry_manifest()}
     if name not in manifest_ids:
         raise ValueError(
@@ -555,6 +591,11 @@ def load_universe_from_package(
 
 def get_universe_benchmark(name: str) -> Optional[str]:
     """Return benchmark from manifest entry."""
+    from swing_screener.data.auto_universe import get_auto_universe_benchmark
+
+    auto_benchmark = get_auto_universe_benchmark(name)
+    if auto_benchmark:
+        return auto_benchmark
     try:
         snapshot = _load_snapshot(name)
         benchmark = snapshot.get("benchmark")

--- a/tests/api/test_universe_endpoints.py
+++ b/tests/api/test_universe_endpoints.py
@@ -93,3 +93,39 @@ def test_discover_symbols_endpoint_returns_taxonomy(monkeypatch):
     payload = response.json()
     assert payload["symbols"][0]["symbol"] == "AAPL"
     assert payload["taxonomy"]["currency"] == {"USD": 1}
+
+
+def test_auto_refresh_endpoint_materializes_universe(monkeypatch, tmp_path):
+    import swing_screener.data.auto_universe as auto_mod
+
+    monkeypatch.setattr(auto_mod, "_AUTO_STORE_PATH_OVERRIDE", str(tmp_path / "auto.json"), raising=False)
+
+    def fake_discover(query):
+        return SymbolDiscoveryResult(
+            provider="yahoo_predefined",
+            source_asof="2026-06-16",
+            source_documents=[],
+            filters={"limit": query.limit},
+            symbols=[
+                {"symbol": "MSFT", "currency": "USD", "exchange_mic": "XNAS", "instrument_type": "EQUITY", "volume": 500000, "last_price": 300},
+                {"symbol": "LOWP", "currency": "USD", "exchange_mic": "XNAS", "instrument_type": "EQUITY", "volume": 1, "last_price": 1},
+            ],
+            taxonomy={"currency": {"USD": 2}},
+            notes=[],
+        )
+
+    monkeypatch.setattr("swing_screener.data.auto_universe.discover_symbols", fake_discover)
+
+    response = client.post(
+        "/api/universes/auto-refresh",
+        json={"universe_id": "auto_test", "currencies": ["USD"], "exchange_mics": ["XNAS"], "min_volume": 1000, "min_price": 5, "apply": True},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["applied"] is True
+    assert payload["universe"]["symbols"] == ["MSFT"]
+
+    detail = client.get("/api/universes/auto_test")
+    assert detail.status_code == 200
+    assert detail.json()["constituents"][0]["symbol"] == "MSFT"

--- a/tests/test_universe_data_management.py
+++ b/tests/test_universe_data_management.py
@@ -159,3 +159,43 @@ def test_refresh_apply_merges_new_master_records(monkeypatch, tmp_path):
     symbols = {r["symbol"]: r for r in written}
     assert "MSFT" in symbols
     assert symbols["AAPL"]["source"] == "manual"
+
+
+def test_materialize_auto_universe_persists_and_loads(monkeypatch, tmp_path):
+    from swing_screener.data.auto_universe import (
+        AutoUniverseFilter,
+        AutoUniverseRequest,
+        SymbolDiscoveryQuery,
+        materialize_auto_universe,
+    )
+    from swing_screener.data.symbol_discovery import SymbolDiscoveryResult
+
+    store_path = tmp_path / "auto_universes.json"
+    import swing_screener.data.auto_universe as auto_mod
+
+    monkeypatch.setattr(auto_mod, "_AUTO_STORE_PATH_OVERRIDE", str(store_path), raising=False)
+
+    result = SymbolDiscoveryResult(
+        provider="yahoo_predefined",
+        source_asof="2026-06-16",
+        source_documents=[{"label": "fixture", "url": "https://example.test"}],
+        filters={"limit": 3},
+        symbols=[
+            {"symbol": "AAPL", "currency": "USD", "exchange_mic": "XNAS", "instrument_type": "EQUITY", "volume": 1000000, "market_cap": 1000000000, "last_price": 200},
+            {"symbol": "PINK", "currency": "USD", "exchange_mic": "XOTC", "instrument_type": "EQUITY", "volume": 1000, "market_cap": 1000, "last_price": 1},
+        ],
+        taxonomy={"currency": {"USD": 2}},
+        notes=["fixture"],
+    )
+    request = AutoUniverseRequest(
+        universe_id="Auto USD Liquid",
+        discovery=SymbolDiscoveryQuery(limit=3, currencies=("USD",)),
+        filters=AutoUniverseFilter(currencies=("USD",), exchange_mics=("XNAS",), min_volume=100000, min_price=5),
+    )
+
+    payload = materialize_auto_universe(request, discovery_result=result, apply=True)
+
+    assert payload["applied"] is True
+    assert payload["universe"]["id"] == "auto_usd_liquid"
+    assert load_universe_from_package("auto_usd_liquid", UniverseConfig(benchmark="SPY", ensure_benchmark=False)) == ["AAPL"]
+    assert "auto_usd_liquid" in list_package_universes()

--- a/web-ui/src/lib/api.test.ts
+++ b/web-ui/src/lib/api.test.ts
@@ -26,6 +26,7 @@ describe('API Client', () => {
     it('has universe management endpoints', () => {
       expect(API_ENDPOINTS.universes).toBe('/api/universes')
       expect(API_ENDPOINTS.universeDiscover).toBe('/api/universes/discover')
+      expect(API_ENDPOINTS.universeAutoRefresh).toBe('/api/universes/auto-refresh')
       expect(API_ENDPOINTS.universeById('amsterdam_all')).toBe('/api/universes/amsterdam_all')
     })
 

--- a/web-ui/src/lib/api.ts
+++ b/web-ui/src/lib/api.ts
@@ -20,6 +20,7 @@ export const API_ENDPOINTS = {
   // Universe management
   universes: '/api/universes',
   universeDiscover: '/api/universes/discover',
+  universeAutoRefresh: '/api/universes/auto-refresh',
   universeById: (id: string) => `/api/universes/${encodeURIComponent(id)}`,
   universeRefresh: (id: string) => `/api/universes/${encodeURIComponent(id)}/refresh`,
   universeBenchmark: (id: string) => `/api/universes/${encodeURIComponent(id)}/benchmark`,


### PR DESCRIPTION
### Motivation
- Provide an automated, repeatable way to discover, filter, and materialize trading universes so the screener can consume fresh, relevant symbol sets without manual ticker management.
- Expose a simple API to materialize and persist auto-generated universes so other services and the UI can trigger refreshes and list generated universes.

### Description
- Introduces a new backend module `src/swing_screener/data/auto_universe.py` that implements discovery-driven universe materialization, a persisted auto-universe store, filtering (`AutoUniverseFilter`), request model (`AutoUniverseRequest`), and helper APIs like `materialize_auto_universe`, `list_auto_universe_entries`, and `load_auto_universe_symbols`.
- Adds API router support in `api/routers/universes.py` including a new request model `AutoUniverseRefreshRequest` and a POST endpoint `POST /api/universes/auto-refresh` that materializes an auto-universe (dry-run or `apply=True`).
- Integrates auto-universes into the universe registry surface by updating `src/swing_screener/data/universe.py` to list and expose auto-universe entries and to load auto-universe symbols and benchmarks when requested.
- Adds documentation `docs/product/SCALABLE_UNIVERSE_AUTOMATION.md` describing the proposed pipeline and updates `api/README.md` and `src/swing_screener/data/README.md` to mention auto-universes, and updates the web UI client to include the new endpoint (`universeAutoRefresh`).
- Adds unit tests for the new behavior in `tests/api/test_universe_endpoints.py` and `tests/test_universe_data_management.py`, and updates a frontend test `web-ui/src/lib/api.test.ts` to assert the new client endpoint.

### Testing
- Ran backend test suite with `pytest`, including `tests/api/test_universe_endpoints.py` and `tests/test_universe_data_management.py`, and all tests passed. 
- Exercised the new API endpoint in tests to verify materialization and persistence semantics by simulating discovery results and asserting store contents. 
- Verified that auto-universes appear in the universe listing and can be loaded via `load_universe_from_package` in the unit tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31d27efe648322a6ea14542f698a64)