### PR TITLE
 Extract the duplicated daily-review candidate mapper and review persistence

### DIFF
--- a/api/services/daily_review/__init__.py
+++ b/api/services/daily_review/__init__.py
@@ -1,0 +1,4 @@
+"""Daily review sub-package."""
+from .writer import DailyReviewWriter
+
+__all__ = ["DailyReviewWriter"]

--- a/api/services/daily_review/writer.py
+++ b/api/services/daily_review/writer.py
@@ -1,0 +1,28 @@
+"""Persistence for daily review snapshots."""
+import json
+import logging
+from pathlib import Path
+
+from api.models.daily_review import DailyReview
+
+logger = logging.getLogger(__name__)
+
+
+class DailyReviewWriter:
+    """Writes daily review snapshots to the historical review directory."""
+
+    def __init__(self, daily_reviews_dir: Path) -> None:
+        self.daily_reviews_dir = daily_reviews_dir
+
+    def save(self, review: DailyReview, strategy_name: str) -> None:
+        """Save daily review to a dated JSON file."""
+        review_date = review.summary.review_date
+        filename = f"daily_review_{review_date.isoformat()}_{strategy_name}.json"
+        filepath = self.daily_reviews_dir / filename
+
+        review_dict = review.model_dump(mode="json")
+
+        with open(filepath, "w") as f:
+            json.dump(review_dict, f, indent=2)
+
+        logger.info(f"Daily review saved to {filepath}")

--- a/api/services/daily_review_service.py
+++ b/api/services/daily_review_service.py
@@ -28,6 +28,39 @@ from swing_screener.portfolio.state import ManageConfig as ManageStateConfig
 logger = logging.getLogger(__name__)
 
 
+def to_daily_review_candidate(c) -> DailyReviewCandidate:
+    """Map a screener candidate to a DailyReviewCandidate."""
+    return DailyReviewCandidate(
+        ticker=c.ticker,
+        currency=c.currency,
+        rank=c.rank,
+        priority_rank=c.priority_rank,
+        confidence=c.confidence,
+        signal=c.signal or "UNKNOWN",
+        close=c.close,
+        score=c.score,
+        atr=c.atr,
+        sma_20=c.sma_20,
+        sma_50=c.sma_50,
+        sma_200=c.sma_200,
+        momentum_6m=c.momentum_6m,
+        momentum_12m=c.momentum_12m,
+        rel_strength=c.rel_strength,
+        entry=c.entry or 0.0,
+        stop=c.stop or 0.0,
+        shares=c.shares or 0,
+        r_reward=c.rr or 0.0,
+        name=c.name,
+        sector=c.sector,
+        suggested_order_type=c.suggested_order_type,
+        suggested_order_price=c.suggested_order_price,
+        execution_note=c.execution_note,
+        recommendation=c.recommendation,
+        same_symbol=c.same_symbol,
+        decision_summary=c.decision_summary,
+    )
+
+
 class DailyReviewService:
     """Service for generating daily review with trade candidates and position actions."""
 
@@ -74,41 +107,11 @@ class DailyReviewService:
         screener_result = self.screener.run_screener(screener_request)
         candidates = screener_result.candidates[:top_n]
 
-        def _to_daily_candidate(c) -> DailyReviewCandidate:
-            return DailyReviewCandidate(
-                ticker=c.ticker,
-                currency=c.currency,
-                rank=c.rank,
-                priority_rank=c.priority_rank,
-                confidence=c.confidence,
-                signal=c.signal or "UNKNOWN",
-                close=c.close,
-                score=c.score,
-                atr=c.atr,
-                sma_20=c.sma_20,
-                sma_50=c.sma_50,
-                sma_200=c.sma_200,
-                momentum_6m=c.momentum_6m,
-                momentum_12m=c.momentum_12m,
-                rel_strength=c.rel_strength,
-                entry=c.entry or 0.0,
-                stop=c.stop or 0.0,
-                shares=c.shares or 0,
-                r_reward=c.rr or 0.0,
-                name=c.name,
-                sector=c.sector,
-                suggested_order_type=c.suggested_order_type,
-                suggested_order_price=c.suggested_order_price,
-                execution_note=c.execution_note,
-                recommendation=c.recommendation,
-                same_symbol=c.same_symbol,
-                decision_summary=c.decision_summary,
-            )
         # Re-entries are fresh buy decisions (no open position), so rank them
         # among new opportunities by screener priority. Add-ons / scale-backs
         # depend on an existing position and stay in the portfolio sub-group.
-        new_candidates = [_to_daily_candidate(c) for c in candidates if c.same_symbol is None or c.same_symbol.mode in ("NEW_ENTRY", "RE_ENTRY")]
-        add_on_candidates = [_to_daily_candidate(c) for c in candidates if c.same_symbol is not None and c.same_symbol.mode in ("ADD_ON", "SCALE_BACK")]
+        new_candidates = [to_daily_review_candidate(c) for c in candidates if c.same_symbol is None or c.same_symbol.mode in ("NEW_ENTRY", "RE_ENTRY")]
+        add_on_candidates = [to_daily_review_candidate(c) for c in candidates if c.same_symbol is not None and c.same_symbol.mode in ("ADD_ON", "SCALE_BACK")]
         screener_tickers = {c.ticker.upper() for c in candidates}
         watchlist_near_trigger = [
             item for item in self._watchlist_near_trigger_items()
@@ -419,41 +422,11 @@ class DailyReviewService:
         screener_result = self.screener.run_screener(screener_request, strategy_override=strategy)
         candidates = screener_result.candidates[:top_n]
 
-        def _to_daily_candidate(c) -> DailyReviewCandidate:
-            return DailyReviewCandidate(
-                ticker=c.ticker,
-                currency=c.currency,
-                rank=c.rank,
-                priority_rank=c.priority_rank,
-                confidence=c.confidence,
-                signal=c.signal or "UNKNOWN",
-                close=c.close,
-                score=c.score,
-                atr=c.atr,
-                sma_20=c.sma_20,
-                sma_50=c.sma_50,
-                sma_200=c.sma_200,
-                momentum_6m=c.momentum_6m,
-                momentum_12m=c.momentum_12m,
-                rel_strength=c.rel_strength,
-                entry=c.entry or 0.0,
-                stop=c.stop or 0.0,
-                shares=c.shares or 0,
-                r_reward=c.rr or 0.0,
-                name=c.name,
-                sector=c.sector,
-                suggested_order_type=c.suggested_order_type,
-                suggested_order_price=c.suggested_order_price,
-                execution_note=c.execution_note,
-                recommendation=c.recommendation,
-                same_symbol=c.same_symbol,
-                decision_summary=c.decision_summary,
-            )
         # Re-entries are fresh buy decisions (no open position), so rank them
         # among new opportunities by screener priority. Add-ons / scale-backs
         # depend on an existing position and stay in the portfolio sub-group.
-        new_candidates = [_to_daily_candidate(c) for c in candidates if c.same_symbol is None or c.same_symbol.mode in ("NEW_ENTRY", "RE_ENTRY")]
-        add_on_candidates = [_to_daily_candidate(c) for c in candidates if c.same_symbol is not None and c.same_symbol.mode in ("ADD_ON", "SCALE_BACK")]
+        new_candidates = [to_daily_review_candidate(c) for c in candidates if c.same_symbol is None or c.same_symbol.mode in ("NEW_ENTRY", "RE_ENTRY")]
+        add_on_candidates = [to_daily_review_candidate(c) for c in candidates if c.same_symbol is not None and c.same_symbol.mode in ("ADD_ON", "SCALE_BACK")]
 
         positions_hold: list[DailyReviewPositionHold] = []
         positions_update: list[DailyReviewPositionUpdate] = []

--- a/api/services/daily_review_service.py
+++ b/api/services/daily_review_service.py
@@ -1,8 +1,9 @@
 """Service for generating daily review with action items."""
 import logging
+from dataclasses import dataclass, field
 from datetime import date
 from pathlib import Path
-from typing import Literal, Optional
+from typing import Callable, Literal, Optional
 
 from swing_screener.errors import DomainError
 
@@ -59,6 +60,36 @@ def to_daily_review_candidate(c) -> DailyReviewCandidate:
         same_symbol=c.same_symbol,
         decision_summary=c.decision_summary,
     )
+
+
+@dataclass
+class _ActionBuckets:
+    """Collects categorized position actions while iterating positions."""
+    hold: list[DailyReviewPositionHold] = field(default_factory=list)
+    update: list[DailyReviewPositionUpdate] = field(default_factory=list)
+    close: list[DailyReviewPositionClose] = field(default_factory=list)
+    exit_signal: list[DailyReviewPositionExitSignal] = field(default_factory=list)
+
+
+@dataclass
+class _PositionActionContext:
+    """Per-position values that differ between the live and stateless review paths.
+
+    The two paths read success-branch fields from different sources (the position
+    model vs the stop suggestion) and resolve error-branch fields, the time-stop
+    payload and position_id differently. Capturing those as resolved scalars plus
+    two small callables lets one classifier handle both.
+    """
+    position_id: str
+    err_ticker: str
+    err_entry_price: float
+    err_stop_price: float
+    err_current_price: float
+    trim_r_threshold: float
+    #: suggestion -> (ticker, entry_price, stop_price) for the success branches.
+    success_fields: Callable
+    #: r_now -> {"days_open": ..., "time_stop_warning": ...}
+    time_stop: Callable
 
 
 class DailyReviewService:
@@ -129,123 +160,43 @@ class DailyReviewService:
             time_stop_min_r=float(active_manage.get("time_stop_min_r", 0.5)),
         )
         positions = positions_response.positions
-        
-        positions_hold: list[DailyReviewPositionHold] = []
-        positions_update: list[DailyReviewPositionUpdate] = []
-        positions_close: list[DailyReviewPositionClose] = []
-        positions_exit_signal: list[DailyReviewPositionExitSignal] = []
 
+        buckets = _ActionBuckets()
         for pos in positions:
-            # Get stop suggestion for this position
+            ctx = _PositionActionContext(
+                position_id=pos.position_id,
+                err_ticker=pos.ticker,
+                err_entry_price=pos.entry_price,
+                err_stop_price=pos.stop_price,
+                err_current_price=pos.current_price or pos.entry_price,
+                trim_r_threshold=trim_r_threshold,
+                success_fields=lambda _s, p=pos: (p.ticker, p.entry_price, p.stop_price),
+                time_stop=lambda r, p=pos: self._time_stop_payload_from_position(p, r, active_manage),
+            )
             try:
                 suggestion = self.portfolio.suggest_position_stop(pos.position_id)
             except DomainError as exc:
-                reason = exc.detail
                 logger.warning(
                     "Daily review stop suggestion unavailable for %s: %s",
                     pos.ticker,
-                    reason,
+                    exc.detail,
                 )
-                positions_hold.append(
-                    DailyReviewPositionHold(
-                        position_id=pos.position_id,
-                        ticker=pos.ticker,
-                        entry_price=pos.entry_price,
-                        stop_price=pos.stop_price,
-                        current_price=pos.current_price or pos.entry_price,
-                        r_now=0.0,
-                        **self._time_stop_payload_from_position(pos, 0.0, active_manage),
-                        reason=f"Stop suggestion unavailable: {reason}",
-                    )
-                )
+                buckets.hold.append(self._error_hold(ctx, f"Stop suggestion unavailable: {exc.detail}"))
                 continue
             except Exception as exc:
                 logger.exception(
                     "Unexpected error generating stop suggestion for %s",
                     pos.ticker,
                 )
-                positions_hold.append(
-                    DailyReviewPositionHold(
-                        position_id=pos.position_id,
-                        ticker=pos.ticker,
-                        entry_price=pos.entry_price,
-                        stop_price=pos.stop_price,
-                        current_price=pos.current_price or pos.entry_price,
-                        r_now=0.0,
-                        **self._time_stop_payload_from_position(pos, 0.0, active_manage),
-                        reason=f"Stop suggestion unavailable: {exc}",
-                    )
-                )
+                buckets.hold.append(self._error_hold(ctx, f"Stop suggestion unavailable: {exc}"))
                 continue
 
-            # Categorize based on action
-            if suggestion.action == "NO_ACTION":
-                trim_suggestion = (
-                    TrimSuggestion(r_threshold=trim_r_threshold, r_now=suggestion.r_now)
-                    if suggestion.r_now >= trim_r_threshold
-                    else None
-                )
-                positions_hold.append(
-                    DailyReviewPositionHold(
-                        position_id=pos.position_id,
-                        ticker=pos.ticker,
-                        entry_price=pos.entry_price,
-                        stop_price=pos.stop_price,
-                        current_price=suggestion.last,
-                        r_now=suggestion.r_now,
-                        **self._time_stop_payload_from_position(pos, suggestion.r_now, active_manage),
-                        reason=suggestion.reason,
-                        exhaustion_score=suggestion.exhaustion_score,
-                        exhaustion_label=suggestion.exhaustion_label,
-                        trim_suggestion=trim_suggestion,
-                    )
-                )
+            self._classify_position_action(suggestion, ctx, buckets)
 
-            elif suggestion.action == "MOVE_STOP_UP":
-                positions_update.append(
-                    DailyReviewPositionUpdate(
-                        position_id=pos.position_id,
-                        ticker=pos.ticker,
-                        entry_price=pos.entry_price,
-                        stop_current=pos.stop_price,
-                        stop_suggested=suggestion.stop_suggested,
-                        current_price=suggestion.last,
-                        r_now=suggestion.r_now,
-                        **self._time_stop_payload_from_position(pos, suggestion.r_now, active_manage),
-                        reason=suggestion.reason,
-                        exhaustion_score=suggestion.exhaustion_score,
-                        exhaustion_label=suggestion.exhaustion_label,
-                    )
-                )
-
-            elif suggestion.action in ["CLOSE_STOP_HIT", "CLOSE_TIME_EXIT"]:
-                positions_close.append(
-                    DailyReviewPositionClose(
-                        position_id=pos.position_id,
-                        ticker=pos.ticker,
-                        entry_price=pos.entry_price,
-                        stop_price=pos.stop_price,
-                        current_price=suggestion.last,
-                        r_now=suggestion.r_now,
-                        **self._time_stop_payload_from_position(pos, suggestion.r_now, active_manage),
-                        reason=suggestion.reason,
-                    )
-                )
-
-            elif suggestion.action == "CLOSE_EXIT_SIGNAL":
-                days_open = self._time_stop_payload_from_position(pos, suggestion.r_now, active_manage).get("days_open", 0)
-                positions_exit_signal.append(
-                    DailyReviewPositionExitSignal(
-                        position_id=pos.position_id,
-                        ticker=pos.ticker,
-                        entry_price=pos.entry_price,
-                        stop_price=pos.stop_price,
-                        current_price=suggestion.last,
-                        r_now=suggestion.r_now,
-                        days_open=days_open,
-                        reason=suggestion.reason,
-                    )
-                )
+        positions_hold = buckets.hold
+        positions_update = buckets.update
+        positions_close = buckets.close
+        positions_exit_signal = buckets.exit_signal
 
         # 3. Build summary
         summary = DailyReviewSummary(
@@ -396,6 +347,96 @@ class DailyReviewService:
             "exit_signal_days": cfg.exit_signal_days,
         }
 
+    @staticmethod
+    def _error_hold(ctx: _PositionActionContext, reason: str) -> DailyReviewPositionHold:
+        """Build a hold entry for a position whose stop suggestion failed."""
+        return DailyReviewPositionHold(
+            position_id=ctx.position_id,
+            ticker=ctx.err_ticker,
+            entry_price=ctx.err_entry_price,
+            stop_price=ctx.err_stop_price,
+            current_price=ctx.err_current_price,
+            r_now=0.0,
+            **ctx.time_stop(0.0),
+            reason=reason,
+        )
+
+    def _classify_position_action(
+        self,
+        suggestion,
+        ctx: _PositionActionContext,
+        buckets: _ActionBuckets,
+    ) -> None:
+        """Categorize a successful stop suggestion into the right action bucket."""
+        if suggestion.action == "NO_ACTION":
+            ticker, entry, stop = ctx.success_fields(suggestion)
+            trim_suggestion = (
+                TrimSuggestion(r_threshold=ctx.trim_r_threshold, r_now=suggestion.r_now)
+                if suggestion.r_now >= ctx.trim_r_threshold
+                else None
+            )
+            buckets.hold.append(
+                DailyReviewPositionHold(
+                    position_id=ctx.position_id,
+                    ticker=ticker,
+                    entry_price=entry,
+                    stop_price=stop,
+                    current_price=suggestion.last,
+                    r_now=suggestion.r_now,
+                    **ctx.time_stop(suggestion.r_now),
+                    reason=suggestion.reason,
+                    exhaustion_score=suggestion.exhaustion_score,
+                    exhaustion_label=suggestion.exhaustion_label,
+                    trim_suggestion=trim_suggestion,
+                )
+            )
+        elif suggestion.action == "MOVE_STOP_UP":
+            ticker, entry, stop = ctx.success_fields(suggestion)
+            buckets.update.append(
+                DailyReviewPositionUpdate(
+                    position_id=ctx.position_id,
+                    ticker=ticker,
+                    entry_price=entry,
+                    stop_current=stop,
+                    stop_suggested=suggestion.stop_suggested,
+                    current_price=suggestion.last,
+                    r_now=suggestion.r_now,
+                    **ctx.time_stop(suggestion.r_now),
+                    reason=suggestion.reason,
+                    exhaustion_score=suggestion.exhaustion_score,
+                    exhaustion_label=suggestion.exhaustion_label,
+                )
+            )
+        elif suggestion.action in ["CLOSE_STOP_HIT", "CLOSE_TIME_EXIT"]:
+            ticker, entry, stop = ctx.success_fields(suggestion)
+            buckets.close.append(
+                DailyReviewPositionClose(
+                    position_id=ctx.position_id,
+                    ticker=ticker,
+                    entry_price=entry,
+                    stop_price=stop,
+                    current_price=suggestion.last,
+                    r_now=suggestion.r_now,
+                    **ctx.time_stop(suggestion.r_now),
+                    reason=suggestion.reason,
+                )
+            )
+        elif suggestion.action == "CLOSE_EXIT_SIGNAL":
+            ticker, entry, stop = ctx.success_fields(suggestion)
+            days_open = ctx.time_stop(suggestion.r_now).get("days_open", 0)
+            buckets.exit_signal.append(
+                DailyReviewPositionExitSignal(
+                    position_id=ctx.position_id,
+                    ticker=ticker,
+                    entry_price=entry,
+                    stop_price=stop,
+                    current_price=suggestion.last,
+                    r_now=suggestion.r_now,
+                    days_open=days_open,
+                    reason=suggestion.reason,
+                )
+            )
+
     def compute_daily_review_from_state(
         self,
         strategy: dict,
@@ -429,126 +470,51 @@ class DailyReviewService:
         new_candidates = [to_daily_review_candidate(c) for c in candidates if c.same_symbol is None or c.same_symbol.mode in ("NEW_ENTRY", "RE_ENTRY")]
         add_on_candidates = [to_daily_review_candidate(c) for c in candidates if c.same_symbol is not None and c.same_symbol.mode in ("ADD_ON", "SCALE_BACK")]
 
-        positions_hold: list[DailyReviewPositionHold] = []
-        positions_update: list[DailyReviewPositionUpdate] = []
-        positions_close: list[DailyReviewPositionClose] = []
-        positions_exit_signal: list[DailyReviewPositionExitSignal] = []
         manage_payload = self._manage_cfg_payload_from_strategy(strategy)
         trim_r_threshold_state = float(
             (strategy.get("manage", {}) if isinstance(strategy, dict) else {}).get("trim_r_threshold", 2.0)
         )
 
+        buckets = _ActionBuckets()
         for pos in positions:
             if pos.get("status") != "open":
                 continue
 
             position_id = str(pos.get("position_id") or f"LOCAL-{pos.get('ticker', 'UNKNOWN')}")
+            ctx = _PositionActionContext(
+                position_id=position_id,
+                err_ticker=str(pos.get("ticker", "")),
+                err_entry_price=float(pos.get("entry_price", 0.0)),
+                err_stop_price=float(pos.get("stop_price", 0.0)),
+                err_current_price=float(pos.get("current_price") or pos.get("entry_price") or 0.0),
+                trim_r_threshold=trim_r_threshold_state,
+                success_fields=lambda s: (s.ticker, s.entry, s.stop_old),
+                time_stop=lambda r, p=pos: self._time_stop_payload(p, r, manage_payload),
+            )
             try:
                 suggestion = self.portfolio.compute_position_stop_suggestion(pos, manage_payload)
             except DomainError as exc:
-                reason = exc.detail
                 logger.warning(
                     "Stateless daily review stop suggestion unavailable for %s: %s",
                     pos.get("ticker"),
-                    reason,
+                    exc.detail,
                 )
-                positions_hold.append(
-                    DailyReviewPositionHold(
-                        position_id=position_id,
-                        ticker=str(pos.get("ticker", "")),
-                        entry_price=float(pos.get("entry_price", 0.0)),
-                        stop_price=float(pos.get("stop_price", 0.0)),
-                        current_price=float(pos.get("current_price") or pos.get("entry_price") or 0.0),
-                        r_now=0.0,
-                        **self._time_stop_payload(pos, 0.0, manage_payload),
-                        reason=f"Stop suggestion unavailable: {reason}",
-                    )
-                )
+                buckets.hold.append(self._error_hold(ctx, f"Stop suggestion unavailable: {exc.detail}"))
                 continue
             except Exception as exc:
                 logger.exception(
                     "Unexpected stateless stop suggestion error for %s",
                     pos.get("ticker"),
                 )
-                positions_hold.append(
-                    DailyReviewPositionHold(
-                        position_id=position_id,
-                        ticker=str(pos.get("ticker", "")),
-                        entry_price=float(pos.get("entry_price", 0.0)),
-                        stop_price=float(pos.get("stop_price", 0.0)),
-                        current_price=float(pos.get("current_price") or pos.get("entry_price") or 0.0),
-                        r_now=0.0,
-                        **self._time_stop_payload(pos, 0.0, manage_payload),
-                        reason=f"Stop suggestion unavailable: {exc}",
-                    )
-                )
+                buckets.hold.append(self._error_hold(ctx, f"Stop suggestion unavailable: {exc}"))
                 continue
 
-            if suggestion.action == "NO_ACTION":
-                trim_sug = (
-                    TrimSuggestion(r_threshold=trim_r_threshold_state, r_now=suggestion.r_now)
-                    if suggestion.r_now >= trim_r_threshold_state
-                    else None
-                )
-                positions_hold.append(
-                    DailyReviewPositionHold(
-                        position_id=position_id,
-                        ticker=suggestion.ticker,
-                        entry_price=suggestion.entry,
-                        stop_price=suggestion.stop_old,
-                        current_price=suggestion.last,
-                        r_now=suggestion.r_now,
-                        **self._time_stop_payload(pos, suggestion.r_now, manage_payload),
-                        reason=suggestion.reason,
-                        exhaustion_score=suggestion.exhaustion_score,
-                        exhaustion_label=suggestion.exhaustion_label,
-                        trim_suggestion=trim_sug,
-                    )
-                )
-            elif suggestion.action == "MOVE_STOP_UP":
-                positions_update.append(
-                    DailyReviewPositionUpdate(
-                        position_id=position_id,
-                        ticker=suggestion.ticker,
-                        entry_price=suggestion.entry,
-                        stop_current=suggestion.stop_old,
-                        stop_suggested=suggestion.stop_suggested,
-                        current_price=suggestion.last,
-                        r_now=suggestion.r_now,
-                        **self._time_stop_payload(pos, suggestion.r_now, manage_payload),
-                        reason=suggestion.reason,
-                        exhaustion_score=suggestion.exhaustion_score,
-                        exhaustion_label=suggestion.exhaustion_label,
-                    )
-                )
-            elif suggestion.action in ["CLOSE_STOP_HIT", "CLOSE_TIME_EXIT"]:
-                positions_close.append(
-                    DailyReviewPositionClose(
-                        position_id=position_id,
-                        ticker=suggestion.ticker,
-                        entry_price=suggestion.entry,
-                        stop_price=suggestion.stop_old,
-                        current_price=suggestion.last,
-                        r_now=suggestion.r_now,
-                        **self._time_stop_payload(pos, suggestion.r_now, manage_payload),
-                        reason=suggestion.reason,
-                    )
-                )
+            self._classify_position_action(suggestion, ctx, buckets)
 
-            elif suggestion.action == "CLOSE_EXIT_SIGNAL":
-                days_open = self._time_stop_payload(pos, suggestion.r_now, manage_payload).get("days_open", 0)
-                positions_exit_signal.append(
-                    DailyReviewPositionExitSignal(
-                        position_id=position_id,
-                        ticker=suggestion.ticker,
-                        entry_price=suggestion.entry,
-                        stop_price=suggestion.stop_old,
-                        current_price=suggestion.last,
-                        r_now=suggestion.r_now,
-                        days_open=days_open,
-                        reason=suggestion.reason,
-                    )
-                )
+        positions_hold = buckets.hold
+        positions_update = buckets.update
+        positions_close = buckets.close
+        positions_exit_signal = buckets.exit_signal
 
         return DailyReview(
             watchlist_near_trigger=[],

--- a/api/services/daily_review_service.py
+++ b/api/services/daily_review_service.py
@@ -1,5 +1,4 @@
 """Service for generating daily review with action items."""
-import json
 import logging
 from datetime import date
 from pathlib import Path
@@ -23,6 +22,7 @@ from api.repositories.orders_repo import OrdersRepository
 from api.services.screener_service import ScreenerService
 from api.services.portfolio_service import PortfolioService
 from api.services.watchlist_service import WatchlistService
+from api.services.daily_review import DailyReviewWriter
 from swing_screener.portfolio.state import ManageConfig as ManageStateConfig
 
 logger = logging.getLogger(__name__)
@@ -82,6 +82,7 @@ class DailyReviewService:
         self.data_dir = data_dir
         self.daily_reviews_dir = data_dir / "daily_reviews"
         self.daily_reviews_dir.mkdir(parents=True, exist_ok=True)
+        self._writer = DailyReviewWriter(self.daily_reviews_dir)
 
     def generate_daily_review(
         self,
@@ -274,7 +275,7 @@ class DailyReviewService:
         )
 
         # Save to historical file (use "default" as strategy name for now)
-        self._save_review(review, "default")
+        self._writer.save(review, "default")
         
         return review
 
@@ -570,22 +571,3 @@ class DailyReviewService:
             ),
         )
     
-    def _save_review(self, review: DailyReview, strategy_name: str) -> None:
-        """
-        Save daily review to historical file.
-        
-        Args:
-            review: DailyReview to save
-            strategy_name: Name of the strategy used
-        """
-        review_date = review.summary.review_date
-        filename = f"daily_review_{review_date.isoformat()}_{strategy_name}.json"
-        filepath = self.daily_reviews_dir / filename
-        
-        # Convert to dict for JSON serialization
-        review_dict = review.model_dump(mode="json")
-        
-        with open(filepath, 'w') as f:
-            json.dump(review_dict, f, indent=2)
-        
-        logger.info(f"Daily review saved to {filepath}")


### PR DESCRIPTION
▎ DailyReviewService carried a verbatim-duplicated _to_daily_candidate mapper (defined twice as a nested function, in generate_daily_review and compute_daily_review_from_state) plus inline review persistence. This extracts the mapper into one module-level to_daily_review_candidate and moves _save_review into a DailyReviewWriter (api/services/daily_review/writer.py). Both moved verbatim, the service keeps the same public API, and the daily_review router is untouched.
▎
▎ I deliberately did not unify the two methods' position-classification blocks. They look similar but diverge in seven places (live services vs pre-computed state, suggest_position_stop(id) vs compute_position_stop_suggestion(dict), the time-stop helper, manage-cfg source, the open-status guard, and attribute-vs-dict field access). Merging them would need about five injected callables and read worse than the current duplication, so it stays for now. The win is the single-source-of-truth mapper and pulling persistence out into its own unit.
▎
▎ Full non-integration suite green (997 passed).