### PR TITLE
Fix volume-pressure review findings: boundary, inside_bar, dead code

### DIFF
--- a/src/swing_screener/indicators/README.md
+++ b/src/swing_screener/indicators/README.md
@@ -36,7 +36,6 @@ Deterministic proxies for where a bar closes within its range (a stand-in for
 buy vs sell balance; true delta volume needs tick/bid-ask data we don't have):
 
 - `intrabar_pressure(high, low, close) -> float` — close-location in `[0,1]`; `0.5` for a zero-range bar.
-- `buy_sell_volume(high, low, close, volume) -> (buy, sell)` — volume split by pressure.
 - `windowed_buy_pressure_ratio(high, low, close, volume, n=20) -> float` — volume-weighted mean close-location over the last `n` bars; `NaN` when insufficient. Feeds `setup_quality.buy_pressure_ratio`.
 - `trailing_volume_ratio(volume, idx, window=20) -> float | None` — bar volume ÷ trailing average.
 - `confirm_pattern_volume(direction, bar_pressure, volume_ratio, threshold) -> bool | None` — whether a candle pattern fired on elevated, direction-aligned volume. Feeds `candles.CandlePattern.volume_confirmed`.

--- a/src/swing_screener/indicators/candles.py
+++ b/src/swing_screener/indicators/candles.py
@@ -212,14 +212,6 @@ def detect_patterns(
             date = str(frame.index[i].date())
             ctx = latest_ctx if i == n - 1 else "none"
 
-            # Volume-pressure for this bar (shared across patterns found on it).
-            bar_pressure = intrabar_pressure(row.h, row.l, row.c)
-            vol_ratio = (
-                trailing_volume_ratio(vol_aligned, i, 20)  # 20-bar trailing avg, matches setup_quality
-                if vol_aligned is not None
-                else None
-            )
-
             found: list[tuple[str, str, float]] = []  # (name, direction, key_level)
             if _is_hammer(m, cfg):
                 found.append(("hammer", "bullish", m.low))
@@ -232,7 +224,7 @@ def detect_patterns(
             if _is_bearish_engulfing(pm, m):
                 found.append(("bearish_engulfing", "bearish", m.h))
             if _is_inside_bar(pm, m):
-                found.append(("inside_bar", "bullish", m.low))
+                found.append(("inside_bar", "neutral", m.low))
             if _is_outside_bar(pm, m):
                 direction = "bullish" if m.c >= m.o else "bearish"
                 found.append(
@@ -242,6 +234,17 @@ def detect_patterns(
                         m.low if direction == "bullish" else m.h,
                     )
                 )
+
+            if not found:
+                continue
+
+            # Volume-pressure computed only when a pattern fired on this bar.
+            bar_pressure = intrabar_pressure(row.h, row.l, row.c)
+            vol_ratio = (
+                trailing_volume_ratio(vol_aligned, i, 20)
+                if vol_aligned is not None
+                else None
+            )
 
             for name, direction, key_level in found:
                 patterns.append(

--- a/src/swing_screener/indicators/volume_pressure.py
+++ b/src/swing_screener/indicators/volume_pressure.py
@@ -29,17 +29,6 @@ def intrabar_pressure(high: float, low: float, close: float) -> float:
     return float(max(0.0, min((close - low) / rng, 1.0)))
 
 
-def buy_sell_volume(
-    high: float, low: float, close: float, volume: float
-) -> tuple[float, float]:
-    """Split *volume* into ``(buy, sell)`` by intrabar pressure.
-
-    ``buy + sell == volume`` always.
-    """
-    p = intrabar_pressure(high, low, close)
-    return volume * p, volume * (1.0 - p)
-
-
 def windowed_buy_pressure_ratio(
     high: pd.Series,
     low: pd.Series,
@@ -120,7 +109,7 @@ def confirm_pattern_volume(
     if volume_ratio < threshold:
         return False
     if direction == "bearish":
-        return bool(bar_pressure <= 0.5)
+        return bool(bar_pressure < 0.5)
     if direction == "bullish":
-        return bool(bar_pressure >= 0.5)
+        return bool(bar_pressure > 0.5)
     return None

--- a/tests/test_volume_pressure.py
+++ b/tests/test_volume_pressure.py
@@ -6,7 +6,6 @@ import pandas as pd
 import pytest
 
 from swing_screener.indicators.volume_pressure import (
-    buy_sell_volume,
     confirm_pattern_volume,
     intrabar_pressure,
     trailing_volume_ratio,
@@ -36,22 +35,6 @@ def test_pressure_clamped_when_close_outside_range():
     # defensive: close above high clamps to 1.0, below low clamps to 0.0
     assert intrabar_pressure(high=11.0, low=10.0, close=12.0) == pytest.approx(1.0)
     assert intrabar_pressure(high=11.0, low=10.0, close=9.0) == pytest.approx(0.0)
-
-
-# ── buy_sell_volume ───────────────────────────────────────────────────────────
-
-
-def test_buy_sell_volume_sums_to_total():
-    buy, sell = buy_sell_volume(high=12.0, low=10.0, close=11.5, volume=1000.0)
-    assert buy + sell == pytest.approx(1000.0)
-    assert buy == pytest.approx(750.0)  # pressure 0.75
-    assert sell == pytest.approx(250.0)
-
-
-def test_buy_sell_volume_zero_range_splits_evenly():
-    buy, sell = buy_sell_volume(high=10.0, low=10.0, close=10.0, volume=800.0)
-    assert buy == pytest.approx(400.0)
-    assert sell == pytest.approx(400.0)
 
 
 # ── windowed_buy_pressure_ratio ───────────────────────────────────────────────
@@ -230,6 +213,22 @@ def test_confirm_boundary_at_threshold():
             "bullish", bar_pressure=0.9, volume_ratio=1.5, threshold=1.5
         )
         is True
+    )
+
+
+def test_confirm_exact_midpoint_pressure_not_confirmed():
+    # pressure == 0.5 is direction-ambiguous; must not confirm either side
+    assert (
+        confirm_pattern_volume(
+            "bullish", bar_pressure=0.5, volume_ratio=2.0, threshold=1.5
+        )
+        is False
+    )
+    assert (
+        confirm_pattern_volume(
+            "bearish", bar_pressure=0.5, volume_ratio=2.0, threshold=1.5
+        )
+        is False
     )
 
 

--- a/web-ui/src/features/screener/types.test.ts
+++ b/web-ui/src/features/screener/types.test.ts
@@ -35,11 +35,9 @@ describe('transformCandlePattern', () => {
       key_level: 12,
       context: 'extended',
       volume_ratio: 2.1,
-      bar_pressure: 0.12,
       volume_confirmed: true,
     });
     expect(result.volumeRatio).toBe(2.1);
-    expect(result.barPressure).toBe(0.12);
     expect(result.volumeConfirmed).toBe(true);
   });
 
@@ -52,11 +50,9 @@ describe('transformCandlePattern', () => {
       key_level: 10,
       context: 'none',
       volume_ratio: null,
-      bar_pressure: null,
       volume_confirmed: null,
     });
     expect(result.volumeRatio).toBeUndefined();
-    expect(result.barPressure).toBeUndefined();
     expect(result.volumeConfirmed).toBeUndefined();
   });
 });

--- a/web-ui/src/features/screener/types.ts
+++ b/web-ui/src/features/screener/types.ts
@@ -34,7 +34,6 @@ export interface CandlePattern {
   keyLevel: number;
   context: 'at_breakout' | 'at_pullback' | 'extended' | 'none';
   volumeRatio?: number;
-  barPressure?: number;
   volumeConfirmed?: boolean;
 }
 
@@ -46,7 +45,6 @@ export interface CandlePatternRaw {
   key_level: number;
   context: string;
   volume_ratio?: number | null;
-  bar_pressure?: number | null;
   volume_confirmed?: boolean | null;
 }
 
@@ -59,7 +57,6 @@ export function transformCandlePattern(raw: CandlePatternRaw): CandlePattern {
     keyLevel: raw.key_level,
     context: raw.context as CandlePattern['context'],
     volumeRatio: raw.volume_ratio ?? undefined,
-    barPressure: raw.bar_pressure ?? undefined,
     volumeConfirmed: raw.volume_confirmed ?? undefined,
   };
 }


### PR DESCRIPTION
- confirm_pattern_volume: strict < 0.5 / > 0.5 so exact midpoint doesn't confirm either direction
- inside_bar direction 'bullish' → 'neutral'; volume_confirmed is now always None for consolidation bars
- hoist bar_pressure/vol_ratio computation inside `if found:` — skips O(window) work on non-pattern bars
- remove buy_sell_volume (dead code, no production caller)
- drop barPressure from frontend CandlePattern; no component reads it