### PR TITLE
Add data source diagnostics: inventory, fallback feed, per-source probes

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -116,5 +116,11 @@ Catalysts (`/api/catalysts`):
 - `GET /api/catalysts/latest`
 - `GET /api/catalysts/symbol/{ticker}`
 
+Data Sources (`/api/datasources`) — read-only diagnostics, no config mutation:
+- `GET /api/datasources` — inventory of all known sources. Response: `{sources: [SourceDescriptorOut, ...]}`. Each `SourceDescriptorOut` has `id`, `display_name`, `domain`, `role` (`primary`/`fallback`/`enrichment`), `requires` (env var or pkg name; null if unconditional), `configured` (bool), `probeable` (bool), `canary_market` (`us`/`eu`/null), `note` (null or a free-text annotation), and `last_probe` (null or `ProbeResultOut` from the most recent probe run). Intelligence catalyst sources appear with `probeable=false` and a `note` explaining the gap.
+- `POST /api/datasources/probe` — probe all probeable sources concurrently. Response: `[ProbeResultOut, ...]`. `ProbeResultOut` has `id`, `status` (`ok`/`down`/`not_configured`), `latency_ms`, `detail`, `sample` (small dict of live data), `error`.
+- `POST /api/datasources/{source_id}/probe` — probe one source by id. Response: `ProbeResultOut` (same shape). Returns `not_configured` status (no exception) for unknown or non-probeable ids.
+- `GET /api/datasources/events?limit=N` — most recent fallback/stale-cache events recorded at runtime (default 100, max 200). Response: `{events: [FallbackEventOut, ...]}`. Each `FallbackEventOut` has `ts` (ISO-8601 UTC), `domain`, `from_provider`, `reason`, `fell_back_to` (null or id), `tickers` (list), `stale_asof` (null or date string). Events are in-memory only (not persisted; reset on server restart).
+
 ## Ownership
 Routers live in `api/routers/` and call services in `api/services/`.

--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -192,6 +192,18 @@ def get_fundamentals_service(
 
 
 
+from api.services.datasources_service import DatasourcesService
+
+_datasources_service: DatasourcesService | None = None
+
+
+def get_datasources_service() -> DatasourcesService:
+    global _datasources_service
+    if _datasources_service is None:
+        _datasources_service = DatasourcesService()
+    return _datasources_service
+
+
 SCREENER_HISTORY_FILE = DATA_DIR / "screener_history.json"
 
 def get_screener_history_repo() -> ScreenerHistoryRepository:

--- a/api/main.py
+++ b/api/main.py
@@ -22,6 +22,7 @@ from api.routers import (
     catalysts,
     config,
     daily_review,
+    datasources,
     fundamentals,
     intelligence,
     market_data,
@@ -315,6 +316,7 @@ app.include_router(fundamentals.router, prefix="/api/fundamentals", tags=["funda
 app.include_router(intelligence.router, prefix="/api", tags=["intelligence"])
 app.include_router(catalysts.router, prefix="/api", tags=["catalysts"])
 app.include_router(daily_review.router, prefix="/api", tags=["daily-review"])
+app.include_router(datasources.router, prefix="/api/datasources", tags=["datasources"])
 app.include_router(market_data.router, prefix="/api", tags=["market-data"])
 app.include_router(weekly_reviews.router, prefix="/api/weekly-reviews", tags=["weekly-reviews"])
 app.include_router(backtest.router, prefix="/api/backtest", tags=["backtest"])

--- a/api/models/datasources.py
+++ b/api/models/datasources.py
@@ -1,0 +1,46 @@
+"""Pydantic response models for the Data Sources diagnostics API (snake_case)."""
+from __future__ import annotations
+
+from typing import Literal, Optional
+
+from pydantic import BaseModel
+
+
+class ProbeResultOut(BaseModel):
+    id: str
+    status: Literal["ok", "down", "not_configured"]
+    latency_ms: Optional[float] = None
+    detail: Optional[str] = None
+    sample: Optional[dict] = None
+    error: Optional[str] = None
+
+
+class SourceDescriptorOut(BaseModel):
+    id: str
+    display_name: str
+    domain: str
+    role: Literal["primary", "fallback", "enrichment"]
+    requires: Optional[str] = None
+    configured: bool
+    probeable: bool
+    canary_market: Optional[str] = None
+    note: Optional[str] = None
+    last_probe: Optional[ProbeResultOut] = None
+
+
+class DataSourcesInventoryOut(BaseModel):
+    sources: list[SourceDescriptorOut]
+
+
+class FallbackEventOut(BaseModel):
+    ts: str
+    domain: str
+    from_provider: str
+    reason: str
+    fell_back_to: Optional[str] = None
+    tickers: list[str] = []
+    stale_asof: Optional[str] = None
+
+
+class FallbackEventsOut(BaseModel):
+    events: list[FallbackEventOut]

--- a/api/routers/datasources.py
+++ b/api/routers/datasources.py
@@ -1,0 +1,43 @@
+"""Data source diagnostics endpoints (read-only)."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+
+from api.dependencies import get_datasources_service
+from api.models.datasources import (
+    DataSourcesInventoryOut, SourceDescriptorOut, ProbeResultOut,
+    FallbackEventsOut, FallbackEventOut,
+)
+from api.services.datasources_service import DatasourcesService
+
+router = APIRouter(tags=["datasources"])
+
+
+def _descriptor_out(descriptor, last_probe) -> SourceDescriptorOut:
+    payload = descriptor.to_dict()
+    payload["last_probe"] = ProbeResultOut(**last_probe.to_dict()) if last_probe else None
+    return SourceDescriptorOut(**payload)
+
+
+@router.get("", response_model=DataSourcesInventoryOut)
+def get_inventory(service: DatasourcesService = Depends(get_datasources_service)) -> DataSourcesInventoryOut:
+    sources = [_descriptor_out(d, p) for d, p in service.inventory_with_probes()]
+    return DataSourcesInventoryOut(sources=sources)
+
+
+@router.post("/probe", response_model=list[ProbeResultOut])
+def probe_all(service: DatasourcesService = Depends(get_datasources_service)) -> list[ProbeResultOut]:
+    return [ProbeResultOut(**r.to_dict()) for r in service.probe_all()]
+
+
+@router.post("/{source_id}/probe", response_model=ProbeResultOut)
+def probe_one(source_id: str, service: DatasourcesService = Depends(get_datasources_service)) -> ProbeResultOut:
+    return ProbeResultOut(**service.probe_one(source_id).to_dict())
+
+
+@router.get("/events", response_model=FallbackEventsOut)
+def get_events(
+    limit: int = Query(default=100, ge=1, le=200),
+    service: DatasourcesService = Depends(get_datasources_service),
+) -> FallbackEventsOut:
+    return FallbackEventsOut(events=[FallbackEventOut(**e.to_dict()) for e in service.events(limit)])

--- a/api/services/datasources_service.py
+++ b/api/services/datasources_service.py
@@ -1,0 +1,101 @@
+"""Aggregates data-source descriptors, runs probes, exposes fallback events.
+
+This is the ONLY place that enumerates sources across domains. It reads from
+the existing provider classes (no central registry in the core library).
+To add a probeable source: implement describe()/probe() on the provider and
+add it to _PROBEABLE below.
+"""
+from __future__ import annotations
+
+import logging
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+from swing_screener.data.providers.yfinance_provider import YfinanceProvider
+from swing_screener.data.providers.stooq_provider import StooqDataProvider
+from swing_screener.data.providers.alpaca_provider import AlpacaDataProvider
+from swing_screener.fundamentals.providers.sec_edgar import SecEdgarFundamentalsProvider
+from swing_screener.fundamentals.providers.yfinance import YfinanceFundamentalsProvider
+from swing_screener.fundamentals.providers.degiro import DegiroFundamentalsProvider
+from swing_screener.fundamentals.finnhub_client import FinnhubEnrichmentClient
+from swing_screener.data.source_health import (
+    SourceDescriptor, ProbeResult, FallbackEvent, recent_events,
+)
+from swing_screener.settings import get_settings_manager
+
+logger = logging.getLogger(__name__)
+
+# id -> provider class exposing describe()/probe() classmethods
+_PROBEABLE: dict[str, type] = {
+    "yfinance": YfinanceProvider,
+    "stooq": StooqDataProvider,
+    "alpaca": AlpacaDataProvider,
+    "sec_edgar": SecEdgarFundamentalsProvider,
+    "yfinance_fundamentals": YfinanceFundamentalsProvider,
+    "degiro": DegiroFundamentalsProvider,
+    "finnhub": FinnhubEnrichmentClient,
+}
+
+# The 6 declared catalyst sources — inert today (no runtime adapter). Listed
+# honestly so the page shows the gap rather than faking confidence.
+INTELLIGENCE_SOURCES: list[SourceDescriptor] = [
+    SourceDescriptor(id=sid, display_name=name, domain="intelligence", role="primary",
+                     requires=None, configured=False, probeable=False, canary_market=None, note=note)
+    for sid, name, note in [
+        ("yahoo_finance", "Yahoo Finance (catalysts)", "declared — no runtime adapter"),
+        ("earnings_calendar", "Earnings Calendar", "declared — no runtime adapter"),
+        ("sec_edgar_catalysts", "SEC EDGAR (catalysts)", "implemented for fundamentals, not as catalyst collector"),
+        ("company_ir_rss", "Company IR RSS", "declared — no runtime adapter"),
+        ("exchange_announcements", "Exchange Announcements", "declared — no runtime adapter"),
+        ("financial_news_rss", "Financial News RSS", "declared — no runtime adapter"),
+    ]
+]
+
+_DEFAULT_CANARY = {"us": "AAPL", "eu": "ASML.AS"}
+
+
+class DatasourcesService:
+    def __init__(self) -> None:
+        self._probe_cache: dict[str, ProbeResult] = {}
+
+    def _canary_map(self) -> dict[str, str]:
+        try:
+            defaults = get_settings_manager().load_defaults_document()
+            cfg = defaults.get("low_level", {}).get("data_providers", {}).get("probe_canary", {})
+            return {"us": cfg.get("us", _DEFAULT_CANARY["us"]), "eu": cfg.get("eu", _DEFAULT_CANARY["eu"])}
+        except Exception:
+            return dict(_DEFAULT_CANARY)
+
+    def inventory(self) -> list[SourceDescriptor]:
+        descriptors = [cls.describe() for cls in _PROBEABLE.values()]
+        descriptors.extend(INTELLIGENCE_SOURCES)
+        return descriptors
+
+    def inventory_with_probes(self) -> list[tuple[SourceDescriptor, ProbeResult | None]]:
+        return [(d, self._probe_cache.get(d.id)) for d in self.inventory()]
+
+    def probe_one(self, source_id: str) -> ProbeResult:
+        cls = _PROBEABLE.get(source_id)
+        if cls is None:
+            return ProbeResult(id=source_id, status="not_configured", detail="unknown or not probeable")
+        descriptor = cls.describe()
+        canary = self._canary_map().get(descriptor.canary_market or "us", _DEFAULT_CANARY["us"])
+        result = cls.probe(canary)
+        self._probe_cache[source_id] = result
+        return result
+
+    def probe_all(self) -> list[ProbeResult]:
+        ids = [d.id for d in self.inventory() if d.probeable]
+        results: list[ProbeResult] = []
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            futures = {pool.submit(self.probe_one, sid): sid for sid in ids}
+            for future in as_completed(futures):
+                sid = futures[future]
+                try:
+                    results.append(future.result())
+                except Exception as exc:  # pragma: no cover - defensive
+                    logger.warning("probe failed for %s: %s", sid, exc)
+                    results.append(ProbeResult(id=sid, status="down", error=str(exc)))
+        return results
+
+    def events(self, limit: int | None = None) -> list[FallbackEvent]:
+        return recent_events(limit)

--- a/config/README.md
+++ b/config/README.md
@@ -27,6 +27,11 @@ Candlestick pattern + structural-stop settings live under `low_level`:
   invalidation level instead of a wide ATR multiple. It is only applied when it is
   tighter than the ATR stop, below entry, not in an `extended` context, and does
   not breach minimum R.
+- `low_level.data_providers.probe_canary` — canary symbols used by data source
+  diagnostics (Data Sources page probes). Contains region-keyed symbols: `us` (US
+  market canary, default AAPL) and `eu` (EU market canary, default ASML.AS). Used
+  by the `DatasourcesService` to test provider health without requiring a real
+  universe.
 
 ### `user.yaml`
 

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -427,6 +427,9 @@ low_level:
       rate_limit_window_seconds: 60
       max_retries: 3
       retry_delay_base_seconds: 1.0
+    probe_canary:
+      us: AAPL
+      eu: ASML.AS
 
 # ---------------------------------------------------------------------------
 # Paid provider roadmap only. These entries document intended future gates and

--- a/docs/engineering/MODULE_ARCHITECTURE.md
+++ b/docs/engineering/MODULE_ARCHITECTURE.md
@@ -88,6 +88,30 @@ Also removed:
 
 - `swing_screener.reporting.config` as a canonical import target.
 
+## Data Source Diagnostics
+
+`src/swing_screener/data/source_health.py` owns the diagnostics contract and the
+in-memory fallback ring used by the Data Sources page.
+
+**`DiagnosableSource` Protocol** — a `@runtime_checkable` Protocol a provider
+implements to appear in the inventory and get a Test button. Both methods must be
+**classmethods** (so unconfigured providers can be described without instantiation):
+
+- `describe() -> SourceDescriptor` — static, credential-free; reports `configured`
+  (env var / package present) and `probeable` (has a live canary path).
+- `probe(canary: str) -> ProbeResult` — fires a small real request; returns
+  `ProbeResult(status="not_configured")` (no exception) when credentials/package
+  are absent.
+
+**`FallbackEventRing`** — process-local, bounded (`capacity=200`), thread-safe
+`deque`. Call `record_fallback(...)` at any provider fallback site; read via
+`recent_events(limit)`. Not persisted — resets on server restart. Surfaced by
+`GET /api/datasources/events`.
+
+The single cross-domain enumeration (`id → provider class`) lives in
+`api/services/datasources_service.py` (`_PROBEABLE`). There is no central
+registry in core; to add or remove a probeable source, update `_PROBEABLE` only.
+
 ## Universe Registry Data Sources
 
 The packaged universe registry (`src/swing_screener/data/universes/registry/`) is

--- a/src/swing_screener/data/providers/README.md
+++ b/src/swing_screener/data/providers/README.md
@@ -1,0 +1,28 @@
+# data/providers
+
+Market-data provider implementations for OHLCV and price history.
+
+## Providers
+
+| Module | Provider class | Source | Role |
+|--------|---------------|--------|------|
+| `yfinance_provider.py` | `YfinanceProvider` | Yahoo Finance | primary |
+| `stooq_provider.py` | `StooqDataProvider` | Stooq | fallback |
+| `alpaca_provider.py` | `AlpacaDataProvider` | Alpaca Markets | primary (requires `ALPACA_API_KEY` + `ALPACA_SECRET_KEY`) |
+
+## How to add a data source
+
+A source appears on the Data Sources page when it implements the diagnostics
+contract (`swing_screener.data.source_health.DiagnosableSource`):
+
+1. Implement the domain fetch method (`fetch_ohlcv` / `fetch_record`).
+2. Add two classmethods:
+   - `describe() -> SourceDescriptor` — static, credential-free; set `configured`
+     by checking the env var / package; set `probeable` accordingly.
+   - `probe(canary: str) -> ProbeResult` — a tiny real request; return
+     `not_configured` (no exception) when keys/pkg are missing.
+3. Register the provider id → class in `api/services/datasources_service.py`
+   (`_PROBEABLE`). It then auto-appears in the inventory, gets a Test button,
+   and (if it has fallbacks) records events via `record_fallback(...)`.
+
+To remove a source: delete the provider file and its `_PROBEABLE` entry.

--- a/src/swing_screener/data/providers/_probe.py
+++ b/src/swing_screener/data/providers/_probe.py
@@ -1,0 +1,43 @@
+"""Shared helpers for provider canary probes."""
+from __future__ import annotations
+
+import time
+from datetime import date, timedelta
+
+import pandas as pd
+
+from swing_screener.data.source_health import ProbeResult
+
+
+def ohlcv_canary_probe(provider, canary: str, source_id: str) -> ProbeResult:
+    """Fetch a short recent OHLCV window for `canary` and grade reachability."""
+    end = date.today().isoformat()
+    start = (date.today() - timedelta(days=10)).isoformat()
+    started = time.perf_counter()
+    try:
+        df = provider.fetch_ohlcv([canary], start_date=start, end_date=end)
+    except Exception as exc:  # network / parsing failure
+        elapsed = (time.perf_counter() - started) * 1000.0
+        return ProbeResult(id=source_id, status="down", latency_ms=round(elapsed, 1), error=str(exc))
+
+    elapsed = (time.perf_counter() - started) * 1000.0
+    if df is None or df.empty or ("Close", canary) not in df.columns:
+        return ProbeResult(
+            id=source_id, status="down", latency_ms=round(elapsed, 1),
+            detail="empty response",
+        )
+    closes = df[("Close", canary)].dropna()
+    if closes.empty:
+        return ProbeResult(
+            id=source_id, status="down", latency_ms=round(elapsed, 1),
+            detail="no close data",
+        )
+    last_close = float(closes.iloc[-1])
+    last_date = str(closes.index[-1].date()) if isinstance(closes.index, pd.DatetimeIndex) else str(closes.index[-1])
+    return ProbeResult(
+        id=source_id,
+        status="ok",
+        latency_ms=round(elapsed, 1),
+        detail=f"{len(closes)} bars",
+        sample={"last_close": last_close, "last_date": last_date},
+    )

--- a/src/swing_screener/data/providers/alpaca_provider.py
+++ b/src/swing_screener/data/providers/alpaca_provider.py
@@ -1,6 +1,7 @@
 """Alpaca market data provider using alpaca-py SDK."""
 from __future__ import annotations
 
+import os
 from datetime import date, datetime, timedelta
 from pathlib import Path
 from typing import Optional
@@ -8,12 +9,10 @@ import time
 import hashlib
 
 import pandas as pd
-from alpaca.data import StockHistoricalDataClient
-from alpaca.data.requests import StockBarsRequest
-from alpaca.data.timeframe import TimeFrame
 
 from .base import MarketDataProvider
-from swing_screener.data.source_health import DataSourceHealth
+from swing_screener.data.source_health import DataSourceHealth, SourceDescriptor, ProbeResult
+from swing_screener.data.providers._probe import ohlcv_canary_probe
 
 
 class AlpacaDataProvider(MarketDataProvider):
@@ -51,12 +50,14 @@ class AlpacaDataProvider(MarketDataProvider):
             cache_dir: Directory for parquet cache files
             use_cache: Enable caching (default: True)
         """
+        from alpaca.data import StockHistoricalDataClient  # lazy: keeps module importable without alpaca-py
+
         self.api_key = api_key
         self.secret_key = secret_key
         self.paper = paper
         self.cache_dir = Path(cache_dir)
         self.use_cache = use_cache
-        
+
         # Initialize Alpaca client
         self.client = StockHistoricalDataClient(api_key, secret_key)
         
@@ -114,8 +115,9 @@ class AlpacaDataProvider(MarketDataProvider):
             key = f"{prefix}__n={len(tickers)}__{start_date}__{end_date}__{interval}__{digest}"
         return self.cache_dir / f"{key}.parquet"
     
-    def _parse_timeframe(self, interval: str) -> TimeFrame:
+    def _parse_timeframe(self, interval: str):
         """Convert interval string to Alpaca TimeFrame."""
+        from alpaca.data.timeframe import TimeFrame  # lazy
         interval_map = {
             "1m": TimeFrame.Minute,
             "1min": TimeFrame.Minute,
@@ -186,6 +188,7 @@ class AlpacaDataProvider(MarketDataProvider):
         
         # Fetch data from Alpaca
         def fetch():
+            from alpaca.data.requests import StockBarsRequest  # lazy
             self._wait_for_rate_limit()
             request = StockBarsRequest(
                 symbol_or_symbols=tickers,
@@ -348,8 +351,39 @@ class AlpacaDataProvider(MarketDataProvider):
     def get_provider_name(self) -> str:
         """
         Get provider name.
-        
+
         Returns:
             "alpaca" or "alpaca-paper"
         """
         return "alpaca-paper" if self.paper else "alpaca"
+
+    @classmethod
+    def _credentials_present(cls) -> bool:
+        return bool(os.environ.get("ALPACA_API_KEY") and os.environ.get("ALPACA_SECRET_KEY"))
+
+    @classmethod
+    def describe(cls) -> SourceDescriptor:
+        return SourceDescriptor(
+            id="alpaca",
+            display_name="Alpaca",
+            domain="market_data",
+            role="primary",
+            requires="ALPACA_API_KEY",
+            configured=cls._credentials_present(),
+            probeable=True,
+            canary_market="us",
+        )
+
+    @classmethod
+    def probe(cls, canary: str) -> ProbeResult:
+        if not cls._credentials_present():
+            return ProbeResult(id="alpaca", status="not_configured", detail="ALPACA_API_KEY/SECRET not set")
+        try:
+            provider = cls(
+                api_key=os.environ["ALPACA_API_KEY"],
+                secret_key=os.environ["ALPACA_SECRET_KEY"],
+                paper=os.environ.get("ALPACA_PAPER", "true").lower() != "false",
+            )
+        except ModuleNotFoundError:
+            return ProbeResult(id="alpaca", status="not_configured", detail="alpaca-py not installed")
+        return ohlcv_canary_probe(provider, canary, "alpaca")

--- a/src/swing_screener/data/providers/stooq_provider.py
+++ b/src/swing_screener/data/providers/stooq_provider.py
@@ -11,7 +11,8 @@ import httpx
 import pandas as pd
 
 from .base import MarketDataProvider
-from swing_screener.data.source_health import DataSourceHealth
+from swing_screener.data.source_health import DataSourceHealth, SourceDescriptor, ProbeResult
+from swing_screener.data.providers._probe import ohlcv_canary_probe
 from swing_screener.utils import normalize_tickers
 
 _INSTRUMENT_MASTER_PATH = Path("data/intelligence/instrument_master.json")
@@ -246,3 +247,20 @@ class StooqDataProvider(MarketDataProvider):
 
     def get_provider_name(self) -> str:
         return "stooq"
+
+    @classmethod
+    def describe(cls) -> SourceDescriptor:
+        return SourceDescriptor(
+            id="stooq",
+            display_name="Stooq",
+            domain="market_data",
+            role="fallback",
+            requires=None,
+            configured=True,
+            probeable=True,
+            canary_market="eu",
+        )
+
+    @classmethod
+    def probe(cls, canary: str) -> ProbeResult:
+        return ohlcv_canary_probe(cls(), canary, "stooq")

--- a/src/swing_screener/data/providers/yfinance_provider.py
+++ b/src/swing_screener/data/providers/yfinance_provider.py
@@ -15,7 +15,9 @@ import yfinance as yf
 from .base import MarketDataProvider
 from .stooq_provider import StooqDataProvider
 from ..market_data import fetch_ticker_metadata
-from swing_screener.data.source_health import DataSourceHealth, SourceDescriptor, ProbeResult
+from swing_screener.data.source_health import (
+    DataSourceHealth, SourceDescriptor, ProbeResult, record_fallback,
+)
 from swing_screener.data.providers._probe import ohlcv_canary_probe
 from swing_screener.utils import normalize_tickers
 
@@ -251,6 +253,13 @@ class YfinanceProvider(MarketDataProvider):
                 len(tickers),
                 ",".join(tickers[:5]),
                 exc,
+            )
+            record_fallback(
+                domain="market_data",
+                from_provider="yfinance",
+                reason=f"stooq fallback failed: {exc}",
+                fell_back_to="stooq",
+                tickers=list(tickers[:20]),
             )
             return pd.DataFrame()
 
@@ -508,6 +517,13 @@ class YfinanceProvider(MarketDataProvider):
                     "Bulk yfinance download returned no data for %s tickers; retrying sequentially.",
                     len(misses),
                 )
+                record_fallback(
+                    domain="market_data",
+                    from_provider="yfinance",
+                    reason="bulk download empty; retrying sequentially",
+                    fell_back_to="yfinance-sequential",
+                    tickers=list(misses[:20]),
+                )
                 df = self._download_sequential(misses, start_date, actual_end)
 
             if df is None or df.empty:
@@ -522,6 +538,14 @@ class YfinanceProvider(MarketDataProvider):
                         )
                         if frame is not None and not frame.empty:
                             cached_frames.append(frame)
+                if cached_frames:
+                    record_fallback(
+                        domain="market_data",
+                        from_provider="yfinance",
+                        reason="serving stale cache after download failure",
+                        fell_back_to="stale_cache",
+                        tickers=list(misses[:20]),
+                    )
                 if not cached_frames:
                     raise RuntimeError("Download empty. Check tickers or connection.")
             else:
@@ -542,6 +566,13 @@ class YfinanceProvider(MarketDataProvider):
                             len(remaining_missing),
                             ",".join(remaining_missing[:10]),
                         )
+                        record_fallback(
+                            domain="market_data",
+                            from_provider="yfinance",
+                            reason="missing close after retries; trying stooq",
+                            fell_back_to="stooq",
+                            tickers=list(remaining_missing[:20]),
+                        )
                         fallback_df = self._fetch_stooq_fallback(
                             remaining_missing,
                             start_date,
@@ -552,6 +583,7 @@ class YfinanceProvider(MarketDataProvider):
 
                 # Tickers that still have no data but hold stale cached coverage
                 # are better served stale than dropped.
+                _pre_stale_len = len(cached_frames)
                 if allow_cache_fallback_on_error and stale_fallback:
                     for ticker in self._missing_close_tickers(df, misses):
                         path = stale_fallback.get(ticker)
@@ -562,6 +594,14 @@ class YfinanceProvider(MarketDataProvider):
                         )
                         if frame is not None and not frame.empty:
                             cached_frames.append(frame)
+                if len(cached_frames) > _pre_stale_len:
+                    record_fallback(
+                        domain="market_data",
+                        from_provider="yfinance",
+                        reason="serving stale cache after download failure",
+                        fell_back_to="stale_cache",
+                        tickers=list(misses[:20]),
+                    )
 
                 if use_cache:
                     self._store_per_ticker_cache(df, misses, start_date, end_for_coverage)

--- a/src/swing_screener/data/providers/yfinance_provider.py
+++ b/src/swing_screener/data/providers/yfinance_provider.py
@@ -531,6 +531,8 @@ class YfinanceProvider(MarketDataProvider):
 
             if df is None or df.empty:
                 df = pd.DataFrame()
+                _pre_stale_len_1 = len(cached_frames)
+                _served_stale_tickers_1: list[str] = []
                 if allow_cache_fallback_on_error:
                     for ticker, path in stale_fallback.items():
                         frame = self._slice_window(
@@ -538,13 +540,14 @@ class YfinanceProvider(MarketDataProvider):
                         )
                         if frame is not None and not frame.empty:
                             cached_frames.append(frame)
-                if cached_frames:
+                            _served_stale_tickers_1.append(ticker)
+                if len(cached_frames) > _pre_stale_len_1:
                     record_fallback(
                         domain="market_data",
                         from_provider="yfinance",
                         reason="serving stale cache after download failure",
                         fell_back_to="stale_cache",
-                        tickers=list(misses[:20]),
+                        tickers=_served_stale_tickers_1[:20],
                     )
                 if not cached_frames:
                     raise RuntimeError("Download empty. Check tickers or connection.")
@@ -584,6 +587,7 @@ class YfinanceProvider(MarketDataProvider):
                 # Tickers that still have no data but hold stale cached coverage
                 # are better served stale than dropped.
                 _pre_stale_len = len(cached_frames)
+                _served_stale_tickers: list[str] = []
                 if allow_cache_fallback_on_error and stale_fallback:
                     for ticker in self._missing_close_tickers(df, misses):
                         path = stale_fallback.get(ticker)
@@ -594,13 +598,14 @@ class YfinanceProvider(MarketDataProvider):
                         )
                         if frame is not None and not frame.empty:
                             cached_frames.append(frame)
+                            _served_stale_tickers.append(ticker)
                 if len(cached_frames) > _pre_stale_len:
                     record_fallback(
                         domain="market_data",
                         from_provider="yfinance",
                         reason="serving stale cache after download failure",
                         fell_back_to="stale_cache",
-                        tickers=list(misses[:20]),
+                        tickers=_served_stale_tickers[:20],
                     )
 
                 if use_cache:

--- a/src/swing_screener/data/providers/yfinance_provider.py
+++ b/src/swing_screener/data/providers/yfinance_provider.py
@@ -15,7 +15,8 @@ import yfinance as yf
 from .base import MarketDataProvider
 from .stooq_provider import StooqDataProvider
 from ..market_data import fetch_ticker_metadata
-from swing_screener.data.source_health import DataSourceHealth
+from swing_screener.data.source_health import DataSourceHealth, SourceDescriptor, ProbeResult
+from swing_screener.data.providers._probe import ohlcv_canary_probe
 from swing_screener.utils import normalize_tickers
 
 logger = logging.getLogger(__name__)
@@ -709,8 +710,25 @@ class YfinanceProvider(MarketDataProvider):
     def get_provider_name(self) -> str:
         """
         Get provider name.
-        
+
         Returns:
             "yfinance"
         """
         return "yfinance"
+
+    @classmethod
+    def describe(cls) -> SourceDescriptor:
+        return SourceDescriptor(
+            id="yfinance",
+            display_name="Yahoo Finance",
+            domain="market_data",
+            role="primary",
+            requires=None,
+            configured=True,
+            probeable=True,
+            canary_market="us",
+        )
+
+    @classmethod
+    def probe(cls, canary: str) -> ProbeResult:
+        return ohlcv_canary_probe(cls(), canary, "yfinance")

--- a/src/swing_screener/data/source_health.py
+++ b/src/swing_screener/data/source_health.py
@@ -1,7 +1,10 @@
 """Shared data source health and provenance models."""
 from __future__ import annotations
 
+from collections import deque
 from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from threading import Lock
 from typing import Literal, Protocol, runtime_checkable
 
 SourceDomain = Literal[
@@ -145,3 +148,59 @@ def merge_source_health(items: list[DataSourceHealth]) -> DataSourceHealth:
         quality_score=max(0.0, round(base_score - warning_penalty - failure_penalty, 4)),
         warnings=warnings,
     )
+
+
+class FallbackEventRing:
+    """Process-local, bounded, thread-safe ring of fallback events."""
+
+    def __init__(self, capacity: int = 200) -> None:
+        self._events: deque[FallbackEvent] = deque(maxlen=capacity)
+        self._lock = Lock()
+
+    def record(self, event: FallbackEvent) -> None:
+        with self._lock:
+            self._events.append(event)
+
+    def recent(self, limit: int | None = None) -> list[FallbackEvent]:
+        with self._lock:
+            items = list(self._events)
+        items.reverse()  # newest first
+        return items[: limit] if limit else items
+
+    def clear(self) -> None:
+        with self._lock:
+            self._events.clear()
+
+
+_FALLBACK_RING = FallbackEventRing()
+
+
+def record_fallback(
+    *,
+    domain: SourceDomain,
+    from_provider: str,
+    reason: str,
+    fell_back_to: str | None = None,
+    tickers: list[str] | None = None,
+    stale_asof: str | None = None,
+) -> None:
+    """Record a runtime fallback event into the process-local ring."""
+    _FALLBACK_RING.record(
+        FallbackEvent(
+            ts=datetime.now(timezone.utc).isoformat(),
+            domain=domain,
+            from_provider=from_provider,
+            reason=reason,
+            fell_back_to=fell_back_to,
+            tickers=list(tickers or []),
+            stale_asof=stale_asof,
+        )
+    )
+
+
+def recent_events(limit: int | None = None) -> list[FallbackEvent]:
+    return _FALLBACK_RING.recent(limit)
+
+
+def reset_fallback_events() -> None:
+    _FALLBACK_RING.clear()

--- a/src/swing_screener/data/source_health.py
+++ b/src/swing_screener/data/source_health.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field
-from typing import Literal
+from typing import Literal, Protocol, runtime_checkable
 
 SourceDomain = Literal[
     "market_data",
@@ -13,6 +13,74 @@ SourceDomain = Literal[
     "aggregate",
 ]
 SourceStatus = Literal["ok", "degraded", "failed", "unknown"]
+
+ProbeStatus = Literal["ok", "down", "not_configured"]
+SourceRole = Literal["primary", "fallback", "enrichment"]
+CanaryMarket = Literal["us", "eu"]
+
+
+@dataclass(frozen=True)
+class SourceDescriptor:
+    """Static, credential-free description of one data source."""
+
+    id: str
+    display_name: str
+    domain: SourceDomain
+    role: SourceRole
+    requires: str | None = None          # env var or pkg name; None if unconditional
+    configured: bool = True              # key/pkg present
+    probeable: bool = True               # has a live canary path
+    canary_market: CanaryMarket | None = "us"
+    note: str | None = None              # e.g. "declared — no runtime adapter"
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ProbeResult:
+    """Outcome of a single live canary request against one source."""
+
+    id: str
+    status: ProbeStatus
+    latency_ms: float | None = None
+    detail: str | None = None
+    sample: dict | None = None
+    error: str | None = None
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class FallbackEvent:
+    """One runtime fallback / stale-cache / silent-swallow event."""
+
+    ts: str                              # ISO-8601 UTC
+    domain: SourceDomain
+    from_provider: str
+    reason: str
+    fell_back_to: str | None = None
+    tickers: list[str] = field(default_factory=list)
+    stale_asof: str | None = None
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@runtime_checkable
+class DiagnosableSource(Protocol):
+    """Contract a data source implements to appear in the Data Sources page.
+
+    Implement BOTH as classmethods so inventory works without instantiating
+    a provider that may need credentials or an optional package.
+    """
+
+    @classmethod
+    def describe(cls) -> SourceDescriptor: ...
+
+    @classmethod
+    def probe(cls, canary: str) -> ProbeResult: ...
 
 
 @dataclass(frozen=True)

--- a/src/swing_screener/fundamentals/finnhub_client.py
+++ b/src/swing_screener/fundamentals/finnhub_client.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
 import datetime as dt
+import json
 import logging
+import os
+import time
+import urllib.request
 from dataclasses import replace
 from typing import Any
 
 import httpx
 
+from swing_screener.data.source_health import ProbeResult, SourceDescriptor
 from swing_screener.fundamentals.models import ProviderFundamentalsRecord
 
 logger = logging.getLogger(__name__)
@@ -236,3 +241,44 @@ class FinnhubEnrichmentClient:
         if not updates:
             return record
         return replace(record, **updates)
+
+    @classmethod
+    def _key(cls) -> str | None:
+        return os.environ.get("FINNHUB_API_KEY") or None
+
+    @classmethod
+    def describe(cls) -> SourceDescriptor:
+        return SourceDescriptor(
+            id="finnhub",
+            display_name="Finnhub (enrichment)",
+            domain="fundamentals",
+            role="enrichment",
+            requires="FINNHUB_API_KEY",
+            configured=cls._key() is not None,
+            probeable=cls._key() is not None,
+            canary_market="us",
+        )
+
+    @classmethod
+    def probe(cls, canary: str) -> ProbeResult:
+        key = cls._key()
+        if not key:
+            return ProbeResult(id="finnhub", status="not_configured", detail="FINNHUB_API_KEY not set")
+        url = f"https://finnhub.io/api/v1/quote?symbol={canary}&token={key}"
+        started = time.perf_counter()
+        try:
+            with urllib.request.urlopen(url, timeout=10) as resp:
+                payload = json.loads(resp.read().decode("utf-8"))
+            elapsed = (time.perf_counter() - started) * 1000.0
+            price = payload.get("c")
+            if not price:
+                return ProbeResult(id="finnhub", status="down", latency_ms=round(elapsed, 1), detail="empty quote")
+            return ProbeResult(
+                id="finnhub",
+                status="ok",
+                latency_ms=round(elapsed, 1),
+                sample={"symbol": canary, "current_price": price},
+            )
+        except Exception as exc:
+            elapsed = (time.perf_counter() - started) * 1000.0
+            return ProbeResult(id="finnhub", status="down", latency_ms=round(elapsed, 1), error=str(exc))

--- a/src/swing_screener/fundamentals/providers/README.md
+++ b/src/swing_screener/fundamentals/providers/README.md
@@ -1,0 +1,33 @@
+# fundamentals/providers
+
+Fundamental data provider implementations (income statement, balance sheet, ratios).
+
+## Providers
+
+| Module | Provider class | Source | Role |
+|--------|---------------|--------|------|
+| `sec_edgar.py` | `SecEdgarFundamentalsProvider` | SEC EDGAR | primary |
+| `yfinance.py` | `YfinanceFundamentalsProvider` | Yahoo Finance | fallback |
+| `degiro.py` | `DegiroFundamentalsProvider` | DeGiro (EU equities) | primary (requires `DEGIRO_USERNAME` + `DEGIRO_PASSWORD`) |
+
+`FinnhubEnrichmentClient` (`fundamentals/finnhub_client.py`) is registered as a
+diagnostics-only source (`role=enrichment`; requires `FINNHUB_API_KEY`). It is
+not a `FundamentalsProvider` subclass — it enriches snapshots with signal fields
+rather than supplying full fundamental records.
+
+## How to add a data source
+
+A source appears on the Data Sources page when it implements the diagnostics
+contract (`swing_screener.data.source_health.DiagnosableSource`):
+
+1. Implement the domain fetch method (`fetch_ohlcv` / `fetch_record`).
+2. Add two classmethods:
+   - `describe() -> SourceDescriptor` — static, credential-free; set `configured`
+     by checking the env var / package; set `probeable` accordingly.
+   - `probe(canary: str) -> ProbeResult` — a tiny real request; return
+     `not_configured` (no exception) when keys/pkg are missing.
+3. Register the provider id → class in `api/services/datasources_service.py`
+   (`_PROBEABLE`). It then auto-appears in the inventory, gets a Test button,
+   and (if it has fallbacks) records events via `record_fallback(...)`.
+
+To remove a source: delete the provider file and its `_PROBEABLE` entry.

--- a/src/swing_screener/fundamentals/providers/degiro.py
+++ b/src/swing_screener/fundamentals/providers/degiro.py
@@ -14,8 +14,10 @@ import json
 import logging
 from datetime import date
 from pathlib import Path
+import time
 from typing import Any, Optional
 
+from swing_screener.data.source_health import ProbeResult, SourceDescriptor
 from swing_screener.fundamentals.models import (
     FundamentalMetricContext,
     FundamentalMetricSeries,
@@ -365,3 +367,40 @@ class DegiroFundamentalsProvider:
             metric_context=metric_context,
             metric_sources=metric_sources,
         )
+
+    @classmethod
+    def _available(cls) -> bool:
+        from swing_screener.fundamentals.config import _degiro_integration_available
+        return _degiro_integration_available()
+
+    @classmethod
+    def describe(cls) -> SourceDescriptor:
+        available = cls._available()
+        return SourceDescriptor(
+            id="degiro",
+            display_name="DEGIRO",
+            domain="fundamentals",
+            role="fallback",
+            requires="swing_screener.integrations.degiro",
+            configured=available,
+            probeable=available,
+            canary_market="eu",
+        )
+
+    @classmethod
+    def probe(cls, canary: str) -> ProbeResult:
+        if not cls._available():
+            return ProbeResult(id="degiro", status="not_configured", detail="degiro integration not installed")
+        started = time.perf_counter()
+        try:
+            record = cls().fetch_record(canary)
+            elapsed = (time.perf_counter() - started) * 1000.0
+            return ProbeResult(
+                id="degiro",
+                status="ok",
+                latency_ms=round(elapsed, 1),
+                sample={"symbol": canary, "has_market_cap": record.market_cap is not None},
+            )
+        except Exception as exc:
+            elapsed = (time.perf_counter() - started) * 1000.0
+            return ProbeResult(id="degiro", status="down", latency_ms=round(elapsed, 1), error=str(exc))

--- a/src/swing_screener/fundamentals/providers/sec_edgar.py
+++ b/src/swing_screener/fundamentals/providers/sec_edgar.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import UTC, date, datetime
 import os
+import time
 from typing import Any
 
 import httpx
 
+from swing_screener.data.source_health import ProbeResult, SourceDescriptor
 from swing_screener.fundamentals.models import (
     FundamentalMetricContext,
     FundamentalMetricSeries,
@@ -773,3 +775,34 @@ class SecEdgarFundamentalsProvider:
             metric_context=metric_context,
             metric_sources={key: value for key, value in metric_sources.items() if value},
         )
+
+    @classmethod
+    def describe(cls) -> SourceDescriptor:
+        return SourceDescriptor(
+            id="sec_edgar",
+            display_name="SEC EDGAR",
+            domain="fundamentals",
+            role="primary",
+            requires=None,
+            configured=True,
+            probeable=True,
+            canary_market="us",
+        )
+
+    @classmethod
+    def probe(cls, canary: str) -> ProbeResult:
+        started = time.perf_counter()
+        try:
+            provider = cls()
+            record = provider.fetch_record(canary)
+            elapsed = (time.perf_counter() - started) * 1000.0
+            return ProbeResult(
+                id="sec_edgar",
+                status="ok",
+                latency_ms=round(elapsed, 1),
+                detail="record fetched",
+                sample={"symbol": canary, "has_market_cap": record.market_cap is not None},
+            )
+        except Exception as exc:
+            elapsed = (time.perf_counter() - started) * 1000.0
+            return ProbeResult(id="sec_edgar", status="down", latency_ms=round(elapsed, 1), error=str(exc))

--- a/src/swing_screener/fundamentals/providers/yfinance.py
+++ b/src/swing_screener/fundamentals/providers/yfinance.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 from datetime import date, datetime, timezone
+import time
 from typing import Any
 
 import pandas as pd
 import yfinance as yf
 
+from swing_screener.data.source_health import ProbeResult, SourceDescriptor
 from swing_screener.fundamentals.models import (
     FundamentalMetricContext,
     FundamentalMetricSeries,
@@ -517,3 +519,33 @@ class YfinanceFundamentalsProvider:
             metric_context=metric_context,
             metric_sources={key: value for key, value in metric_sources.items() if value},
         )
+
+    @classmethod
+    def describe(cls) -> SourceDescriptor:
+        return SourceDescriptor(
+            id="yfinance_fundamentals",
+            display_name="Yahoo Finance (fundamentals)",
+            domain="fundamentals",
+            role="fallback",
+            requires=None,
+            configured=True,
+            probeable=True,
+            canary_market="us",
+        )
+
+    @classmethod
+    def probe(cls, canary: str) -> ProbeResult:
+        started = time.perf_counter()
+        try:
+            record = cls().fetch_record(canary)
+            elapsed = (time.perf_counter() - started) * 1000.0
+            return ProbeResult(
+                id="yfinance_fundamentals",
+                status="ok",
+                latency_ms=round(elapsed, 1),
+                detail="record fetched",
+                sample={"symbol": canary, "has_market_cap": record.market_cap is not None},
+            )
+        except Exception as exc:
+            elapsed = (time.perf_counter() - started) * 1000.0
+            return ProbeResult(id="yfinance_fundamentals", status="down", latency_ms=round(elapsed, 1), error=str(exc))

--- a/src/swing_screener/fundamentals/service.py
+++ b/src/swing_screener/fundamentals/service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from swing_screener.fundamentals.config import FundamentalsConfig
 from swing_screener.fundamentals.models import TRUST_METADATA_MISSING_FLAG, FundamentalSnapshot
+from swing_screener.data.source_health import record_fallback
 from swing_screener.fundamentals.providers import (
     DegiroFundamentalsProvider,
     SecEdgarFundamentalsProvider,
@@ -77,7 +78,7 @@ class FundamentalsAnalysisService:
         snapshot = None
         last_error: Exception | None = None
         last_provider_name = "unknown"
-        for provider in providers:
+        for idx, provider in enumerate(providers):
             last_provider_name = provider.name
             try:
                 record = provider.fetch_record(normalized_symbol)
@@ -87,6 +88,14 @@ class FundamentalsAnalysisService:
                 break
             except Exception as exc:
                 last_error = exc
+                next_provider = providers[idx + 1].name if idx + 1 < len(providers) else None
+                record_fallback(
+                    domain="fundamentals",
+                    from_provider=provider.name,
+                    reason=str(exc),
+                    fell_back_to=next_provider,
+                    tickers=[normalized_symbol],
+                )
                 continue
         if snapshot is None:
             if cached is not None:

--- a/tests/api/test_datasources_models.py
+++ b/tests/api/test_datasources_models.py
@@ -1,0 +1,23 @@
+from api.models.datasources import (
+    SourceDescriptorOut, ProbeResultOut, FallbackEventOut, DataSourcesInventoryOut,
+)
+
+
+def test_inventory_model_serializes_snake_case():
+    inv = DataSourcesInventoryOut(
+        sources=[
+            SourceDescriptorOut(
+                id="yfinance", display_name="Yahoo Finance", domain="market_data",
+                role="primary", requires=None, configured=True, probeable=True,
+                canary_market="us", note=None, last_probe=None,
+            )
+        ]
+    )
+    payload = inv.model_dump()
+    assert payload["sources"][0]["display_name"] == "Yahoo Finance"
+    assert payload["sources"][0]["last_probe"] is None
+
+
+def test_probe_result_model():
+    r = ProbeResultOut(id="stooq", status="ok", latency_ms=12.0, detail="1 bar", sample={"x": 1}, error=None)
+    assert r.model_dump()["status"] == "ok"

--- a/tests/api/test_datasources_router.py
+++ b/tests/api/test_datasources_router.py
@@ -1,0 +1,26 @@
+from fastapi.testclient import TestClient
+
+from api.main import app
+
+client = TestClient(app)
+
+
+def test_get_inventory():
+    resp = client.get("/api/datasources")
+    assert resp.status_code == 200
+    body = resp.json()
+    ids = {s["id"] for s in body["sources"]}
+    assert "yfinance" in ids
+    assert any(s["domain"] == "intelligence" for s in body["sources"])
+
+
+def test_get_events_empty_or_list():
+    resp = client.get("/api/datasources/events")
+    assert resp.status_code == 200
+    assert "events" in resp.json()
+
+
+def test_probe_unknown_id():
+    resp = client.post("/api/datasources/nope/probe")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "not_configured"

--- a/tests/api/test_datasources_service.py
+++ b/tests/api/test_datasources_service.py
@@ -1,0 +1,44 @@
+from api.services.datasources_service import DatasourcesService
+from swing_screener.data.source_health import SourceDescriptor, ProbeResult
+
+
+def test_inventory_includes_market_fundamentals_intelligence():
+    svc = DatasourcesService()
+    ids = {d.id for d in svc.inventory()}
+    assert {"yfinance", "stooq", "alpaca"} <= ids               # market
+    assert {"sec_edgar", "yfinance_fundamentals", "finnhub"} <= ids  # fundamentals + enrichment
+    # the 6 intelligence catalyst sources, listed but not probeable
+    intel = [d for d in svc.inventory() if d.domain == "intelligence"]
+    assert len(intel) == 6
+    assert all(d.probeable is False for d in intel)
+    assert all(d.note for d in intel)
+
+
+def test_probe_one_unknown_id_returns_not_configured():
+    svc = DatasourcesService()
+    r = svc.probe_one("does_not_exist")
+    assert r.status == "not_configured"
+
+
+def test_probe_one_routes_to_provider(monkeypatch):
+    svc = DatasourcesService()
+    monkeypatch.setattr(
+        "swing_screener.data.providers.yfinance_provider.YfinanceProvider.probe",
+        classmethod(lambda cls, canary: ProbeResult(id="yfinance", status="ok", latency_ms=1.0)),
+    )
+    r = svc.probe_one("yfinance")
+    assert r.status == "ok"
+
+
+def test_probe_all_runs_each_probeable(monkeypatch):
+    svc = DatasourcesService()
+    calls = []
+
+    def fake_probe_one(source_id):
+        calls.append(source_id)
+        return ProbeResult(id=source_id, status="ok")
+
+    monkeypatch.setattr(svc, "probe_one", fake_probe_one)
+    results = svc.probe_all()
+    probeable_ids = {d.id for d in svc.inventory() if d.probeable}
+    assert {r.id for r in results} == probeable_ids

--- a/tests/api/test_datasources_service.py
+++ b/tests/api/test_datasources_service.py
@@ -1,5 +1,22 @@
 from api.services.datasources_service import DatasourcesService
 from swing_screener.data.source_health import SourceDescriptor, ProbeResult
+from swing_screener.settings import get_settings_manager
+
+
+def test_probe_canary_present_in_defaults_yaml():
+    """Verify probe_canary symbols are present in defaults.yaml (not just fallback)."""
+    defaults = get_settings_manager().load_defaults_document()
+    pc = defaults.get("low_level", {}).get("data_providers", {}).get("probe_canary", {})
+    assert pc.get("us") == "AAPL"
+    assert pc.get("eu") == "ASML.AS"
+
+
+def test_canary_map_reads_defaults():
+    """Verify _canary_map() returns expected symbols from config or fallback."""
+    svc = DatasourcesService()
+    m = svc._canary_map()
+    assert m["us"] == "AAPL"
+    assert m["eu"] == "ASML.AS"
 
 
 def test_inventory_includes_market_fundamentals_intelligence():

--- a/tests/data/test_fallback_events.py
+++ b/tests/data/test_fallback_events.py
@@ -1,0 +1,56 @@
+from swing_screener.data.source_health import (
+    FallbackEventRing,
+    FallbackEvent,
+    record_fallback,
+    recent_events,
+    reset_fallback_events,
+)
+
+
+def test_ring_is_bounded_and_newest_first():
+    ring = FallbackEventRing(capacity=3)
+    for i in range(5):
+        ring.record(
+            FallbackEvent(
+                ts=f"2026-06-24T10:00:0{i}+00:00",
+                domain="market_data",
+                from_provider="yfinance",
+                reason=f"r{i}",
+                fell_back_to="stooq",
+            )
+        )
+    items = ring.recent()
+    assert len(items) == 3                       # bounded to capacity
+    assert [e.reason for e in items] == ["r4", "r3", "r2"]  # newest first
+
+
+def test_recent_events_respects_limit():
+    ring = FallbackEventRing(capacity=10)
+    for i in range(4):
+        ring.record(
+            FallbackEvent(
+                ts=f"2026-06-24T10:00:0{i}+00:00",
+                domain="market_data",
+                from_provider="yfinance",
+                reason=f"r{i}",
+            )
+        )
+    assert len(ring.recent(limit=2)) == 2
+
+
+def test_module_record_and_reset():
+    reset_fallback_events()
+    record_fallback(
+        domain="fundamentals",
+        from_provider="sec_edgar",
+        reason="provider raised",
+        fell_back_to="yfinance",
+        tickers=["AAPL"],
+    )
+    events = recent_events()
+    assert len(events) == 1
+    assert events[0].from_provider == "sec_edgar"
+    assert events[0].tickers == ["AAPL"]
+    assert events[0].ts  # auto-stamped, non-empty
+    reset_fallback_events()
+    assert recent_events() == []

--- a/tests/data/test_provider_diagnostics.py
+++ b/tests/data/test_provider_diagnostics.py
@@ -1,0 +1,66 @@
+import pandas as pd
+import pytest
+
+from swing_screener.data.providers.yfinance_provider import YfinanceProvider
+from swing_screener.data.providers.stooq_provider import StooqDataProvider
+from swing_screener.data.providers.alpaca_provider import AlpacaDataProvider
+from swing_screener.data.source_health import SourceDescriptor, ProbeResult
+
+
+def test_yfinance_describe_static():
+    d = YfinanceProvider.describe()
+    assert isinstance(d, SourceDescriptor)
+    assert d.id == "yfinance"
+    assert d.domain == "market_data"
+    assert d.role == "primary"
+    assert d.configured is True
+    assert d.probeable is True
+
+
+def test_stooq_describe_static():
+    d = StooqDataProvider.describe()
+    assert d.id == "stooq"
+    assert d.role == "fallback"
+    assert d.canary_market == "eu"
+
+
+def test_alpaca_describe_not_configured_without_keys(monkeypatch):
+    monkeypatch.delenv("ALPACA_API_KEY", raising=False)
+    monkeypatch.delenv("ALPACA_SECRET_KEY", raising=False)
+    d = AlpacaDataProvider.describe()
+    assert d.id == "alpaca"
+    assert d.configured is False
+    assert d.requires == "ALPACA_API_KEY"
+
+
+def test_alpaca_probe_not_configured_returns_status(monkeypatch):
+    monkeypatch.delenv("ALPACA_API_KEY", raising=False)
+    monkeypatch.delenv("ALPACA_SECRET_KEY", raising=False)
+    r = AlpacaDataProvider.probe("AAPL")
+    assert isinstance(r, ProbeResult)
+    assert r.status == "not_configured"
+
+
+def test_yfinance_probe_ok_when_data(monkeypatch):
+    df = pd.DataFrame(
+        {("Close", "AAPL"): [100.0, 101.0]},
+        index=pd.to_datetime(["2026-06-22", "2026-06-23"]),
+    )
+    df.columns = pd.MultiIndex.from_tuples(df.columns)
+    monkeypatch.setattr(
+        "swing_screener.data.providers.yfinance_provider.YfinanceProvider.fetch_ohlcv",
+        lambda self, tickers, start_date, end_date, interval="1d": df,
+    )
+    r = YfinanceProvider.probe("AAPL")
+    assert r.status == "ok"
+    assert r.latency_ms is not None
+    assert r.sample["last_close"] == 101.0
+
+
+def test_yfinance_probe_down_on_empty(monkeypatch):
+    monkeypatch.setattr(
+        "swing_screener.data.providers.yfinance_provider.YfinanceProvider.fetch_ohlcv",
+        lambda self, tickers, start_date, end_date, interval="1d": pd.DataFrame(),
+    )
+    r = YfinanceProvider.probe("AAPL")
+    assert r.status == "down"

--- a/tests/data/test_provider_diagnostics.py
+++ b/tests/data/test_provider_diagnostics.py
@@ -64,3 +64,28 @@ def test_yfinance_probe_down_on_empty(monkeypatch):
     )
     r = YfinanceProvider.probe("AAPL")
     assert r.status == "down"
+
+
+def test_stooq_probe_ok_when_data(monkeypatch):
+    df = pd.DataFrame(
+        {("Close", "ASML.AS"): [700.0, 710.0]},
+        index=pd.to_datetime(["2026-06-22", "2026-06-23"]),
+    )
+    df.columns = pd.MultiIndex.from_tuples(df.columns)
+    monkeypatch.setattr(
+        "swing_screener.data.providers.stooq_provider.StooqDataProvider.fetch_ohlcv",
+        lambda self, tickers, start_date, end_date, interval="1d": df,
+    )
+    r = StooqDataProvider.probe("ASML.AS")
+    assert r.status == "ok"
+    assert r.latency_ms is not None
+    assert r.sample["last_close"] == 710.0
+
+
+def test_stooq_probe_down_on_empty(monkeypatch):
+    monkeypatch.setattr(
+        "swing_screener.data.providers.stooq_provider.StooqDataProvider.fetch_ohlcv",
+        lambda self, tickers, start_date, end_date, interval="1d": pd.DataFrame(),
+    )
+    r = StooqDataProvider.probe("ASML.AS")
+    assert r.status == "down"

--- a/tests/data/test_source_health.py
+++ b/tests/data/test_source_health.py
@@ -2,6 +2,9 @@ from swing_screener.data.source_health import (
     DataSourceHealth,
     DataSourceProvenance,
     merge_source_health,
+    SourceDescriptor,
+    ProbeResult,
+    FallbackEvent,
 )
 from swing_screener.data.providers.alpaca_provider import AlpacaDataProvider
 from swing_screener.data.providers.base import MarketDataProvider
@@ -118,3 +121,54 @@ def test_market_data_provider_quality_defaults_are_explicit(tmp_path):
     assert alpaca_health["quality_score"] == 0.75
     assert alpaca_health["delay_policy"] == "provider_plan_dependent"
     assert alpaca_health["warnings"] == ["paper_or_basic_plan_may_be_limited"]
+
+
+def test_source_descriptor_to_dict_roundtrip():
+    d = SourceDescriptor(
+        id="yfinance",
+        display_name="Yahoo Finance",
+        domain="market_data",
+        role="primary",
+        requires=None,
+        configured=True,
+        probeable=True,
+        canary_market="us",
+        note=None,
+    )
+    payload = d.to_dict()
+    assert payload["id"] == "yfinance"
+    assert payload["domain"] == "market_data"
+    assert payload["role"] == "primary"
+    assert payload["configured"] is True
+    assert payload["canary_market"] == "us"
+
+
+def test_probe_result_to_dict():
+    r = ProbeResult(
+        id="stooq",
+        status="ok",
+        latency_ms=42.5,
+        detail="1 bar",
+        sample={"last_close": 123.4, "last_date": "2026-06-23"},
+        error=None,
+    )
+    payload = r.to_dict()
+    assert payload["status"] == "ok"
+    assert payload["latency_ms"] == 42.5
+    assert payload["sample"]["last_close"] == 123.4
+
+
+def test_fallback_event_to_dict():
+    e = FallbackEvent(
+        ts="2026-06-24T10:00:00+00:00",
+        domain="market_data",
+        from_provider="yfinance",
+        reason="bulk download empty",
+        fell_back_to="stooq",
+        tickers=["AAPL", "MSFT"],
+        stale_asof=None,
+    )
+    payload = e.to_dict()
+    assert payload["from_provider"] == "yfinance"
+    assert payload["fell_back_to"] == "stooq"
+    assert payload["tickers"] == ["AAPL", "MSFT"]

--- a/tests/data/test_yfinance_fallback_events.py
+++ b/tests/data/test_yfinance_fallback_events.py
@@ -17,3 +17,57 @@ def test_stooq_fallback_records_event(monkeypatch, tmp_path):
 
     events = recent_events()
     assert any(e.from_provider == "yfinance" and e.fell_back_to == "stooq" for e in events)
+
+
+def test_no_stale_cache_event_when_only_fresh_cache_served(monkeypatch, tmp_path):
+    """
+    Regression: the first stale-cache site must NOT fire when the stale loop adds nothing.
+
+    Setup:
+    - AAPL is fully cached (fresh): lands in cached_frames during the first loop.
+    - MSFT is a miss with no stale fallback at all.
+    - All download paths return empty DataFrames, so the all-empty branch executes.
+    - The stale loop iterates stale_fallback (empty for MSFT, absent for AAPL) -> appends nothing.
+    - Pre-fix: `if cached_frames:` fires because AAPL is already there -> false positive.
+    - Post-fix: `if len(cached_frames) > _pre_stale_len_1:` is False -> no event.
+    """
+    reset_fallback_events()
+    start_date = "2026-06-01"
+    end_date = "2026-06-10"
+    end_for_coverage = "2026-06-11"  # exclusive end used by _store_per_ticker_cache
+
+    provider = YfinanceProvider(cache_dir=str(tmp_path))
+
+    # Build a real fresh-cache entry for AAPL.
+    aapl_df = pd.DataFrame(
+        {("Close", "AAPL"): [150.0, 151.0], ("Open", "AAPL"): [149.0, 150.0]},
+        index=pd.to_datetime(["2026-06-02", "2026-06-03"]),
+    )
+    aapl_df.columns = pd.MultiIndex.from_tuples(aapl_df.columns)
+    provider._store_per_ticker_cache(aapl_df, ["AAPL"], start_date, end_for_coverage)
+
+    # Disable all live-download paths.
+    monkeypatch.setattr(provider, "_download_batch", lambda *a, **kw: pd.DataFrame())
+    monkeypatch.setattr(provider, "_download_sequential", lambda *a, **kw: pd.DataFrame())
+    monkeypatch.setattr(provider, "_fetch_stooq_fallback", lambda *a, **kw: pd.DataFrame())
+
+    # Call with AAPL (fresh cache hit) + MSFT (miss, no stale fallback).
+    # Should succeed because AAPL frame is in cached_frames.
+    result = provider._fetch_ohlcv_with_config(
+        ["AAPL", "MSFT"],
+        start_date,
+        end_for_coverage,
+        use_cache=True,
+        force_refresh=False,
+        allow_cache_fallback_on_error=True,
+    )
+
+    assert not result.empty, "Expected AAPL data in result"
+
+    stale_events = [
+        e for e in recent_events()
+        if e.fell_back_to == "stale_cache"
+    ]
+    assert stale_events == [], (
+        f"Expected no stale-cache events but got: {stale_events}"
+    )

--- a/tests/data/test_yfinance_fallback_events.py
+++ b/tests/data/test_yfinance_fallback_events.py
@@ -1,0 +1,19 @@
+import pandas as pd
+
+from swing_screener.data.providers.yfinance_provider import YfinanceProvider
+from swing_screener.data.source_health import recent_events, reset_fallback_events
+
+
+def test_stooq_fallback_records_event(monkeypatch, tmp_path):
+    reset_fallback_events()
+    provider = YfinanceProvider(cache_dir=str(tmp_path))
+
+    # Force the stooq fallback path: stooq raises -> event recorded.
+    def boom(*args, **kwargs):
+        raise RuntimeError("stooq down")
+
+    monkeypatch.setattr(provider._stooq_provider, "fetch_ohlcv", boom)
+    provider._fetch_stooq_fallback(["ASML.AS"], "2026-06-01", "2026-06-10", interval="1d")
+
+    events = recent_events()
+    assert any(e.from_provider == "yfinance" and e.fell_back_to == "stooq" for e in events)

--- a/tests/test_fundamentals_diagnostics.py
+++ b/tests/test_fundamentals_diagnostics.py
@@ -1,0 +1,40 @@
+from swing_screener.fundamentals.providers.sec_edgar import SecEdgarFundamentalsProvider
+from swing_screener.fundamentals.providers.yfinance import YfinanceFundamentalsProvider
+from swing_screener.fundamentals.providers.degiro import DegiroFundamentalsProvider
+from swing_screener.fundamentals.finnhub_client import FinnhubEnrichmentClient
+from swing_screener.data.source_health import SourceDescriptor, ProbeResult
+
+
+def test_sec_edgar_describe():
+    d = SecEdgarFundamentalsProvider.describe()
+    assert d.id == "sec_edgar"
+    assert d.domain == "fundamentals"
+    assert d.role == "primary"
+
+
+def test_yfinance_fundamentals_describe():
+    d = YfinanceFundamentalsProvider.describe()
+    assert d.id == "yfinance_fundamentals"
+    assert d.role == "fallback"
+
+
+def test_degiro_describe_configured_reflects_availability():
+    d = DegiroFundamentalsProvider.describe()
+    assert d.id == "degiro"
+    assert isinstance(d.configured, bool)
+    assert d.probeable == d.configured
+
+
+def test_finnhub_describe_not_configured_without_key(monkeypatch):
+    monkeypatch.delenv("FINNHUB_API_KEY", raising=False)
+    d = FinnhubEnrichmentClient.describe()
+    assert d.id == "finnhub"
+    assert d.role == "enrichment"
+    assert d.configured is False
+    assert d.requires == "FINNHUB_API_KEY"
+
+
+def test_finnhub_probe_not_configured_without_key(monkeypatch):
+    monkeypatch.delenv("FINNHUB_API_KEY", raising=False)
+    r = FinnhubEnrichmentClient.probe("AAPL")
+    assert r.status == "not_configured"

--- a/tests/test_fundamentals_service_fallback_events.py
+++ b/tests/test_fundamentals_service_fallback_events.py
@@ -1,0 +1,36 @@
+from swing_screener.fundamentals.service import FundamentalsAnalysisService
+from swing_screener.fundamentals.config import FundamentalsConfig
+from swing_screener.data.source_health import recent_events, reset_fallback_events
+
+
+class _BoomProvider:
+    name = "sec_edgar"
+
+    def fetch_record(self, symbol):
+        raise RuntimeError("sec edgar 503")
+
+
+class _OkProvider:
+    name = "yfinance"
+
+    def fetch_record(self, symbol):
+        from swing_screener.fundamentals.models import ProviderFundamentalsRecord
+        return ProviderFundamentalsRecord(symbol=symbol, asof_date="2026-06-24", provider="yfinance")
+
+
+def test_provider_exception_records_fallback_event(monkeypatch, tmp_path):
+    reset_fallback_events()
+    service = FundamentalsAnalysisService()
+    monkeypatch.setattr(
+        service, "_providers_for", lambda cfg: [_BoomProvider(), _OkProvider()]
+    )
+    monkeypatch.setattr(service._storage, "load_snapshot", lambda s: None)
+    monkeypatch.setattr(service._storage, "save_snapshot", lambda s: None)
+
+    service.get_snapshot("AAPL", cfg=FundamentalsConfig())
+
+    events = recent_events()
+    assert any(
+        e.domain == "fundamentals" and e.from_provider == "sec_edgar" and e.fell_back_to == "yfinance"
+        for e in events
+    )

--- a/web-ui/docs/WEB_UI_GUIDE.md
+++ b/web-ui/docs/WEB_UI_GUIDE.md
@@ -17,6 +17,7 @@ Daily trading workflow through the Swing Screener web interface.
 | Universes | `/universes` | Universe management, manual refresh, benchmark, symbol discovery with ad-hoc screener run (row click opens symbol detail modal) |
 | Strategy | `/strategy` | Strategy CRUD, activation, and validation |
 | Onboarding | `/onboarding` | Setup guide for new users |
+| Data Sources | `/datasources` | Data source diagnostics: inventory of all sources with configured/probeable status, per-source Test button (fires a live canary probe), Test All (concurrent probe of all probeable sources), and a fallback event feed |
 
 ## Feature Directory Map
 
@@ -37,6 +38,7 @@ Each domain has a directory under `web-ui/src/features/<domain>/` with `api.ts` 
 | `features/strategy` | Strategy | Strategy CRUD and activation |
 | `features/universes` | Universes | Universe list, detail, refresh, benchmark |
 | `features/backtest` | Today (canvas Backtest tab) | Event-study run (202+poll), trade ledger + metrics, snake_case→camelCase transform. Run inline per-symbol from the analysis canvas Backtest tab (`components/domain/workspace/SymbolBacktestTab`, locked to the selected symbol); results render via `components/domain/backtest/BacktestResults`. No standalone page |
+| `features/datasources` | Data Sources | Source inventory, per-source and bulk probe, fallback event feed |
 | `features/config` | (cross-cutting) | App config read/write |
 | `features/persistence` | (cross-cutting) | API vs localStorage mode toggle |
 

--- a/web-ui/src/App.tsx
+++ b/web-ui/src/App.tsx
@@ -16,6 +16,7 @@ const Today = lazy(() => import('./pages/Today'));
 const Book = lazy(() => import('./pages/Book'));
 const Universes = lazy(() => import('./pages/Universes'));
 const Calendar = lazy(() => import('./pages/Calendar'));
+const DataSources = lazy(() => import('./pages/DataSources'));
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -47,6 +48,7 @@ function App() {
                 <Route path="calendar" element={<ErrorBoundary><Calendar /></ErrorBoundary>} />
                 <Route path="book" element={<ErrorBoundary><Book /></ErrorBoundary>} />
                 <Route path="universes" element={<ErrorBoundary><Universes /></ErrorBoundary>} />
+                <Route path="datasources" element={<ErrorBoundary><DataSources /></ErrorBoundary>} />
 
                 {/* Strategy / settings — still accessible */}
                 <Route path="strategy" element={<ErrorBoundary><Strategy /></ErrorBoundary>} />

--- a/web-ui/src/components/domain/datasources/FallbackFeed.tsx
+++ b/web-ui/src/components/domain/datasources/FallbackFeed.tsx
@@ -1,0 +1,23 @@
+import { t } from '@/i18n/t';
+import type { FallbackEvent } from '@/features/datasources/types';
+
+export default function FallbackFeed({ events }: { events: FallbackEvent[] }) {
+  return (
+    <section className="rounded-lg border border-border bg-surface p-3">
+      <h2 className="text-sm font-medium text-foreground mb-2">{t('datasources.fallbacks.title')}</h2>
+      {events.length === 0 ? (
+        <p className="text-xs text-muted">{t('datasources.fallbacks.empty')}</p>
+      ) : (
+        <ul className="space-y-1">
+          {events.map((e, i) => (
+            <li key={`${e.ts}-${i}`} className="text-xs text-muted">
+              <span className="text-foreground">{e.fromProvider}</span>
+              {e.fellBackTo ? ` → ${e.fellBackTo}` : ''} · {e.reason}
+              {e.tickers.length ? ` · ${e.tickers.slice(0, 5).join(', ')}` : ''}
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/web-ui/src/components/domain/datasources/SourceCard.tsx
+++ b/web-ui/src/components/domain/datasources/SourceCard.tsx
@@ -1,0 +1,55 @@
+import { t } from '@/i18n/t';
+import { cn } from '@/utils/cn';
+import type { MessageKey } from '@/i18n/types';
+import type { DataSource } from '@/features/datasources/types';
+
+interface Props {
+  source: DataSource;
+  onTest: (id: string) => void;
+  testing: boolean;
+}
+
+const STATUS_KEY: Record<string, MessageKey> = {
+  ok: 'datasources.status.ok',
+  down: 'datasources.status.down',
+  not_configured: 'datasources.status.not_configured',
+};
+
+const STATUS_CLASS: Record<string, string> = {
+  ok: 'text-success',
+  down: 'text-danger',
+  not_configured: 'text-muted',
+};
+
+export default function SourceCard({ source, onTest, testing }: Props) {
+  const probe = source.lastProbe;
+  return (
+    <div className="rounded-lg border border-border bg-surface p-3 flex flex-col gap-2">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-sm font-medium text-foreground">{source.displayName}</span>
+        <span className="text-[11px] uppercase tracking-wide text-muted">{source.role}</span>
+      </div>
+      {source.note && <span className="text-xs text-muted">{source.note}</span>}
+      {!source.configured && !source.note && (
+        <span className="text-xs text-muted">{t('datasources.notConfigured')}</span>
+      )}
+      {probe && (
+        <span className={cn('text-xs', STATUS_CLASS[probe.status] ?? 'text-muted')}>
+          {t(STATUS_KEY[probe.status] ?? 'datasources.status.not_configured')}
+          {probe.latencyMs != null ? ` · ${Math.round(probe.latencyMs)}ms` : ''}
+          {probe.detail ? ` · ${probe.detail}` : ''}
+        </span>
+      )}
+      <div>
+        <button
+          type="button"
+          disabled={!source.probeable || testing}
+          onClick={() => onTest(source.id)}
+          className="text-xs font-medium text-primary disabled:text-muted disabled:cursor-not-allowed hover:underline"
+        >
+          {source.probeable ? (testing ? t('datasources.testing') : t('datasources.test')) : t('datasources.notProbeable')}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web-ui/src/components/layout/Sidebar.tsx
+++ b/web-ui/src/components/layout/Sidebar.tsx
@@ -5,6 +5,7 @@ import {
   BookMarked,
   Database,
   Settings2,
+  Activity,
 } from 'lucide-react';
 import { cn } from '@/utils/cn';
 import { t } from '@/i18n/t';
@@ -21,6 +22,7 @@ const primaryNav: NavigationItem[] = [
   { labelKey: 'sidebar.nav.calendar', href: '/calendar', icon: CalendarDays },
   { labelKey: 'sidebar.nav.book', href: '/book', icon: BookMarked },
   { labelKey: 'sidebar.nav.universes', href: '/universes', icon: Database },
+  { labelKey: 'sidebar.nav.datasources', href: '/datasources', icon: Activity },
 ];
 
 const settingsNav: NavigationItem = {

--- a/web-ui/src/features/datasources/api.ts
+++ b/web-ui/src/features/datasources/api.ts
@@ -1,0 +1,41 @@
+import { API_ENDPOINTS } from '@/lib/api';
+import { fetchJson } from '@/lib/fetchJson';
+import type {
+  DataSource,
+  DataSourcesInventoryAPI,
+  ProbeResult,
+  ProbeResultAPI,
+  FallbackEvent,
+  FallbackEventsAPI,
+} from './types';
+import { transformDataSource, transformProbeResult, transformFallbackEvent } from './types';
+
+export async function fetchDataSources(): Promise<DataSource[]> {
+  const data = await fetchJson<DataSourcesInventoryAPI>(API_ENDPOINTS.datasources, {
+    errorMessage: 'Failed to fetch data sources',
+  });
+  return (data.sources ?? []).map(transformDataSource);
+}
+
+export async function probeSource(id: string): Promise<ProbeResult> {
+  const data = await fetchJson<ProbeResultAPI>(API_ENDPOINTS.datasourceProbe(id), {
+    method: 'POST',
+    errorMessage: 'Failed to probe data source',
+  });
+  return transformProbeResult(data);
+}
+
+export async function probeAll(): Promise<ProbeResult[]> {
+  const data = await fetchJson<ProbeResultAPI[]>(API_ENDPOINTS.datasourcesProbeAll, {
+    method: 'POST',
+    errorMessage: 'Failed to probe data sources',
+  });
+  return (data ?? []).map(transformProbeResult);
+}
+
+export async function fetchFallbackEvents(): Promise<FallbackEvent[]> {
+  const data = await fetchJson<FallbackEventsAPI>(API_ENDPOINTS.datasourcesEvents, {
+    errorMessage: 'Failed to fetch fallback events',
+  });
+  return (data.events ?? []).map(transformFallbackEvent);
+}

--- a/web-ui/src/features/datasources/hooks.test.tsx
+++ b/web-ui/src/features/datasources/hooks.test.tsx
@@ -1,0 +1,50 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/features/datasources/api', () => ({
+  fetchDataSources: vi.fn(),
+  probeSource: vi.fn(),
+  probeAll: vi.fn(),
+  fetchFallbackEvents: vi.fn(),
+}));
+
+import * as api from '@/features/datasources/api';
+import { queryKeys } from '@/lib/queryKeys';
+import { useProbeSourceMutation } from '@/features/datasources/hooks';
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+}
+
+function createWrapper(queryClient: QueryClient) {
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe('datasources hooks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('probe mutation invalidates inventory', async () => {
+    const queryClient = createQueryClient();
+    const spy = vi.spyOn(queryClient, 'invalidateQueries');
+    vi.mocked(api.probeSource).mockResolvedValue({ id: 'yfinance', status: 'ok' });
+
+    const { result } = renderHook(() => useProbeSourceMutation(), {
+      wrapper: createWrapper(queryClient),
+    });
+    await act(async () => { await result.current.mutateAsync('yfinance'); });
+
+    expect(api.probeSource).toHaveBeenCalledWith('yfinance');
+    expect(spy).toHaveBeenCalledWith({ queryKey: queryKeys.datasources() });
+  });
+});

--- a/web-ui/src/features/datasources/hooks.ts
+++ b/web-ui/src/features/datasources/hooks.ts
@@ -1,0 +1,40 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { queryKeys } from '@/lib/queryKeys';
+import { fetchDataSources, fetchFallbackEvents, probeSource, probeAll } from './api';
+
+export function useDataSources() {
+  return useQuery({
+    queryKey: queryKeys.datasources(),
+    queryFn: fetchDataSources,
+    refetchOnWindowFocus: false,
+  });
+}
+
+export function useFallbackEvents() {
+  return useQuery({
+    queryKey: queryKeys.datasourcesEvents(),
+    queryFn: fetchFallbackEvents,
+    refetchInterval: 15000,
+    refetchOnWindowFocus: false,
+  });
+}
+
+export function useProbeSourceMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => probeSource(id),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: queryKeys.datasources() });
+    },
+  });
+}
+
+export function useProbeAllMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => probeAll(),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: queryKeys.datasources() });
+    },
+  });
+}

--- a/web-ui/src/features/datasources/types.test.ts
+++ b/web-ui/src/features/datasources/types.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { transformDataSource, transformFallbackEvent } from './types';
+
+describe('datasources transforms', () => {
+  it('maps snake_case source to camelCase', () => {
+    const out = transformDataSource({
+      id: 'yfinance',
+      display_name: 'Yahoo Finance',
+      domain: 'market_data',
+      role: 'primary',
+      requires: null,
+      configured: true,
+      probeable: true,
+      canary_market: 'us',
+      note: null,
+      last_probe: { id: 'yfinance', status: 'ok', latency_ms: 12, detail: '1 bar', sample: null, error: null },
+    });
+    expect(out.displayName).toBe('Yahoo Finance');
+    expect(out.lastProbe?.status).toBe('ok');
+    expect(out.lastProbe?.latencyMs).toBe(12);
+  });
+
+  it('maps fallback event', () => {
+    const out = transformFallbackEvent({
+      ts: '2026-06-24T10:00:00+00:00',
+      domain: 'market_data',
+      from_provider: 'yfinance',
+      reason: 'empty',
+      fell_back_to: 'stooq',
+      tickers: ['AAPL'],
+      stale_asof: null,
+    });
+    expect(out.fromProvider).toBe('yfinance');
+    expect(out.fellBackTo).toBe('stooq');
+  });
+});

--- a/web-ui/src/features/datasources/types.ts
+++ b/web-ui/src/features/datasources/types.ts
@@ -1,0 +1,112 @@
+export type ProbeStatus = 'ok' | 'down' | 'not_configured';
+export type SourceRole = 'primary' | 'fallback' | 'enrichment';
+
+export interface ProbeResultAPI {
+  id: string;
+  status: ProbeStatus;
+  latency_ms: number | null;
+  detail: string | null;
+  sample: Record<string, unknown> | null;
+  error: string | null;
+}
+
+export interface DataSourceAPI {
+  id: string;
+  display_name: string;
+  domain: string;
+  role: SourceRole;
+  requires: string | null;
+  configured: boolean;
+  probeable: boolean;
+  canary_market: string | null;
+  note: string | null;
+  last_probe: ProbeResultAPI | null;
+}
+
+export interface DataSourcesInventoryAPI {
+  sources: DataSourceAPI[];
+}
+
+export interface FallbackEventAPI {
+  ts: string;
+  domain: string;
+  from_provider: string;
+  reason: string;
+  fell_back_to: string | null;
+  tickers: string[];
+  stale_asof: string | null;
+}
+
+export interface FallbackEventsAPI {
+  events: FallbackEventAPI[];
+}
+
+export interface ProbeResult {
+  id: string;
+  status: ProbeStatus;
+  latencyMs?: number;
+  detail?: string;
+  sample?: Record<string, unknown>;
+  error?: string;
+}
+
+export interface DataSource {
+  id: string;
+  displayName: string;
+  domain: string;
+  role: SourceRole;
+  requires?: string;
+  configured: boolean;
+  probeable: boolean;
+  canaryMarket?: string;
+  note?: string;
+  lastProbe?: ProbeResult;
+}
+
+export interface FallbackEvent {
+  ts: string;
+  domain: string;
+  fromProvider: string;
+  reason: string;
+  fellBackTo?: string;
+  tickers: string[];
+  staleAsof?: string;
+}
+
+export function transformProbeResult(api: ProbeResultAPI): ProbeResult {
+  return {
+    id: api.id,
+    status: api.status,
+    latencyMs: api.latency_ms ?? undefined,
+    detail: api.detail ?? undefined,
+    sample: api.sample ?? undefined,
+    error: api.error ?? undefined,
+  };
+}
+
+export function transformDataSource(api: DataSourceAPI): DataSource {
+  return {
+    id: api.id,
+    displayName: api.display_name,
+    domain: api.domain,
+    role: api.role,
+    requires: api.requires ?? undefined,
+    configured: api.configured,
+    probeable: api.probeable,
+    canaryMarket: api.canary_market ?? undefined,
+    note: api.note ?? undefined,
+    lastProbe: api.last_probe ? transformProbeResult(api.last_probe) : undefined,
+  };
+}
+
+export function transformFallbackEvent(api: FallbackEventAPI): FallbackEvent {
+  return {
+    ts: api.ts,
+    domain: api.domain,
+    fromProvider: api.from_provider,
+    reason: api.reason,
+    fellBackTo: api.fell_back_to ?? undefined,
+    tickers: api.tickers ?? [],
+    staleAsof: api.stale_asof ?? undefined,
+  };
+}

--- a/web-ui/src/i18n/messages.en.ts
+++ b/web-ui/src/i18n/messages.en.ts
@@ -574,6 +574,7 @@ export const messagesEn = {
       book: 'Book',
       universes: 'Universes',
       settings: 'Settings',
+      datasources: 'Data Sources',
     },
     activeStrategy: 'Active Strategy',
     loadingStrategies: 'Loading strategies...',
@@ -587,6 +588,29 @@ export const messagesEn = {
   },
   analysis: {
     prepareOrder: 'Prepare order',
+  },
+  datasources: {
+    title: 'Data Sources',
+    subtitle: 'Inventory, health probes, and recent fallbacks.',
+    test: 'Test',
+    testAll: 'Test all',
+    testing: 'Testing…',
+    notConfigured: 'Not configured',
+    notProbeable: 'No probe',
+    fallbacks: {
+      title: 'Recent fallbacks',
+      empty: 'No fallbacks recorded since the server started.',
+    },
+    domains: {
+      market_data: 'Market data',
+      fundamentals: 'Fundamentals',
+      intelligence: 'Intelligence',
+    },
+    status: {
+      ok: 'OK',
+      down: 'Down',
+      not_configured: 'Not configured',
+    },
   },
   workspacePage: {
     title: 'Workspace',

--- a/web-ui/src/lib/api.ts
+++ b/web-ui/src/lib/api.ts
@@ -82,6 +82,12 @@ export const API_ENDPOINTS = {
 
   // Market data
   marketDataCandles: (ticker: string) => `/api/market-data/${encodeURIComponent(ticker)}/candles`,
+
+  // Data sources
+  datasources: '/api/datasources',
+  datasourceProbe: (id: string) => `/api/datasources/${encodeURIComponent(id)}/probe`,
+  datasourcesProbeAll: '/api/datasources/probe',
+  datasourcesEvents: '/api/datasources/events',
 } as const;
 
 // Helper to build full URL

--- a/web-ui/src/lib/queryKeys.ts
+++ b/web-ui/src/lib/queryKeys.ts
@@ -31,4 +31,6 @@ export const queryKeys = {
     ['calendar-events', daysAhead ?? 30] as const,
   openPositionsIntelligence: () => ['openPositionsIntelligence'] as const,
   tickerCandles: (ticker?: string | null) => ['ticker-candles', ticker ?? null] as const,
+  datasources: () => ['datasources'] as const,
+  datasourcesEvents: () => ['datasources', 'events'] as const,
 };

--- a/web-ui/src/pages/DataSources.test.tsx
+++ b/web-ui/src/pages/DataSources.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { screen } from '@testing-library/react';
+import { server } from '@/test/mocks/server';
+import { renderWithProviders } from '@/test/utils';
+import { t } from '@/i18n/t';
+import DataSources from './DataSources';
+
+describe('DataSources page', () => {
+  it('renders sources grouped by domain', async () => {
+    server.use(
+      http.get('*/api/datasources', () =>
+        HttpResponse.json({
+          sources: [
+            { id: 'yfinance', display_name: 'Yahoo Finance', domain: 'market_data', role: 'primary',
+              requires: null, configured: true, probeable: true, canary_market: 'us', note: null, last_probe: null },
+            { id: 'company_ir_rss', display_name: 'Company IR RSS', domain: 'intelligence', role: 'primary',
+              requires: null, configured: false, probeable: false, canary_market: null,
+              note: 'declared — no runtime adapter', last_probe: null },
+          ],
+        }),
+      ),
+      http.get('*/api/datasources/events', () => HttpResponse.json({ events: [] })),
+    );
+
+    renderWithProviders(<DataSources />, { route: '/datasources' });
+
+    expect(await screen.findByText('Yahoo Finance')).toBeInTheDocument();
+    expect(await screen.findByText('Company IR RSS')).toBeInTheDocument();
+    expect(screen.getByText(t('datasources.title'))).toBeInTheDocument();
+  });
+});

--- a/web-ui/src/pages/DataSources.tsx
+++ b/web-ui/src/pages/DataSources.tsx
@@ -1,0 +1,68 @@
+import { useCallback, useState } from 'react';
+import { t } from '@/i18n/t';
+import type { MessageKey } from '@/i18n/types';
+import { useDataSources, useFallbackEvents, useProbeSourceMutation, useProbeAllMutation } from '@/features/datasources/hooks';
+import SourceCard from '@/components/domain/datasources/SourceCard';
+import FallbackFeed from '@/components/domain/datasources/FallbackFeed';
+import type { DataSource } from '@/features/datasources/types';
+
+const DOMAIN_ORDER = ['market_data', 'fundamentals', 'intelligence'] as const;
+
+const DOMAIN_KEY: Record<string, MessageKey> = {
+  market_data: 'datasources.domains.market_data',
+  fundamentals: 'datasources.domains.fundamentals',
+  intelligence: 'datasources.domains.intelligence',
+};
+
+export default function DataSources() {
+  const sourcesQuery = useDataSources();
+  const eventsQuery = useFallbackEvents();
+  const probeOne = useProbeSourceMutation();
+  const probeAll = useProbeAllMutation();
+  const [testingId, setTestingId] = useState<string | null>(null);
+
+  const onTest = useCallback((id: string) => {
+    setTestingId(id);
+    probeOne.mutate(id, { onSettled: () => setTestingId(null) });
+  }, [probeOne]);
+
+  const sources = sourcesQuery.data ?? [];
+  const grouped = DOMAIN_ORDER.map((domain) => ({
+    domain,
+    items: sources.filter((s: DataSource) => s.domain === domain),
+  })).filter((g) => g.items.length > 0);
+
+  return (
+    <div className="flex flex-col h-full overflow-y-auto p-4 gap-4">
+      <header className="flex items-center justify-between">
+        <div>
+          <h1 className="text-base font-semibold text-foreground">{t('datasources.title')}</h1>
+          <p className="text-xs text-muted">{t('datasources.subtitle')}</p>
+        </div>
+        <button
+          type="button"
+          onClick={() => probeAll.mutate()}
+          disabled={probeAll.isPending}
+          className="text-xs font-medium text-primary hover:underline disabled:text-muted"
+        >
+          {probeAll.isPending ? t('datasources.testing') : t('datasources.testAll')}
+        </button>
+      </header>
+
+      {grouped.map((group) => (
+        <section key={group.domain}>
+          <h2 className="text-xs uppercase tracking-wide text-muted mb-2">
+            {t(DOMAIN_KEY[group.domain] ?? 'datasources.domains.market_data')}
+          </h2>
+          <div className="grid grid-cols-3 gap-2 md:grid-cols-1">
+            {group.items.map((s) => (
+              <SourceCard key={s.id} source={s} onTest={onTest} testing={testingId === s.id} />
+            ))}
+          </div>
+        </section>
+      ))}
+
+      <FallbackFeed events={eventsQuery.data ?? []} />
+    </div>
+  );
+}

--- a/web-ui/src/pages/DataSources.tsx
+++ b/web-ui/src/pages/DataSources.tsx
@@ -54,7 +54,7 @@ export default function DataSources() {
           <h2 className="text-xs uppercase tracking-wide text-muted mb-2">
             {t(DOMAIN_KEY[group.domain] ?? 'datasources.domains.market_data')}
           </h2>
-          <div className="grid grid-cols-3 gap-2 md:grid-cols-1">
+          <div className="grid grid-cols-1 gap-2 md:grid-cols-3">
             {group.items.map((s) => (
               <SourceCard key={s.id} source={s} onTest={onTest} testing={testingId === s.id} />
             ))}

--- a/web-ui/src/test/mocks/handlers.ts
+++ b/web-ui/src/test/mocks/handlers.ts
@@ -995,6 +995,12 @@ export const handlers = [
     })
   }),
 
+  // Datasources endpoints
+  http.get(`${API_BASE_URL}/api/datasources`, () => HttpResponse.json({ sources: [] })),
+  http.get(`${API_BASE_URL}/api/datasources/events`, () => HttpResponse.json({ events: [] })),
+  http.post(`${API_BASE_URL}/api/datasources/probe`, () => HttpResponse.json([])),
+  http.post(`${API_BASE_URL}/api/datasources/:id/probe`, () => HttpResponse.json({ id: 'x', status: 'ok', latency_ms: 1, detail: null, sample: null, error: null })),
+
   // Fundamentals snapshot mock
   http.get(`${API_BASE_URL}/api/fundamentals/snapshot/:symbol`, ({ params }) => {
     const symbol = String(params.symbol ?? 'AAPL').toUpperCase()


### PR DESCRIPTION
  Adds a read-only "Data Sources" page (route /datasources) plus the API and core
  plumbing behind it, so we can see which data providers exist, what each is for,
  and whether they actually work, instead of guessing from WARNING logs.

  Three things it gives you:
  - Inventory: every configured source, its domain (market_data / fundamentals /
    intelligence), role (primary / fallback / enrichment) and whether it's
    configured (key/pkg present).
  - Runtime fallback transparency: the silent fallback chains (yfinance to stooq,
    to stale cache, and the fundamentals provider loop) now also push a structured
    event into an in-memory bounded ring, surfaced as a "recent fallbacks" feed.
    The existing WARNING logs are untouched, the events are added alongside them.
  - Active probes: a per-source Test button (and Test all, run concurrently) that
    fires a tiny real canary request and reports ok / down / not_configured +
    latency + a small sample.

  The diagnostics contract is a DiagnosableSource protocol (describe() / probe() as
  classmethods) implemented on each provider, so it's self-contained per provider
  and unconfigured ones (alpaca without keys, degiro without the pkg) can still be
  described without instantiating them. Sources are enumerated in one place,
  _PROBEABLE in api/services/datasources_service.py, so adding a provider is a
  single drop-in (see the new add-a-provider guide in the providers READMEs). To
  make this work without alpaca-py installed, the alpaca SDK imports were moved to
  lazy/local imports.

  Everything is read-only: probes only do outbound reads, no config is ever
  mutated. Fallback events are in-memory only (reset on restart), no schema change.

  Note on the intelligence catalyst sources: the 6 configured ones
  (yahoo_finance, earnings_calendar, sec_edgar, company_ir_rss,
  exchange_announcements, financial_news_rss) are listed inventory-only with
  probeable=false, because 5 of 6 have no runtime adapter and the actual catalyst
  gathering goes through the web_search path. They're shown honestly as "declared,
  no runtime adapter" rather than faking a green status. Wiring them up to enrich
  the AI context is a separate follow-up.

  Canary symbols are configurable under low_level.data_providers.probe_canary
  (defaults AAPL / ASML.AS).

  Reviewers: worth a closer look at the alpaca lazy-import refactor (that fetch
  still works without regressions) and the stale-cache event gating in
  yfinance_provider.py.