### PR TITLE
feat(backtest): event-study harness replaying live decision path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ data/social_cache/
 data/fundamentals/
 data/daily_reviews/
 data/screener/
+data/backtest/
 data/*.db
 data/*.db-journal
 # data/intelligence — ignore runtime output, track seed/config files

--- a/api/README.md
+++ b/api/README.md
@@ -46,6 +46,10 @@ Screener responses label data freshness as `intraday` while a relevant market is
 
 Candle data (screener candidates and watchlist items): `PriceHistoryPoint` now carries optional `open`/`high`/`low`/`volume` alongside `close` (absent fields omitted; backward-compatible). Candidates and watchlist items also expose `patterns` (list of `{bar_index, date, name, direction, key_level, context}`). Screener candidates additionally expose `pattern_stop` / `pattern_stop_reason` — a structural stop derived from a bullish candlestick pattern on the latest bar. When present it becomes the candidate's entry `stop` (and `target`/`rr`/`risk_usd` are recomputed from it; `shares` unchanged); it does not affect ranking.
 
+Backtest (`/api/backtest`):
+- `POST /api/backtest/event-study` (sync locally, async job launch on dyno by default) — replay the live signal/stop/exit path over history for the requested tickers and return per-trade R outcomes plus an R-distribution summary. Optional `config` overrides (e.g. `pattern_stop_enabled`, `breakeven_at_r`, `k_atr`) test a variant against the live defaults; an A/B is two requests differing in one field. Defaults to today's-snapshot data from `2022-01-01`. Event study only (no portfolio/equity curve), zero-cost fills; see `src/swing_screener/backtest/README.md` for scope and known limitations.
+- `GET /api/backtest/event-study/{job_id}` (poll async backtest status/result)
+
 Universes (`/api/universes`):
 - `GET /api/universes`
 - `GET /api/universes/{universe_id}`

--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 import os
 import threading
 from pathlib import Path
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from api.services.backtest_service import BacktestService
 
 from fastapi import Depends
 
@@ -169,6 +172,12 @@ def get_screener_service(
         portfolio_service=portfolio_service,
         orders_service=orders_service,
     )
+
+
+def get_backtest_service() -> "BacktestService":
+    from api.services.backtest_service import BacktestService
+
+    return BacktestService()
 
 
 def get_fundamentals_service(

--- a/api/main.py
+++ b/api/main.py
@@ -17,6 +17,7 @@ from swing_screener.runtime_env import ensure_runtime_env_loaded
 
 # Import routers
 from api.routers import (
+    backtest,
     calendar,
     catalysts,
     config,
@@ -316,6 +317,7 @@ app.include_router(catalysts.router, prefix="/api", tags=["catalysts"])
 app.include_router(daily_review.router, prefix="/api", tags=["daily-review"])
 app.include_router(market_data.router, prefix="/api", tags=["market-data"])
 app.include_router(weekly_reviews.router, prefix="/api/weekly-reviews", tags=["weekly-reviews"])
+app.include_router(backtest.router, prefix="/api/backtest", tags=["backtest"])
 
 
 @app.api_route(

--- a/api/models/backtest.py
+++ b/api/models/backtest.py
@@ -1,0 +1,99 @@
+"""API models for the event-study backtest endpoint.
+
+Backend is snake_case; the Web UI transforms to camelCase at the boundary.
+"""
+
+from __future__ import annotations
+
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+class BacktestConfigOverrides(BaseModel):
+    """Optional overrides applied on top of the live default config.
+
+    Anything left None keeps the value the live screener/portfolio manager use,
+    so an A/B test is two requests differing only in the field under test.
+    """
+
+    pattern_stop_enabled: Optional[bool] = None
+    pattern_stop_atr_buffer: Optional[float] = None
+    breakeven_at_r: Optional[float] = None
+    trail_after_r: Optional[float] = None
+    trail_sma: Optional[int] = None
+    max_holding_days: Optional[int] = None
+    exit_signal_days: Optional[int] = None
+    k_atr: Optional[float] = None
+    rr_target: Optional[float] = None
+    breakout_lookback: Optional[int] = None
+    pullback_ma: Optional[int] = None
+    min_history: Optional[int] = None
+
+
+class EventStudyRequest(BaseModel):
+    tickers: list[str] = Field(default_factory=list)
+    start: Optional[str] = None
+    end: Optional[str] = None
+    config: Optional[BacktestConfigOverrides] = None
+
+
+class TradeModel(BaseModel):
+    ticker: str
+    setup: str
+    entry_date: str
+    entry_price: float
+    initial_stop: float
+    initial_risk: float
+    target: float
+    exit_date: str
+    exit_price: float
+    exit_reason: str
+    r_multiple: float
+    bars_held: int
+    mfe_r: float
+    mae_r: float
+    pattern_stop_fired: bool
+
+
+class SetupMetricsModel(BaseModel):
+    n_trades: int
+    win_rate: float
+    expectancy_r: float
+    total_r: float
+    # None when there are no losing trades (profit factor is infinite).
+    profit_factor: Optional[float] = None
+    avg_win_r: float
+    avg_loss_r: float
+    avg_bars_held: float
+    max_drawdown_r: float
+    exit_reason_counts: dict[str, int] = Field(default_factory=dict)
+
+
+class BacktestMetricsModel(SetupMetricsModel):
+    by_setup: dict[str, SetupMetricsModel] = Field(default_factory=dict)
+
+
+class EventStudyResponse(BaseModel):
+    tickers: list[str]
+    start: str
+    end: str
+    config_used: dict = Field(default_factory=dict)
+    trades: list[TradeModel] = Field(default_factory=list)
+    metrics: BacktestMetricsModel
+
+
+class BacktestRunLaunchResponse(BaseModel):
+    job_id: str
+    status: Literal["queued", "running", "completed", "error"]
+    created_at: str
+    updated_at: str
+
+
+class BacktestRunStatusResponse(BaseModel):
+    job_id: str
+    status: Literal["queued", "running", "completed", "error"]
+    result: Optional[EventStudyResponse] = None
+    error: Optional[str] = None
+    created_at: str
+    updated_at: str

--- a/api/routers/backtest.py
+++ b/api/routers/backtest.py
@@ -1,0 +1,55 @@
+"""Backtest router - event-study replay over history."""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from fastapi import APIRouter, Depends
+from fastapi.responses import JSONResponse
+
+from api.dependencies import get_backtest_service
+from api.models.backtest import (
+    BacktestRunLaunchResponse,
+    BacktestRunStatusResponse,
+    EventStudyRequest,
+    EventStudyResponse,
+)
+from api.services.backtest_service import BacktestService
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+def _resolve_backtest_run_mode() -> str:
+    """Async on dyno platforms (avoid request timeouts), sync otherwise."""
+    configured = str(os.getenv("BACKTEST_RUN_MODE", "")).strip().lower()
+    if configured in {"sync", "async"}:
+        return configured
+    return "async" if os.getenv("DYNO") else "sync"
+
+
+@router.post(
+    "/event-study",
+    response_model=EventStudyResponse,
+    responses={202: {"model": BacktestRunLaunchResponse}},
+)
+def run_event_study(
+    request: EventStudyRequest,
+    service: BacktestService = Depends(get_backtest_service),
+):
+    """Run the event study sync or launch it as a background job depending on mode."""
+    if _resolve_backtest_run_mode() == "async":
+        launch = service.start_run_async(request)
+        return JSONResponse(status_code=202, content=launch.model_dump())
+    return service.run_event_study(request)
+
+
+@router.get("/event-study/{job_id}", response_model=BacktestRunStatusResponse)
+def get_event_study_status(
+    job_id: str,
+    service: BacktestService = Depends(get_backtest_service),
+):
+    """Get background event-study run status."""
+    return service.get_run_status(job_id)

--- a/api/services/backtest_run_manager.py
+++ b/api/services/backtest_run_manager.py
@@ -1,0 +1,256 @@
+"""Background backtest run jobs.
+
+Mirrors `screener_run_manager`: a thread-backed, disk-persisted job store so a
+long multi-symbol replay can run past the request budget and be polled by the UI.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+import json
+import logging
+from pathlib import Path
+import threading
+import uuid
+from typing import Callable, Optional
+
+from api.models.backtest import EventStudyResponse
+
+logger = logging.getLogger(__name__)
+
+
+def _now_iso() -> str:
+    return datetime.utcnow().replace(microsecond=0).isoformat()
+
+
+@dataclass
+class BacktestRunJob:
+    job_id: str
+    status: str
+    result: Optional[EventStudyResponse]
+    error: Optional[str]
+    created_at: str
+    updated_at: str
+
+
+class BacktestRunManager:
+    def __init__(
+        self,
+        *,
+        max_jobs: int = 32,
+        jobs_dir: str | Path = "data/backtest/jobs",
+    ) -> None:
+        self._jobs: dict[str, BacktestRunJob] = {}
+        self._lock = threading.Lock()
+        self._max_jobs = max_jobs
+        self._jobs_dir = Path(jobs_dir)
+        self._jobs_dir.mkdir(parents=True, exist_ok=True)
+        self._load_jobs()
+
+    def _job_file(self, job_id: str) -> Path:
+        return self._jobs_dir / f"{job_id}.json"
+
+    def _serialize_job(self, job: BacktestRunJob) -> dict:
+        return {
+            "job_id": job.job_id,
+            "status": job.status,
+            "result": job.result.model_dump() if job.result is not None else None,
+            "error": job.error,
+            "created_at": job.created_at,
+            "updated_at": job.updated_at,
+        }
+
+    def _parse_job_payload(
+        self, payload: object, *, now: str
+    ) -> Optional[BacktestRunJob]:
+        if not isinstance(payload, dict):
+            return None
+        try:
+            result_payload = payload.get("result")
+            result = (
+                EventStudyResponse.model_validate(result_payload)
+                if isinstance(result_payload, dict)
+                else None
+            )
+            job = BacktestRunJob(
+                job_id=str(payload.get("job_id", "")).strip(),
+                status=str(payload.get("status", "error")).strip().lower(),
+                result=result,
+                error=str(payload.get("error")) if payload.get("error") else None,
+                created_at=str(payload.get("created_at", now)),
+                updated_at=str(payload.get("updated_at", now)),
+            )
+        except Exception:
+            return None
+        if not job.job_id:
+            return None
+        return job
+
+    def _write_job_to_disk(self, job: BacktestRunJob) -> None:
+        target = self._job_file(job.job_id)
+        tmp = target.with_suffix(".tmp")
+        try:
+            tmp.write_text(
+                json.dumps(self._serialize_job(job), indent=2, ensure_ascii=False)
+                + "\n",
+                encoding="utf-8",
+            )
+            tmp.replace(target)
+        except Exception as exc:
+            logger.warning(
+                "Failed to persist backtest job %s to %s: %s", job.job_id, target, exc
+            )
+            try:
+                tmp.unlink(missing_ok=True)
+            except Exception as rm_exc:
+                logger.debug(
+                    "Failed to remove temp backtest job file %s: %s", tmp, rm_exc
+                )
+
+    def _read_job_from_disk(self, job_id: str) -> Optional[BacktestRunJob]:
+        path = self._job_file(job_id)
+        if not path.exists():
+            return None
+        now = _now_iso()
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            return None
+        return self._parse_job_payload(payload, now=now)
+
+    def _load_jobs(self) -> None:
+        now = _now_iso()
+        loaded: list[BacktestRunJob] = []
+        for path in sorted(self._jobs_dir.glob("*.json")):
+            try:
+                payload = json.loads(path.read_text(encoding="utf-8"))
+            except Exception:
+                continue
+            job = self._parse_job_payload(payload, now=now)
+            if job is None:
+                continue
+            corrected = False
+            if job.status not in {"queued", "running", "completed", "error"}:
+                job.status = "error"
+                job.error = "Recovered invalid job status from disk."
+                job.updated_at = now
+                corrected = True
+            if job.status in {"queued", "running"}:
+                job.status = "error"
+                job.result = None
+                job.error = "Run interrupted by API restart."
+                job.updated_at = now
+                corrected = True
+            if corrected:
+                self._write_job_to_disk(job)
+            loaded.append(job)
+
+        loaded.sort(key=lambda item: item.updated_at)
+        if len(loaded) > self._max_jobs:
+            loaded = loaded[-self._max_jobs :]
+
+        with self._lock:
+            for job in loaded:
+                self._jobs[job.job_id] = job
+            self._trim_jobs_locked()
+
+    def start_job(self, *, run_fn: Callable[[], EventStudyResponse]) -> str:
+        now = _now_iso()
+        job_id = uuid.uuid4().hex
+        job = BacktestRunJob(
+            job_id=job_id,
+            status="queued",
+            result=None,
+            error=None,
+            created_at=now,
+            updated_at=now,
+        )
+        with self._lock:
+            self._jobs[job_id] = job
+            self._trim_jobs_locked()
+        self._write_job_to_disk(job)
+
+        worker = threading.Thread(
+            target=self._run_job,
+            kwargs={"job_id": job_id, "run_fn": run_fn},
+            daemon=True,
+        )
+        worker.start()
+        return job_id
+
+    def get_job(self, job_id: str) -> Optional[BacktestRunJob]:
+        disk_job = self._read_job_from_disk(job_id)
+        if disk_job is not None:
+            with self._lock:
+                self._jobs[job_id] = disk_job
+                self._trim_jobs_locked()
+            return BacktestRunJob(**disk_job.__dict__)
+
+        with self._lock:
+            job = self._jobs.get(job_id)
+            if job is None:
+                return None
+            return BacktestRunJob(**job.__dict__)
+
+    def _run_job(
+        self, *, job_id: str, run_fn: Callable[[], EventStudyResponse]
+    ) -> None:
+        self._update(job_id, status="running", result=None, error=None)
+        try:
+            result = run_fn()
+            self._update(job_id, status="completed", result=result, error=None)
+        except Exception as exc:  # pragma: no cover - defensive path
+            self._update(job_id, status="error", result=None, error=str(exc))
+
+    def _update(
+        self,
+        job_id: str,
+        *,
+        status: Optional[str] = None,
+        result: Optional[EventStudyResponse] = None,
+        error: Optional[str] = None,
+    ) -> None:
+        snapshot: Optional[BacktestRunJob] = None
+        with self._lock:
+            job = self._jobs.get(job_id)
+            if job is None:
+                return
+            if status is not None:
+                job.status = status
+            job.result = result
+            job.error = error
+            job.updated_at = _now_iso()
+            snapshot = BacktestRunJob(**job.__dict__)
+        if snapshot is not None:
+            self._write_job_to_disk(snapshot)
+
+    def _trim_jobs_locked(self) -> None:
+        if len(self._jobs) <= self._max_jobs:
+            return
+        terminal_jobs = sorted(
+            (
+                job
+                for job in self._jobs.values()
+                if job.status in {"completed", "error"}
+            ),
+            key=lambda item: item.updated_at,
+        )
+        to_remove = len(self._jobs) - self._max_jobs
+        for item in terminal_jobs[:to_remove]:
+            self._jobs.pop(item.job_id, None)
+            try:
+                self._job_file(item.job_id).unlink(missing_ok=True)
+            except Exception:
+                logger.debug(
+                    "Failed to remove evicted backtest job file for %s",
+                    item.job_id,
+                    exc_info=True,
+                )
+
+
+_MANAGER = BacktestRunManager()
+
+
+def get_backtest_run_manager() -> BacktestRunManager:
+    return _MANAGER

--- a/api/services/backtest_service.py
+++ b/api/services/backtest_service.py
@@ -1,0 +1,194 @@
+"""Backtest service: fetch point-in-time data and replay the live decision path.
+
+Owns no trading logic. It fetches OHLCV via the same provider stack the screener
+uses, builds a `BacktestConfig` from request overrides, and delegates to
+`swing_screener.backtest.run_event_study`.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import replace
+from datetime import date
+from typing import Optional
+
+from swing_screener.backtest import BacktestConfig, run_event_study
+from swing_screener.backtest.event_study import EventStudyResult
+from swing_screener.backtest.metrics import BacktestMetrics
+from swing_screener.data.providers import MarketDataProvider, get_default_provider
+from swing_screener.errors import ServiceError, UpstreamError, ValidationError
+
+from api.models.backtest import (
+    BacktestConfigOverrides,
+    BacktestMetricsModel,
+    BacktestRunLaunchResponse,
+    BacktestRunStatusResponse,
+    EventStudyRequest,
+    EventStudyResponse,
+    SetupMetricsModel,
+    TradeModel,
+)
+
+logger = logging.getLogger(__name__)
+
+# Earliest history we scan by default. Matches the data layer's default start;
+# documented as today's-snapshot scope in src/swing_screener/backtest/README.md.
+DEFAULT_START = "2022-01-01"
+
+
+class BacktestService:
+    def __init__(self, provider: Optional[MarketDataProvider] = None) -> None:
+        self._provider = provider or get_default_provider()
+
+    def run_event_study(self, request: EventStudyRequest) -> EventStudyResponse:
+        tickers = [
+            str(t).strip().upper() for t in request.tickers if t and str(t).strip()
+        ]
+        tickers = [t for i, t in enumerate(tickers) if t not in tickers[:i]]
+        if not tickers:
+            raise ValidationError("At least one ticker is required.")
+
+        start = (request.start or DEFAULT_START).strip()
+        end = (request.end or date.today().isoformat()).strip()
+
+        try:
+            ohlcv = self._provider.fetch_ohlcv(tickers, start_date=start, end_date=end)
+        except Exception as exc:
+            logger.exception("Backtest data fetch failed")
+            raise UpstreamError(f"Failed to fetch market data: {exc}") from exc
+
+        if ohlcv is None or ohlcv.empty:
+            raise UpstreamError(
+                "No market data returned for the requested tickers and window."
+            )
+
+        config = _build_config(request.config)
+        try:
+            result = run_event_study(ohlcv, tickers, config)
+        except Exception as exc:
+            logger.exception("Event study failed")
+            raise ServiceError(f"Backtest failed: {exc}") from exc
+
+        return _to_response(tickers, start, end, request.config, result)
+
+    def start_run_async(self, request: EventStudyRequest) -> BacktestRunLaunchResponse:
+        from api.services.backtest_run_manager import get_backtest_run_manager
+
+        def _run() -> EventStudyResponse:
+            return self.run_event_study(request)
+
+        manager = get_backtest_run_manager()
+        job_id = manager.start_job(run_fn=_run)
+        job = manager.get_job(job_id)
+        if job is None:
+            raise ServiceError("Failed to start backtest run.")
+        return BacktestRunLaunchResponse(
+            job_id=job.job_id,
+            status=job.status,  # type: ignore[arg-type]
+            created_at=job.created_at,
+            updated_at=job.updated_at,
+        )
+
+    def get_run_status(self, job_id: str) -> BacktestRunStatusResponse:
+        from api.services.backtest_run_manager import get_backtest_run_manager
+        from swing_screener.errors import NotFoundError
+
+        job = get_backtest_run_manager().get_job(job_id)
+        if job is None:
+            raise NotFoundError(f"Backtest run job not found: {job_id}")
+        return BacktestRunStatusResponse(
+            job_id=job.job_id,
+            status=job.status,  # type: ignore[arg-type]
+            result=job.result,
+            error=job.error,
+            created_at=job.created_at,
+            updated_at=job.updated_at,
+        )
+
+
+def _build_config(overrides: Optional[BacktestConfigOverrides]) -> BacktestConfig:
+    cfg = BacktestConfig()
+    if overrides is None:
+        return cfg
+
+    entry_kw = {}
+    if overrides.breakout_lookback is not None:
+        entry_kw["breakout_lookback"] = overrides.breakout_lookback
+    if overrides.pullback_ma is not None:
+        entry_kw["pullback_ma"] = overrides.pullback_ma
+    if overrides.min_history is not None:
+        entry_kw["min_history"] = overrides.min_history
+    if entry_kw:
+        cfg.entry = replace(cfg.entry, **entry_kw)
+
+    exec_kw = {}
+    if overrides.pattern_stop_enabled is not None:
+        exec_kw["pattern_stop_enabled"] = overrides.pattern_stop_enabled
+    if overrides.pattern_stop_atr_buffer is not None:
+        exec_kw["pattern_stop_atr_buffer"] = overrides.pattern_stop_atr_buffer
+    if exec_kw:
+        cfg.execution = replace(cfg.execution, **exec_kw)
+
+    if overrides.breakeven_at_r is not None:
+        cfg.manage.breakeven_at_R = overrides.breakeven_at_r
+    if overrides.trail_after_r is not None:
+        cfg.manage.trail_after_R = overrides.trail_after_r
+    if overrides.trail_sma is not None:
+        cfg.manage.trail_sma = overrides.trail_sma
+    if overrides.max_holding_days is not None:
+        cfg.manage.max_holding_days = overrides.max_holding_days
+    if overrides.exit_signal_days is not None:
+        cfg.manage.exit_signal_days = overrides.exit_signal_days
+
+    if overrides.k_atr is not None:
+        cfg.k_atr = overrides.k_atr
+    if overrides.rr_target is not None:
+        cfg.rr_target = overrides.rr_target
+
+    return cfg
+
+
+def _pf(value: float) -> Optional[float]:
+    """Map an infinite profit factor (no losses) to None for JSON safety."""
+    return None if value is None or math.isinf(value) else round(float(value), 4)
+
+
+def _setup_metrics_model(m: BacktestMetrics) -> SetupMetricsModel:
+    return SetupMetricsModel(
+        n_trades=m.n_trades,
+        win_rate=round(m.win_rate, 4),
+        expectancy_r=round(m.expectancy_r, 4),
+        total_r=round(m.total_r, 4),
+        profit_factor=_pf(m.profit_factor),
+        avg_win_r=round(m.avg_win_r, 4),
+        avg_loss_r=round(m.avg_loss_r, 4),
+        avg_bars_held=round(m.avg_bars_held, 4),
+        max_drawdown_r=round(m.max_drawdown_r, 4),
+        exit_reason_counts=dict(m.exit_reason_counts),
+    )
+
+
+def _metrics_model(m: BacktestMetrics) -> BacktestMetricsModel:
+    base = _setup_metrics_model(m)
+    return BacktestMetricsModel(
+        **base.model_dump(),
+        by_setup={k: _setup_metrics_model(v) for k, v in m.by_setup.items()},
+    )
+
+
+def _to_response(
+    tickers: list[str],
+    start: str,
+    end: str,
+    overrides: Optional[BacktestConfigOverrides],
+    result: EventStudyResult,
+) -> EventStudyResponse:
+    return EventStudyResponse(
+        tickers=tickers,
+        start=start,
+        end=end,
+        config_used=overrides.model_dump(exclude_none=True) if overrides else {},
+        trades=[TradeModel(**t.__dict__) for t in result.trades],
+        metrics=_metrics_model(result.metrics),
+    )

--- a/data/README.md
+++ b/data/README.md
@@ -7,6 +7,7 @@ Runtime data for Swing Screener.
 - `positions.json`: position records (primary storage today)
 - `watchlist.json`: watchlist state
 - `intelligence/`: runtime intelligence snapshots, jobs, caches, and reports
+- `backtest/jobs/`: background event-study run jobs (one JSON per job; not committed, gitignored). Created on API start; interrupted `queued`/`running` jobs are recovered as `error` on restart.
 
 User-authored configuration no longer lives under `data/`. Shared configuration is stored in:
 - `config/user.yaml`

--- a/docs/engineering/MODULE_ARCHITECTURE.md
+++ b/docs/engineering/MODULE_ARCHITECTURE.md
@@ -7,6 +7,7 @@ This document is the canonical module layout after the 2026 architecture consoli
 
 ## Canonical Top-Level Domains
 
+- `src/swing_screener/backtest`
 - `src/swing_screener/data`
 - `src/swing_screener/execution`
 - `src/swing_screener/fundamentals`
@@ -37,6 +38,7 @@ This document is the canonical module layout after the 2026 architecture consoli
     `risk/recommendations`, which owns the risk-side recommendation engine and trade thesis.
 11. `settings` owns settings load/migrate/path resolution.
 12. `integrations` owns third-party brokerage integrations (e.g. degiro).
+13. `backtest` orchestrates the live signal/stop/exit functions over point-in-time history to measure expectancy; owns no trading logic of its own. Validation harness only, never a parameter optimizer.
 
 ## Canonical Import Paths
 

--- a/docs/overview/INDEX.md
+++ b/docs/overview/INDEX.md
@@ -12,6 +12,9 @@
 - `/docs/engineering/AI_RUNTIME_ARCHITECTURE.md`
 - `/src/swing_screener/intelligence/README.md`
 
+## Module READMEs
+- `/src/swing_screener/backtest/README.md` — event-study backtesting (replay live decision path over history)
+
 ## Engineering
 - `/docs/engineering/DATA_SOURCE_AUDIT_AND_PROVIDER_STRATEGY.md`
 - `/docs/engineering/ROADMAP.md`

--- a/src/swing_screener/backtest/README.md
+++ b/src/swing_screener/backtest/README.md
@@ -1,0 +1,80 @@
+# Backtest
+
+Event-study backtesting: replay the **live** signal/stop/exit decision path over
+history to measure expectancy in R-multiples.
+
+## What it is for
+
+A validation harness, not an optimizer. It answers "does this rule change help or
+hurt expectancy?" (e.g. `pattern_stop_enabled` on/off, `breakeven_at_R` 1.0 vs
+0.5) by replaying the same production functions the live system uses. It must
+**not** grow a parameter search: tuning parameters to maximize a historical metric
+is curve-fitting, an explicit project non-goal. Compare two hypotheses you formed
+for a reason; never sweep a grid for the best number.
+
+## How it works (event study)
+
+For each ticker, walk bars forward. On every bar `T` where the live screener fires
+a setup (`build_signal_board`):
+
+1. **Fill** at the next bar's open (`T+1`) — never the close that triggered the
+   signal (no lookahead).
+2. **Stop** = the live stop placement: `compute_stop` (ATR) then
+   `apply_pattern_stop` (structural pattern stop) when `pattern_stop_enabled`.
+3. **Forward simulate** by calling the live portfolio manager
+   (`evaluate_positions`) on a progressively longer point-in-time slice, one bar
+   at a time, applying its `MOVE_STOP_UP` / `CLOSE_*` decisions until it exits.
+4. **Record** the round-trip in the ledger with R realized, exit reason, bars
+   held, MFE/MAE.
+
+Trades never overlap on the same symbol: a new signal is only considered after the
+prior trade closes. R is per-share-normalized (`1R = entry - initial_stop`), so the
+ledger measures edge independently of position sizing or currency.
+
+### Fill model
+
+- Entry: `T+1` open.
+- Stop hit: fills at the stop level (close-based detection mirrors the live EOD
+  manager).
+- Time / exit-signal exit: fills at that bar's close.
+- Never exited within the data: censored as `open` at the last bar.
+
+## Module layout
+
+| File | Role |
+|------|------|
+| `config.py` | `BacktestConfig` — bundles the live config surfaces (entry/manage/execution/candles + `k_atr`/`rr_target`); override any field to test a variant |
+| `event_study.py` | `run_event_study` — the replay loop; `EventStudyResult` |
+| `ledger.py` | `Trade` — one simulated round-trip |
+| `metrics.py` | `compute_metrics` / `BacktestMetrics` — R-distribution summary (expectancy, win rate, profit factor, max drawdown in R, per-setup breakdown) |
+
+This module owns no trading logic. It only orchestrates production functions, so a
+backtest validates real behaviour rather than a parallel reimplementation. It
+raises `swing_screener.errors.DomainError` subclasses (no web framework imports).
+
+## API
+
+Exposed via `POST /api/backtest/event-study` (+ `GET /api/backtest/event-study/{job_id}`
+for the async job). See `api/README.md`.
+
+## Known limitations / future work
+
+These are deliberate v1 scope cuts. The optimal solution is recorded here so it is
+not forgotten.
+
+- **Universe = today's snapshot → survivorship bias.** v1 backtests whatever tickers
+  you pass, using their currently-available history. Delisted/renamed names are
+  silently absent, which flatters results. **Optimal:** replay against the dated
+  point-in-time universe snapshots already stored in the universe registry, so the
+  symbol set at bar `T` is the one that actually existed then.
+- **Zero commission and zero slippage.** v1 fills are frictionless (the live config
+  also runs `commission_pct: 0.0`). **Optimal:** model `commission_pct` per side and
+  a per-trade slippage allowance, plus gap-through-stop fills (a stop fills at the
+  gapped open, not the stop level, when a bar opens through it).
+- **Event study only — no portfolio model.** Each signal is an independent forward
+  outcome; there is no shared capital, concurrent-position cap, or equity curve.
+  **Optimal:** a day-by-day portfolio replay layered on the same ledger, producing a
+  real equity curve and drawdown benchmarked against SPY buy-and-hold.
+- **Cost:** the forward loop re-evaluates `evaluate_positions` on a fresh slice each
+  bar (`O(n²)` per ticker). Fine for a handful of manually-chosen symbols; revisit
+  before running large universes.

--- a/src/swing_screener/backtest/__init__.py
+++ b/src/swing_screener/backtest/__init__.py
@@ -1,0 +1,12 @@
+"""Event-study backtesting: replay the live signal/stop/exit decision path over history.
+
+This module owns no trading logic of its own. It orchestrates the same production
+functions the live screener and portfolio manager use, fed point-in-time data, so a
+backtest validates real behaviour rather than a parallel reimplementation.
+"""
+
+from swing_screener.backtest.config import BacktestConfig
+from swing_screener.backtest.ledger import Trade
+from swing_screener.backtest.event_study import EventStudyResult, run_event_study
+
+__all__ = ["BacktestConfig", "Trade", "EventStudyResult", "run_event_study"]

--- a/src/swing_screener/backtest/config.py
+++ b/src/swing_screener/backtest/config.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from swing_screener.selection.entries import EntrySignalConfig
+from swing_screener.portfolio.state import ManageConfig
+from swing_screener.execution.guidance import ExecutionConfig
+from swing_screener.indicators.candles import CandleConfig
+from swing_screener.risk.position_sizing import RiskConfig
+
+
+@dataclass
+class BacktestConfig:
+    """Bundle of the live config surfaces the event study replays.
+
+    Each sub-config defaults to the same values the live screener/portfolio
+    manager use (loaded from ``config/defaults.yaml``). Override any field to
+    test a variant (e.g. ``execution.pattern_stop_enabled`` on/off, or a
+    different ``manage.breakeven_at_R``) without touching production config.
+    """
+
+    entry: EntrySignalConfig = field(default_factory=EntrySignalConfig)
+    manage: ManageConfig = field(default_factory=ManageConfig)
+    execution: ExecutionConfig = field(default_factory=ExecutionConfig)
+    candles: CandleConfig = field(default_factory=CandleConfig)
+    k_atr: float = field(default_factory=lambda: RiskConfig().k_atr)
+    rr_target: float = field(default_factory=lambda: RiskConfig().rr_target)
+    atr_window: int = 14

--- a/src/swing_screener/backtest/event_study.py
+++ b/src/swing_screener/backtest/event_study.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, replace
+from typing import Iterable
+
+import pandas as pd
+
+from swing_screener.backtest.config import BacktestConfig
+from swing_screener.backtest.ledger import Trade
+from swing_screener.backtest.metrics import BacktestMetrics, compute_metrics
+from swing_screener.execution.guidance import apply_pattern_stop
+from swing_screener.indicators.candles import detect_patterns
+from swing_screener.indicators.volatility import compute_atr_per_ticker
+from swing_screener.portfolio.state import ManageConfig, Position, evaluate_positions
+from swing_screener.risk.position_sizing import compute_stop
+from swing_screener.selection.entries import build_signal_board
+
+_SIGNAL_SETUPS = {"breakout", "pullback", "both"}
+
+
+@dataclass(frozen=True)
+class EventStudyResult:
+    trades: list[Trade]
+    metrics: BacktestMetrics
+
+
+def run_event_study(
+    ohlcv: pd.DataFrame,
+    tickers: Iterable[str],
+    config: BacktestConfig = BacktestConfig(),
+) -> EventStudyResult:
+    """Replay the live entry/stop/exit decision path over history for each ticker.
+
+    For every bar T where the live screener fires a setup, open a simulated trade
+    filled at the next bar's open, then advance the live portfolio manager
+    (`evaluate_positions`) day by day until it exits. Trades never overlap on the
+    same symbol: a new signal is only considered after the prior trade closes.
+    """
+    tks = [str(t).strip().upper() for t in tickers if t and str(t).strip()]
+    tks = [t for i, t in enumerate(tks) if t not in tks[:i]]
+
+    trades: list[Trade] = []
+    for ticker in tks:
+        trades.extend(_study_ticker(ohlcv, ticker, config))
+    return EventStudyResult(trades=trades, metrics=compute_metrics(trades))
+
+
+def _study_ticker(
+    ohlcv: pd.DataFrame, ticker: str, config: BacktestConfig
+) -> list[Trade]:
+    close_m = ohlcv["Close"]
+    if ticker not in close_m.columns:
+        return []
+
+    n = len(ohlcv.index)
+    high_s = ohlcv["High"][ticker]
+    low_s = ohlcv["Low"][ticker]
+    close_s = ohlcv["Close"][ticker]
+    open_s = ohlcv["Open"][ticker]
+
+    out: list[Trade] = []
+    i = 0
+    while i < n - 1:  # need at least one forward bar to fill the entry
+        window_t = ohlcv.iloc[: i + 1]
+        board = build_signal_board(window_t, [ticker], config.entry)
+        if ticker not in board.index:
+            i += 1
+            continue
+        setup = str(board.loc[ticker, "signal"])
+        if setup not in _SIGNAL_SETUPS:
+            i += 1
+            continue
+
+        fill = float(open_s.iloc[i + 1])
+        if not math.isfinite(fill) or fill <= 0:
+            i += 1
+            continue
+
+        atr = compute_atr_per_ticker(
+            high_s.iloc[: i + 1],
+            low_s.iloc[: i + 1],
+            close_s.iloc[: i + 1],
+            config.atr_window,
+        )
+        if not math.isfinite(atr) or atr <= 0:
+            i += 1
+            continue
+
+        stop = compute_stop(fill, atr, config.k_atr)
+        pattern_fired = False
+        if config.execution.pattern_stop_enabled:
+            patterns = detect_patterns(window_t, [ticker], cfg=config.candles)
+            pstop, _reason = apply_pattern_stop(
+                ticker=ticker,
+                entry=fill,
+                current_stop=stop,
+                atr=atr,
+                patterns=patterns,
+                buffer_atr=config.execution.pattern_stop_atr_buffer,
+                min_rr_stop=None,
+            )
+            if pstop is not None:
+                stop = pstop
+                pattern_fired = True
+
+        initial_risk = fill - stop
+        if initial_risk <= 0:
+            i += 1
+            continue
+
+        entry_idx = i + 1
+        entry_date = str(ohlcv.index[entry_idx].date())
+        pos = Position(
+            ticker=ticker,
+            status="open",
+            entry_date=entry_date,
+            entry_price=fill,
+            stop_price=stop,
+            shares=1,
+            initial_risk=round(float(initial_risk), 4),
+            max_favorable_price=fill,
+        )
+
+        exit_idx, exit_price, exit_reason, mfe_r, mae_r = _simulate_forward(
+            ohlcv, ticker, pos, entry_idx, config.manage
+        )
+
+        r_multiple = (exit_price - fill) / initial_risk
+        out.append(
+            Trade(
+                ticker=ticker,
+                setup=setup,
+                entry_date=entry_date,
+                entry_price=round(fill, 4),
+                initial_stop=round(float(stop), 4),
+                initial_risk=round(float(initial_risk), 4),
+                target=round(fill + config.rr_target * initial_risk, 4),
+                exit_date=str(ohlcv.index[exit_idx].date()),
+                exit_price=round(float(exit_price), 4),
+                exit_reason=exit_reason,
+                r_multiple=round(float(r_multiple), 4),
+                bars_held=exit_idx - entry_idx + 1,
+                mfe_r=round(float(mfe_r), 4),
+                mae_r=round(float(mae_r), 4),
+                pattern_stop_fired=pattern_fired,
+            )
+        )
+
+        i = exit_idx + 1  # non-overlapping: resume only after the trade closes
+
+    return out
+
+
+def _simulate_forward(
+    ohlcv: pd.DataFrame,
+    ticker: str,
+    pos: Position,
+    entry_idx: int,
+    manage: ManageConfig,
+) -> tuple[int, float, str, float, float]:
+    """Advance the live portfolio manager bar by bar until it signals an exit.
+
+    Returns (exit_idx, exit_price, exit_reason, mfe_r, mae_r). A stop hit fills at
+    the stop level; time/exit-signal exits fill at that bar's close. If the trade
+    never closes within the data, it is censored (`open`) at the last bar.
+    """
+    n = len(ohlcv.index)
+    close_s = ohlcv["Close"][ticker]
+    risk = float(pos.initial_risk)
+    mfe_r = 0.0
+    mae_r = 0.0
+    cur = pos
+
+    for j in range(entry_idx, n):
+        last_close = float(close_s.iloc[j])
+        if math.isfinite(last_close):
+            r = (last_close - pos.entry_price) / risk
+            mfe_r = max(mfe_r, r)
+            mae_r = min(mae_r, r)
+
+        window_j = ohlcv.iloc[: j + 1]
+        updates, new_positions = evaluate_positions(window_j, [cur], manage)
+        u = updates[0]
+
+        if u.action == "CLOSE_STOP_HIT":
+            return j, cur.stop_price, "stop_hit", mfe_r, mae_r
+        if u.action == "CLOSE_TIME_EXIT":
+            return j, last_close, "time_exit", mfe_r, mae_r
+        if u.action == "CLOSE_EXIT_SIGNAL":
+            return j, last_close, "exit_signal", mfe_r, mae_r
+        if u.action == "MOVE_STOP_UP":
+            cur = replace(new_positions[0], stop_price=float(u.stop_suggested))
+        else:
+            cur = new_positions[0]
+
+    last_close = float(close_s.iloc[n - 1])
+    return n - 1, last_close, "open", mfe_r, mae_r

--- a/src/swing_screener/backtest/ledger.py
+++ b/src/swing_screener/backtest/ledger.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+ExitReason = Literal["stop_hit", "time_exit", "exit_signal", "open"]
+
+
+@dataclass(frozen=True)
+class Trade:
+    """One simulated round-trip produced by the event study.
+
+    R-multiples are per-share-normalised (``1R = entry - initial_stop``), so the
+    ledger measures edge independently of position sizing or account currency.
+    """
+
+    ticker: str
+    setup: str  # breakout | pullback | both
+    entry_date: str
+    entry_price: float
+    initial_stop: float
+    initial_risk: float
+    target: float
+    exit_date: str
+    exit_price: float
+    exit_reason: ExitReason
+    r_multiple: float
+    bars_held: int
+    mfe_r: float  # max favourable excursion, in R (close-based)
+    mae_r: float  # max adverse excursion, in R (close-based)
+    pattern_stop_fired: bool

--- a/src/swing_screener/backtest/metrics.py
+++ b/src/swing_screener/backtest/metrics.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from swing_screener.backtest.ledger import Trade
+
+
+@dataclass(frozen=True)
+class BacktestMetrics:
+    """Aggregate R-distribution summary for a set of simulated trades.
+
+    All edge metrics are in R-multiples so they are comparable across symbols
+    and config variants regardless of price level or position size.
+    """
+
+    n_trades: int
+    win_rate: float
+    expectancy_r: float  # mean R per trade
+    total_r: float
+    profit_factor: float  # sum(win R) / abs(sum(loss R)); inf when no losses
+    avg_win_r: float
+    avg_loss_r: float
+    avg_bars_held: float
+    max_drawdown_r: float  # worst peak-to-trough drop of the cumulative-R curve
+    exit_reason_counts: dict[str, int] = field(default_factory=dict)
+    by_setup: dict[str, "BacktestMetrics"] = field(default_factory=dict)
+
+
+def _zeroed() -> BacktestMetrics:
+    return BacktestMetrics(
+        n_trades=0,
+        win_rate=0.0,
+        expectancy_r=0.0,
+        total_r=0.0,
+        profit_factor=0.0,
+        avg_win_r=0.0,
+        avg_loss_r=0.0,
+        avg_bars_held=0.0,
+        max_drawdown_r=0.0,
+        exit_reason_counts={},
+        by_setup={},
+    )
+
+
+def compute_metrics(trades: list[Trade], *, _nested: bool = False) -> BacktestMetrics:
+    """Summarise a trade list. Pass ``_nested`` internally to skip per-setup splits."""
+    if not trades:
+        return _zeroed()
+
+    rs = [t.r_multiple for t in trades]
+    wins = [r for r in rs if r > 0]
+    losses = [r for r in rs if r < 0]
+    n = len(trades)
+
+    gross_win = sum(wins)
+    gross_loss = abs(sum(losses))
+    profit_factor = (
+        float("inf")
+        if gross_loss == 0 and gross_win > 0
+        else (gross_win / gross_loss if gross_loss > 0 else 0.0)
+    )
+
+    exit_counts: dict[str, int] = {}
+    for t in trades:
+        exit_counts[t.exit_reason] = exit_counts.get(t.exit_reason, 0) + 1
+
+    by_setup: dict[str, BacktestMetrics] = {}
+    if not _nested:
+        setups: dict[str, list[Trade]] = {}
+        for t in trades:
+            setups.setdefault(t.setup, []).append(t)
+        by_setup = {k: compute_metrics(v, _nested=True) for k, v in setups.items()}
+
+    return BacktestMetrics(
+        n_trades=n,
+        win_rate=len(wins) / n,
+        expectancy_r=sum(rs) / n,
+        total_r=sum(rs),
+        profit_factor=profit_factor,
+        avg_win_r=(gross_win / len(wins)) if wins else 0.0,
+        avg_loss_r=(sum(losses) / len(losses)) if losses else 0.0,
+        avg_bars_held=sum(t.bars_held for t in trades) / n,
+        max_drawdown_r=_max_drawdown_r(rs),
+        exit_reason_counts=exit_counts,
+        by_setup=by_setup,
+    )
+
+
+def _max_drawdown_r(rs: list[float]) -> float:
+    """Largest peak-to-trough drop of the cumulative-R equity curve, in R."""
+    equity = 0.0
+    peak = 0.0
+    max_dd = 0.0
+    for r in rs:
+        equity += r
+        peak = max(peak, equity)
+        max_dd = max(max_dd, peak - equity)
+    return max_dd

--- a/tests/api/test_backtest_endpoints.py
+++ b/tests/api/test_backtest_endpoints.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+from fastapi.testclient import TestClient
+
+from api.dependencies import get_backtest_service
+from api.main import app
+from api.services.backtest_service import BacktestService
+
+
+def _ohlcv(ticker: str, opens, highs, lows, closes) -> pd.DataFrame:
+    n = len(closes)
+    idx = pd.date_range("2022-01-03", periods=n, freq="B")
+    cols = pd.MultiIndex.from_tuples(
+        [
+            ("Open", ticker),
+            ("High", ticker),
+            ("Low", ticker),
+            ("Close", ticker),
+            ("Volume", ticker),
+        ]
+    )
+    data = np.column_stack([opens, highs, lows, closes, [1_000_000] * n])
+    return pd.DataFrame(data, index=idx, columns=cols)
+
+
+def _collapse_ohlcv() -> pd.DataFrame:
+    closes = [100.0] * 20 + [110.0, 90.0]
+    opens = [100.0] * 20 + [110.0, 110.0]
+    highs = [101.0] * 20 + [111.0, 111.0]
+    lows = [99.0] * 20 + [99.0, 89.0]
+    return _ohlcv("TEST", opens, highs, lows, closes)
+
+
+class _FakeProvider:
+    def __init__(self, ohlcv: pd.DataFrame) -> None:
+        self._ohlcv = ohlcv
+
+    def fetch_ohlcv(self, tickers, start_date, end_date, interval: str = "1d"):
+        return self._ohlcv
+
+
+def _override(ohlcv: pd.DataFrame):
+    app.dependency_overrides[get_backtest_service] = lambda: BacktestService(
+        provider=_FakeProvider(ohlcv)
+    )
+
+
+def teardown_function() -> None:
+    app.dependency_overrides.pop(get_backtest_service, None)
+
+
+def test_event_study_endpoint_returns_trades_and_metrics():
+    _override(_collapse_ohlcv())
+    client = TestClient(app)
+
+    resp = client.post(
+        "/api/backtest/event-study",
+        json={
+            "tickers": ["TEST"],
+            "config": {
+                "pattern_stop_enabled": False,
+                "breakout_lookback": 5,
+                "pullback_ma": 5,
+                "min_history": 15,
+                "exit_signal_days": 0,
+                "trail_sma": 5,
+            },
+        },
+    )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["tickers"] == ["TEST"]
+    assert len(body["trades"]) == 1
+    trade = body["trades"][0]
+    assert trade["exit_reason"] == "stop_hit"
+    assert trade["r_multiple"] == pytest.approx(-1.0)
+    assert body["metrics"]["n_trades"] == 1
+    assert body["metrics"]["win_rate"] == pytest.approx(0.0)
+
+
+def test_event_study_rejects_empty_tickers():
+    _override(_collapse_ohlcv())
+    client = TestClient(app)
+
+    resp = client.post("/api/backtest/event-study", json={"tickers": []})
+
+    assert resp.status_code == 400

--- a/tests/api/test_backtest_run_manager.py
+++ b/tests/api/test_backtest_run_manager.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import time
+
+from api.models.backtest import BacktestMetricsModel, EventStudyResponse
+from api.services.backtest_run_manager import BacktestRunManager
+
+
+def _response() -> EventStudyResponse:
+    return EventStudyResponse(
+        tickers=["TEST"],
+        start="2022-01-01",
+        end="2022-02-01",
+        trades=[],
+        metrics=BacktestMetricsModel(
+            n_trades=0,
+            win_rate=0.0,
+            expectancy_r=0.0,
+            total_r=0.0,
+            profit_factor=None,
+            avg_win_r=0.0,
+            avg_loss_r=0.0,
+            avg_bars_held=0.0,
+            max_drawdown_r=0.0,
+        ),
+    )
+
+
+def _await_terminal(manager: BacktestRunManager, job_id: str, timeout: float = 5.0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        job = manager.get_job(job_id)
+        if job is not None and job.status in {"completed", "error"}:
+            return job
+        time.sleep(0.02)
+    raise AssertionError("job did not reach a terminal state in time")
+
+
+def test_completed_job_carries_result(tmp_path):
+    manager = BacktestRunManager(jobs_dir=tmp_path / "jobs")
+    job_id = manager.start_job(run_fn=_response)
+
+    job = _await_terminal(manager, job_id)
+
+    assert job.status == "completed"
+    assert job.result is not None
+    assert job.result.tickers == ["TEST"]
+
+
+def test_failed_run_is_recorded_as_error(tmp_path):
+    manager = BacktestRunManager(jobs_dir=tmp_path / "jobs")
+
+    def _boom() -> EventStudyResponse:
+        raise RuntimeError("kaboom")
+
+    job_id = manager.start_job(run_fn=_boom)
+    job = _await_terminal(manager, job_id)
+
+    assert job.status == "error"
+    assert "kaboom" in (job.error or "")

--- a/tests/test_backtest_event_study.py
+++ b/tests/test_backtest_event_study.py
@@ -1,0 +1,202 @@
+"""Event-study backtest: replay live signal/stop/exit logic over history."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from swing_screener.backtest import event_study as event_study_mod
+from swing_screener.backtest.config import BacktestConfig
+from swing_screener.backtest.event_study import run_event_study
+from swing_screener.backtest.ledger import Trade
+from swing_screener.backtest.metrics import compute_metrics
+from swing_screener.selection.entries import EntrySignalConfig
+from swing_screener.execution.guidance import ExecutionConfig
+from swing_screener.portfolio.state import ManageConfig
+
+
+def _ohlcv(ticker: str, opens, highs, lows, closes, volumes=None) -> pd.DataFrame:
+    n = len(closes)
+    idx = pd.date_range("2022-01-03", periods=n, freq="B")
+    if volumes is None:
+        volumes = [1_000_000] * n
+    cols = pd.MultiIndex.from_tuples(
+        [
+            ("Open", ticker),
+            ("High", ticker),
+            ("Low", ticker),
+            ("Close", ticker),
+            ("Volume", ticker),
+        ]
+    )
+    data = np.column_stack([opens, highs, lows, closes, volumes])
+    return pd.DataFrame(data, index=idx, columns=cols)
+
+
+def _fast_config(*, pattern_stop_enabled: bool = False) -> BacktestConfig:
+    """Small lookbacks so synthetic fixtures stay short; deterministic stops."""
+    return BacktestConfig(
+        entry=EntrySignalConfig(breakout_lookback=5, pullback_ma=5, min_history=15),
+        execution=ExecutionConfig(
+            pattern_stop_enabled=pattern_stop_enabled, pattern_stop_atr_buffer=0.25
+        ),
+        manage=ManageConfig(
+            breakeven_at_R=1.0,
+            trail_after_R=2.0,
+            trail_sma=5,
+            max_holding_days=20,
+            exit_signal_days=0,
+        ),
+        k_atr=2.0,
+        rr_target=2.0,
+        atr_window=14,
+    )
+
+
+def _flat_base_then_breakout_then_collapse():
+    """20 flat bars (close 100, TR 2), one breakout bar (close 110), then a deep
+    collapse the following bar that gaps well below any ATR stop."""
+    closes = [100.0] * 20 + [110.0, 90.0]
+    opens = [100.0] * 20 + [110.0, 110.0]
+    highs = [101.0] * 20 + [111.0, 111.0]
+    lows = [99.0] * 20 + [99.0, 89.0]
+    return opens, highs, lows, closes
+
+
+def test_stop_hit_trade_realizes_exactly_minus_one_r():
+    opens, highs, lows, closes = _flat_base_then_breakout_then_collapse()
+    ohlcv = _ohlcv("TEST", opens, highs, lows, closes)
+
+    result = run_event_study(ohlcv, ["TEST"], _fast_config())
+
+    assert len(result.trades) == 1
+    trade = result.trades[0]
+    assert trade.setup == "breakout"
+    # Signal fires on bar 20 (the breakout close); fill is the next bar's open.
+    assert trade.entry_price == 110.0
+    assert trade.exit_reason == "stop_hit"
+    # Exiting at the stop is, by definition, a loss of exactly 1R.
+    assert trade.exit_price == pytest.approx(trade.initial_stop)
+    assert trade.r_multiple == pytest.approx(-1.0)
+    assert trade.initial_risk > 0
+    assert trade.bars_held == 1
+
+
+def test_result_carries_metrics_for_its_trades():
+    opens, highs, lows, closes = _flat_base_then_breakout_then_collapse()
+    ohlcv = _ohlcv("TEST", opens, highs, lows, closes)
+
+    result = run_event_study(ohlcv, ["TEST"], _fast_config())
+
+    assert result.metrics.n_trades == len(result.trades) == 1
+    assert result.metrics.expectancy_r == pytest.approx(result.trades[0].r_multiple)
+
+
+def test_no_signal_yields_no_trades():
+    n = 30
+    flat = [100.0] * n
+    ohlcv = _ohlcv("TEST", flat, [101.0] * n, [99.0] * n, flat)
+
+    result = run_event_study(ohlcv, ["TEST"], _fast_config())
+
+    assert result.trades == []
+
+
+def test_winner_time_exit_has_positive_r_and_breakeven_protected():
+    # Flat base, breakout, then a steady climb that never retraces to the stop.
+    base = [100.0] * 20
+    # 21 rising bars: data ends exactly on the 20th-day time-exit bar, so the
+    # closed trade leaves no room for a second signal.
+    climb = [110.0 + 2.0 * k for k in range(21)]
+    closes = base + climb
+    opens = base + climb
+    highs = [c + 1.0 for c in closes]
+    lows = [c - 1.0 for c in closes]
+    ohlcv = _ohlcv("TEST", opens, highs, lows, closes)
+
+    result = run_event_study(ohlcv, ["TEST"], _fast_config())
+
+    assert len(result.trades) == 1
+    trade = result.trades[0]
+    assert trade.exit_reason == "time_exit"
+    assert trade.r_multiple > 0
+    assert trade.mfe_r >= trade.r_multiple
+    # max_holding_days=20 -> exit on the 20th bar held
+    assert trade.bars_held == 20
+
+
+def test_pattern_stop_flag_tightens_initial_risk(monkeypatch):
+    opens, highs, lows, closes = _flat_base_then_breakout_then_collapse()
+    ohlcv = _ohlcv("TEST", opens, highs, lows, closes)
+
+    baseline = run_event_study(
+        ohlcv, ["TEST"], _fast_config(pattern_stop_enabled=False)
+    )
+    baseline_stop = baseline.trades[0].initial_stop
+
+    # Force a tighter structural stop just above the ATR stop to isolate the wiring.
+    tighter = baseline_stop + 1.0
+
+    def _fake_pattern_stop(**kwargs):
+        return tighter, "forced pattern stop"
+
+    monkeypatch.setattr(event_study_mod, "apply_pattern_stop", _fake_pattern_stop)
+
+    patterned = run_event_study(
+        ohlcv, ["TEST"], _fast_config(pattern_stop_enabled=True)
+    )
+    trade = patterned.trades[0]
+
+    assert trade.pattern_stop_fired is True
+    assert trade.initial_stop == pytest.approx(tighter)
+    assert trade.initial_risk < baseline.trades[0].initial_risk
+
+
+def test_compute_metrics_summarizes_r_distribution():
+    trades = [
+        _trade(r=2.0, reason="time_exit", bars=10),
+        _trade(r=-1.0, reason="stop_hit", bars=3),
+        _trade(r=1.0, reason="exit_signal", bars=6),
+    ]
+
+    m = compute_metrics(trades)
+
+    assert m.n_trades == 3
+    assert m.win_rate == pytest.approx(2 / 3)
+    assert m.expectancy_r == pytest.approx(2 / 3)
+    assert m.total_r == pytest.approx(2.0)
+    assert m.profit_factor == pytest.approx(3.0)
+    assert m.avg_win_r == pytest.approx(1.5)
+    assert m.avg_loss_r == pytest.approx(-1.0)
+    assert m.avg_bars_held == pytest.approx(19 / 3)
+    # equity curve 2 -> 1 -> 2; worst peak-to-trough drop is 1R
+    assert m.max_drawdown_r == pytest.approx(1.0)
+    assert m.exit_reason_counts == {"time_exit": 1, "stop_hit": 1, "exit_signal": 1}
+
+
+def test_compute_metrics_empty_is_zeroed():
+    m = compute_metrics([])
+    assert m.n_trades == 0
+    assert m.expectancy_r == 0.0
+    assert m.win_rate == 0.0
+
+
+def _trade(*, r: float, reason: str, bars: int) -> Trade:
+    return Trade(
+        ticker="TEST",
+        setup="breakout",
+        entry_date="2022-01-03",
+        entry_price=100.0,
+        initial_stop=95.0,
+        initial_risk=5.0,
+        target=110.0,
+        exit_date="2022-01-10",
+        exit_price=100.0 + r * 5.0,
+        exit_reason=reason,
+        r_multiple=r,
+        bars_held=bars,
+        mfe_r=max(r, 0.0),
+        mae_r=min(r, 0.0),
+        pattern_stop_fired=False,
+    )


### PR DESCRIPTION
New backtest module + async API. For each ticker, replay history: where the live screener fires a setup, fill at next bar open, then advance the live portfolio manager (evaluate_positions) bar by bar until exit. Reuses build_signal_board / compute_stop / apply_pattern_stop / evaluate_positions verbatim, so it validates real behaviour, not a reimplementation. Output is a per-trade R ledger plus an R-distribution summary (expectancy, win rate, profit factor, max drawdown in R, per-setup).

Exposed via POST /api/backtest/event-study (+ job poll), mirroring the screener async job pattern. Config overrides (pattern_stop_enabled, breakeven_at_r, k_atr, ...) test one variant against live defaults; an A/B is two requests differing in one field.

Scope (v1): event study only (no portfolio/equity curve), today's-snapshot data, zero-cost fills, T+1 entry. Validation harness, never a parameter optimizer (no curve-fitting). Limitations + optimal solutions recorded in src/swing_screener/backtest/README.md.