### PR TITLE
Stop ticker-metadata cache from re-stamping its TTL on every read

### DIFF
--- a/api/services/cache_service.py
+++ b/api/services/cache_service.py
@@ -114,6 +114,25 @@ _CACHE_DEFS: list[dict] = [
 _ID_TO_DEF: dict[str, dict] = {d["id"]: d for d in _CACHE_DEFS}
 
 
+def _scan_dir(path: str, ext: str) -> tuple[Optional[str], int]:
+    """Single rglob pass: returns (newest_mtime_iso, count_of_matching_files)."""
+    p = Path(path)
+    if not p.exists():
+        return None, 0
+    newest = None
+    count = 0
+    for f in p.rglob("*"):
+        if not f.is_file():
+            continue
+        m = f.stat().st_mtime
+        if newest is None or m > newest:
+            newest = m
+        if f.name.endswith(ext):
+            count += 1
+    iso = datetime.fromtimestamp(newest, tz=timezone.utc).isoformat() if newest is not None else None
+    return iso, count
+
+
 def _mtime_iso(path: str) -> Optional[str]:
     """Return ISO8601 of the newest mtime found under path, or None if absent."""
     p = Path(path)
@@ -121,11 +140,12 @@ def _mtime_iso(path: str) -> Optional[str]:
         return None
     if p.is_file():
         ts = p.stat().st_mtime
+        return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
     else:
-        files = list(p.rglob("*"))
-        if not files:
+        file_mtimes = [f.stat().st_mtime for f in p.rglob("*") if f.is_file()]
+        if not file_mtimes:
             return None
-        ts = max(f.stat().st_mtime for f in files if f.is_file())
+        ts = max(file_mtimes)
     return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
 
 
@@ -151,6 +171,12 @@ class CacheService:
         for d in _CACHE_DEFS:
             path = d.get("path")
             kind = d["kind"]
+            if path and kind in ("parquet_dir", "json_dir"):
+                ext = ".parquet" if kind == "parquet_dir" else ".json"
+                last_modified_at, entry_count = _scan_dir(path, ext)
+            else:
+                last_modified_at = _mtime_iso(path) if path else None
+                entry_count = _entry_count(path, kind) if path else None
             entries.append(
                 CacheStatusEntry(
                     id=d["id"],
@@ -158,8 +184,8 @@ class CacheService:
                     storage=d["storage"],
                     ttl_description=d["ttl_description"],
                     can_clear=d["can_clear"],
-                    last_modified_at=_mtime_iso(path) if path else None,
-                    entry_count=_entry_count(path, kind) if path else None,
+                    last_modified_at=last_modified_at,
+                    entry_count=entry_count,
                 )
             )
         return entries

--- a/src/swing_screener/data/market_data.py
+++ b/src/swing_screener/data/market_data.py
@@ -189,6 +189,7 @@ def fetch_ticker_metadata(
             cache = {}
 
     results: dict[str, dict] = {}
+    freshly_fetched: set[str] = set()
     for t in tks:
         if not force_refresh and t in cache:
             entry = cache[t]
@@ -227,11 +228,12 @@ def fetch_ticker_metadata(
             "currency": currency,
             "exchange": exchange,
         }
+        freshly_fetched.add(t)
 
-    if use_cache:
+    if use_cache and freshly_fetched:
         _now_write = time.time()
-        for t, v in results.items():
-            cache[t] = {**v, "fetched_at": _now_write}
+        for t in freshly_fetched:
+            cache[t] = {**results[t], "fetched_at": _now_write}
         cache_file.parent.mkdir(parents=True, exist_ok=True)
         cache_file.write_text(json.dumps(cache, indent=2), encoding="utf-8")
 

--- a/tests/api/test_cache_router.py
+++ b/tests/api/test_cache_router.py
@@ -62,3 +62,18 @@ def test_clear_json_cache_writes_empty_dict(tmp_path):
         assert json.loads(cache_file.read_text()) == {}
     finally:
         _ID_TO_DEF["ticker_meta"]["path"] = original_path
+
+
+def test_scan_dir_returns_none_for_dir_with_only_subdirs(tmp_path):
+    """_scan_dir (and _mtime_iso) must not raise when a dir contains only subdirs, no files."""
+    from api.services.cache_service import _scan_dir, _ID_TO_DEF
+    subdir = tmp_path / "subdir"
+    subdir.mkdir()
+    original_path = _ID_TO_DEF["intelligence_evidence"]["path"]
+    _ID_TO_DEF["intelligence_evidence"]["path"] = str(tmp_path)
+    try:
+        iso, count = _scan_dir(str(tmp_path), ".json")
+        assert iso is None
+        assert count == 0
+    finally:
+        _ID_TO_DEF["intelligence_evidence"]["path"] = original_path

--- a/tests/data/test_market_metadata.py
+++ b/tests/data/test_market_metadata.py
@@ -97,3 +97,21 @@ def test_ticker_metadata_uses_fresh_cache(tmp_path):
             cache_ttl_days=30,
         )
     assert df.loc["AAPL", "name"] == "Cached Apple"
+
+
+def test_ticker_metadata_cache_hit_does_not_reset_fetched_at(tmp_path):
+    """Cache hit must NOT re-stamp fetched_at (fixes sliding-TTL bug)."""
+    cache_file = tmp_path / "ticker_meta.json"
+    original_ts = time.time() - (10 * 86400)  # 10 days ago, still within 30-day TTL
+    cache_file.write_text(
+        json.dumps({"AAPL": {"name": "Cached Apple", "currency": "USD", "exchange": "NMS", "fetched_at": original_ts}}),
+        encoding="utf-8",
+    )
+    with patch.object(yf, "Ticker", side_effect=AssertionError("should not call yfinance")):
+        fetch_ticker_metadata(
+            ["AAPL"],
+            cache_path=str(cache_file),
+            cache_ttl_days=30,
+        )
+    on_disk = json.loads(cache_file.read_text(encoding="utf-8"))
+    assert on_disk["AAPL"]["fetched_at"] == original_ts


### PR DESCRIPTION
Code-review fixes for the cache work, on top of `main`.

- **TTL re-stamp (`market_data.py`)**: `fetch_ticker_metadata` re-stamped `fetched_at` on every entry in `results`, cache hits included. That turned the absolute `ticker_meta_ttl_days` TTL into a sliding one: any ticker touched at least once per window never expired, defeating the TTL. Now only freshly fetched tickers get a new `fetched_at`, cache hits keep their original timestamp, and the file is rewritten only when something was actually fetched.
- **`max()` on empty sequence (`cache_service.py`)**: `_mtime_iso` guarded on `rglob("*")` being non-empty, but `rglob` also returns subdirectories, so a cache dir holding only subdirectories raised `ValueError: max() arg is an empty sequence` and 500'd `GET /api/cache/status`. It now builds the file-mtime list first and returns `None` when there are no files.
- **Status poll cost (`cache_service.py`)**: `status()` walked each directory cache twice per poll (mtime, then count). Collapsed into a single `rglob` pass via `_scan_dir`.
