### PR TITLE
Clear deferred intelligence cleanup: strict LLM enums, self-healing metrics, test gaps

### DIFF
--- a/src/swing_screener/intelligence/metrics.py
+++ b/src/swing_screener/intelligence/metrics.py
@@ -24,8 +24,14 @@ def record_analysis_metrics(
     root = metrics_root or data_dir() / "intelligence"
     path = root / "intelligence_metrics.json"
     try:
-        existing = json.loads(path.read_text()) if path.exists() else []
-        if not isinstance(existing, list):
+        if path.exists():
+            try:
+                existing = json.loads(path.read_text())
+                if not isinstance(existing, list):
+                    existing = []
+            except (OSError, ValueError):
+                existing = []
+        else:
             existing = []
         existing.append({"ts": datetime.now(timezone.utc).isoformat(), "ticker": ticker.upper(), "tokens": tokens})
         path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/swing_screener/intelligence/models.py
+++ b/src/swing_screener/intelligence/models.py
@@ -8,6 +8,8 @@ from pydantic import BaseModel, Field, field_validator
 from swing_screener.intelligence.evidence.models import SourceEvidence
 from swing_screener.recommendation.models import DecisionAction, DecisionConviction
 
+CatalystUrgency = Literal["high", "medium", "low", "none"]
+
 
 class IntelligenceEventType(str, Enum):
     earnings = "earnings"
@@ -173,7 +175,7 @@ class SymbolIntelligence(BaseModel):
     generated_at: str
     action: DecisionAction
     conviction: DecisionConviction
-    catalyst_urgency: Literal["high", "medium", "low", "none"] = "none"
+    catalyst_urgency: CatalystUrgency = "none"
     summary_line: str
     narrative: str
     upcoming_events: list[IntelligenceEvent] = []

--- a/src/swing_screener/intelligence/symbol_analyzer.py
+++ b/src/swing_screener/intelligence/symbol_analyzer.py
@@ -24,6 +24,7 @@ from swing_screener.intelligence.models import (
     SymbolIntelligenceRequest,
     ThesisDelta,
 )
+from swing_screener.recommendation.models import DecisionAction, DecisionConviction
 from swing_screener.settings import get_settings_manager
 from swing_screener.utils.logging_config import get_logger
 
@@ -127,8 +128,8 @@ class _LLMAnalysis(BaseModel):
     """The LLM-emitted fields only. `symbol`, `generated_at` and `inputs_used` are
     set server-side and are NOT part of the structured-output schema."""
 
-    action: str
-    conviction: str
+    action: DecisionAction
+    conviction: DecisionConviction
     catalyst_urgency: str = "none"
     summary_line: str
     narrative: str

--- a/src/swing_screener/intelligence/symbol_analyzer.py
+++ b/src/swing_screener/intelligence/symbol_analyzer.py
@@ -12,6 +12,7 @@ from swing_screener.intelligence.history import HistoryEntry, append_history, re
 from swing_screener.intelligence.market_hours import is_us_pre_market, previous_session_close
 from swing_screener.data.currency import detect_currency
 from swing_screener.intelligence.models import (
+    CatalystUrgency,
     IntelligenceEvent,
     KeyNumber,
     NewsItem,
@@ -130,7 +131,7 @@ class _LLMAnalysis(BaseModel):
 
     action: DecisionAction
     conviction: DecisionConviction
-    catalyst_urgency: str = "none"
+    catalyst_urgency: CatalystUrgency = "none"
     summary_line: str
     narrative: str
     upcoming_events: list[IntelligenceEvent] = []

--- a/tests/api/test_position_intelligence.py
+++ b/tests/api/test_position_intelligence.py
@@ -118,6 +118,57 @@ def test_open_positions_intelligence_empty_when_no_open_positions(client):
     assert response.json() == []
 
 
+def test_analyze_position_returns_cache_without_calling_analyzer(client):
+    from swing_screener.intelligence.models import (
+        SymbolIntelligence,
+        PositionSignal,
+        PositionSignalAction,
+    )
+
+    pos = _mock_position()
+    positions_resp = MagicMock()
+    positions_resp.positions = [pos]
+
+    cached = SymbolIntelligence(
+        symbol="BESI.AS",
+        generated_at="2026-06-25T00:00:00+00:00",
+        action="MANAGE_ONLY",
+        conviction="low",
+        catalyst_urgency="none",
+        summary_line="Cached result.",
+        narrative="...",
+        upcoming_events=[],
+        position_signal=PositionSignal(action=PositionSignalAction.HOLD, reason="From cache."),
+        sources=[],
+        inputs_used={},
+    )
+
+    def override_portfolio():
+        svc = MagicMock()
+        svc.list_positions.return_value = positions_resp
+        return svc
+
+    class _NeverCalledAnalyzer:
+        def analyze(self, *a, **k):
+            raise AssertionError("analyzer must not be called on a cache hit")
+
+    app.dependency_overrides[get_portfolio_service] = override_portfolio
+    try:
+        with (
+            patch("api.routers.intelligence.read_from_cache", return_value=cached),
+            patch("api.routers.intelligence._get_analyzer", return_value=_NeverCalledAnalyzer()),
+            patch.dict("os.environ", {"OPENAI_API_KEY": "test-key"}),
+        ):
+            response = client.post("/api/intelligence/position/pos-1")
+    finally:
+        app.dependency_overrides.pop(get_portfolio_service, None)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["summary_line"] == "Cached result."
+    assert data["position_signal"]["action"] == "HOLD"
+
+
 def test_analyze_position_503_without_api_key(client):
     import os
     env_backup = os.environ.pop("OPENAI_API_KEY", None)

--- a/tests/intelligence/test_history.py
+++ b/tests/intelligence/test_history.py
@@ -93,6 +93,29 @@ def test_read_skips_bad_entry_keeps_good(tmp_path):
     assert [e.summary_line for e in entries] == ["good"]
 
 
+def test_read_skips_nonsense_action_keeps_valid(tmp_path):
+    """Row with out-of-vocab action is skipped; file is not discarded."""
+    (tmp_path / "history").mkdir(parents=True)
+    valid = {
+        "generated_at": "2026-06-25T08:00:00Z",
+        "action": "BUY_NOW",
+        "conviction": "high",
+        "summary_line": "valid entry",
+        "watch_for": [],
+    }
+    bad_action = {
+        "generated_at": "2026-06-24T08:00:00Z",
+        "action": "NONSENSE",
+        "conviction": "low",
+        "summary_line": "bad entry",
+        "watch_for": [],
+    }
+    (tmp_path / "history" / "AAPL.json").write_text(json.dumps([valid, bad_action]))
+    entries = read_history("AAPL", history_root=tmp_path)
+    assert len(entries) == 1
+    assert entries[0].summary_line == "valid entry"
+
+
 def test_append_same_day_replaces_not_stacks(tmp_path):
     append_history("AAPL", _result("morning", generated_at="2026-06-25T08:00:00Z"), max_entries=50, history_root=tmp_path)
     append_history("AAPL", _result("midday", generated_at="2026-06-25T14:00:00Z"), max_entries=50, history_root=tmp_path)

--- a/tests/intelligence/test_metrics.py
+++ b/tests/intelligence/test_metrics.py
@@ -40,18 +40,9 @@ def test_record_analysis_metrics_none_tokens(tmp_path):
     assert data[-1]["tokens"] is None
 
 
-def test_record_analysis_metrics_degrade_soft_corrupt_file(tmp_path):
-    from swing_screener.intelligence.metrics import record_analysis_metrics
-
-    path = tmp_path / "intelligence_metrics.json"
-    path.write_text("not json{{{")
-    # must not raise
-    record_analysis_metrics("ERR", tokens=5, metrics_root=tmp_path)
-
-
 def test_record_self_heals_corrupt_file(tmp_path):
-    import json
     from swing_screener.intelligence.metrics import record_analysis_metrics
+
     (tmp_path / "intelligence_metrics.json").write_text("{ this is not json")
     record_analysis_metrics("AAA", tokens=5, metrics_root=tmp_path)
     data = json.loads((tmp_path / "intelligence_metrics.json").read_text())

--- a/tests/intelligence/test_metrics.py
+++ b/tests/intelligence/test_metrics.py
@@ -47,3 +47,11 @@ def test_record_self_heals_corrupt_file(tmp_path):
     record_analysis_metrics("AAA", tokens=5, metrics_root=tmp_path)
     data = json.loads((tmp_path / "intelligence_metrics.json").read_text())
     assert isinstance(data, list) and data[-1]["ticker"] == "AAA"
+
+
+def test_record_analysis_metrics_soft_degrades_on_write_failure(tmp_path, monkeypatch):
+    from swing_screener.intelligence.metrics import record_analysis_metrics
+
+    monkeypatch.setattr("pathlib.Path.write_text", lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("disk full")))
+    # must not raise — degrade soft
+    record_analysis_metrics("AAA", tokens=1, metrics_root=tmp_path)

--- a/tests/intelligence/test_metrics.py
+++ b/tests/intelligence/test_metrics.py
@@ -47,3 +47,12 @@ def test_record_analysis_metrics_degrade_soft_corrupt_file(tmp_path):
     path.write_text("not json{{{")
     # must not raise
     record_analysis_metrics("ERR", tokens=5, metrics_root=tmp_path)
+
+
+def test_record_self_heals_corrupt_file(tmp_path):
+    import json
+    from swing_screener.intelligence.metrics import record_analysis_metrics
+    (tmp_path / "intelligence_metrics.json").write_text("{ this is not json")
+    record_analysis_metrics("AAA", tokens=5, metrics_root=tmp_path)
+    data = json.loads((tmp_path / "intelligence_metrics.json").read_text())
+    assert isinstance(data, list) and data[-1]["ticker"] == "AAA"

--- a/tests/intelligence/test_symbol_analyzer.py
+++ b/tests/intelligence/test_symbol_analyzer.py
@@ -192,7 +192,7 @@ def test_symbol_analyzer_raises_on_invalid_action():
         mock_client.responses.parse.side_effect = ValueError("action: literal_error")
 
         analyzer = SymbolAnalyzer()
-        with pytest.raises(Exception):
+        with pytest.raises(ValueError):
             analyzer.analyze("XYZ", request)
 
 

--- a/tests/intelligence/test_symbol_analyzer.py
+++ b/tests/intelligence/test_symbol_analyzer.py
@@ -180,17 +180,20 @@ def test_inputs_used_includes_recent_candle_patterns():
 
 
 def test_symbol_analyzer_raises_on_invalid_action():
-    # Since _LLMAnalysis now types action: DecisionAction, an out-of-vocab action
-    # is rejected at call-2 decode (_LLMAnalysis.model_validate), not at SymbolIntelligence.
-    bad_body = {
-        "action": "TOTALLY_WRONG",
-        "conviction": "high",
-        "summary_line": "x",
-        "narrative": "x",
-        "sources": [],
-    }
-    with pytest.raises(Exception):
-        _LLMAnalysis.model_validate(bad_body)
+    # _LLMAnalysis now validates action: DecisionAction at call-2 decode.
+    # Simulate responses.parse raising (as the real API would) and confirm
+    # analyze() propagates the exception rather than swallowing it.
+    request = SymbolIntelligenceRequest(close=10.0, signal="pullback")
+
+    with patch("swing_screener.intelligence.symbol_analyzer.OpenAI") as MockOpenAI:
+        mock_client = MagicMock()
+        MockOpenAI.return_value = mock_client
+        mock_client.responses.create.return_value = _make_fake_openai_response()
+        mock_client.responses.parse.side_effect = ValueError("action: literal_error")
+
+        analyzer = SymbolAnalyzer()
+        with pytest.raises(Exception):
+            analyzer.analyze("XYZ", request)
 
 
 # --- tests for extended prompt and cache ---

--- a/tests/intelligence/test_symbol_analyzer.py
+++ b/tests/intelligence/test_symbol_analyzer.py
@@ -570,6 +570,16 @@ def test_llm_analysis_rejects_out_of_vocab_action():
         _LLMAnalysis(action="NONSENSE", conviction="medium", summary_line="s", narrative="n")
 
 
+def test_llm_analysis_rejects_out_of_vocab_catalyst_urgency():
+    import pytest
+    from swing_screener.intelligence.symbol_analyzer import _LLMAnalysis
+    with pytest.raises(ValueError):
+        _LLMAnalysis(
+            action="WATCH", conviction="medium", catalyst_urgency="normal",
+            summary_line="s", narrative="n",
+        )
+
+
 def test_analyze_writes_to_cache(tmp_path, monkeypatch):
     import json
     from unittest.mock import MagicMock, patch

--- a/tests/intelligence/test_symbol_analyzer.py
+++ b/tests/intelligence/test_symbol_analyzer.py
@@ -180,8 +180,8 @@ def test_inputs_used_includes_recent_candle_patterns():
 
 
 def test_symbol_analyzer_raises_on_invalid_action():
-    # An out-of-enum action survives the call-2 `_LLMAnalysis` (action: str) but
-    # is rejected when mapped into `SymbolIntelligence.action` (DecisionAction).
+    # Since _LLMAnalysis now types action: DecisionAction, an out-of-vocab action
+    # is rejected at call-2 decode (_LLMAnalysis.model_validate), not at SymbolIntelligence.
     bad_body = {
         "action": "TOTALLY_WRONG",
         "conviction": "high",
@@ -189,16 +189,8 @@ def test_symbol_analyzer_raises_on_invalid_action():
         "narrative": "x",
         "sources": [],
     }
-    request = SymbolIntelligenceRequest(close=10.0, signal="pullback")
-
-    with patch("swing_screener.intelligence.symbol_analyzer.OpenAI") as MockOpenAI:
-        mock_client = MagicMock()
-        MockOpenAI.return_value = mock_client
-        _wire_two_calls(mock_client, bad_body)
-
-        analyzer = SymbolAnalyzer()
-        with pytest.raises(Exception):
-            analyzer.analyze("XYZ", request)
+    with pytest.raises(Exception):
+        _LLMAnalysis.model_validate(bad_body)
 
 
 # --- tests for extended prompt and cache ---
@@ -566,6 +558,13 @@ def test_sources_attempted_non_empty_on_blackout(monkeypatch):
     assert sources["attempted"], "attempted must be non-empty even on a blackout"
     assert "sec_edgar_catalysts" in sources["attempted"]
     assert sources["returned"] == {}
+
+
+def test_llm_analysis_rejects_out_of_vocab_action():
+    import pytest
+    from swing_screener.intelligence.symbol_analyzer import _LLMAnalysis
+    with pytest.raises(ValueError):
+        _LLMAnalysis(action="NONSENSE", conviction="medium", summary_line="s", narrative="n")
 
 
 def test_analyze_writes_to_cache(tmp_path, monkeypatch):

--- a/tests/test_datasources_intelligence.py
+++ b/tests/test_datasources_intelligence.py
@@ -2,8 +2,8 @@ from api.services.datasources_service import DatasourcesService, INTELLIGENCE_SO
 
 
 def test_sec_collector_probeable_in_inventory():
-    ids = {d.id for d in DatasourcesService().inventory() if d.probeable}
-    assert "sec_edgar_catalysts" in ids
+    ids = {d.id for d in DatasourcesService().inventory() if d.probeable and d.domain == "intelligence"}
+    assert ids == {"sec_edgar_catalysts"}
 
 
 def test_no_inert_intelligence_sources():


### PR DESCRIPTION
Follow-up to the intelligence hardening branch, clearing the low-risk items its final review deferred. Stacks on `feat/intelligence-hardening`, merge that first.

Production fixes:
- Type the enum-valued `_LLMAnalysis` draft fields (`action`, `conviction`, `catalyst_urgency`) as the same enums/Literals `SymbolIntelligence` uses, instead of bare `str`. `action`/`conviction` reuse `DecisionAction`/`DecisionConviction`; `catalyst_urgency` now shares a `CatalystUrgency` Literal across both models. The call-2 strict schema constrains the model to valid values, so an off-vocabulary value (the model returned `"normal"` for urgency in practice) can no longer pass call 2 and then 400 from the server-side `SymbolIntelligence` constructor.
- `record_analysis_metrics` self-heals a corrupt `intelligence_metrics.json`: a parse failure now resets to an empty list and writes a fresh log instead of silently dropping every future entry. The 500-entry cap, the record shape, and the degrade-soft write path are unchanged.

Test gaps closed:
- `_LLMAnalysis` rejects an out-of-vocabulary `action` and an out-of-vocabulary `catalyst_urgency`.
- `read_history` skips an out-of-vocabulary `action` row while keeping the valid rows (read-path coverage, not just model-level rejection).
- `POST /intelligence/position/{id}` returns the same-day cache without calling the analyzer.
- Re-tighten the datasources assertion to an exact set scoped to the intelligence domain (`{sec_edgar_catalysts}`), so an accidental re-registration is caught.