### PR TITLE
Fix position analysis using stale Polygon close as current price

### DIFF
--- a/api/routers/intelligence.py
+++ b/api/routers/intelligence.py
@@ -217,6 +217,12 @@ def analyze_position(
     except Exception:
         logger.warning("Technical enrichment skipped for %r", pos.ticker, exc_info=True)
     request = enrich_with_polygon_prices(pos.ticker, request)
+    # Re-pin close to the live position price after Polygon enrichment.
+    # Polygon OHLCV only carries completed-session closes, so during an open
+    # session it returns yesterday's close — contradicting r_now computed from
+    # today's intraday price and causing the LLM to misread position direction.
+    if pos.current_price is not None:
+        request = request.model_copy(update={"close": float(pos.current_price)})
     try:
         return _get_analyzer().analyze(pos.ticker.upper(), request)
     except Exception as exc:


### PR DESCRIPTION
`analyze_position` built the intelligence request with the live position price, then `enrich_with_polygon_prices` overwrote `close` with Polygon's last completed-session candle. During an open session that's yesterday's close, contradicting `r_now` computed from today's intraday price and causing the LLM to misread position direction (e.g. "down since entry" when the position is clearly positive).

Re-pin `close` to `pos.current_price` after Polygon enrichment so the price the LLM sees is always consistent with `r_now` and `days_open`.