### PR TITLE
Derive cache TTL labels from config instead of hardcoded strings

### DIFF
--- a/api/services/cache_service.py
+++ b/api/services/cache_service.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Optional
 
 from api.models.cache import CacheStatusEntry
+from swing_screener.settings import get_settings_manager
 
 
 _CACHE_DEFS: list[dict] = [
@@ -114,6 +115,26 @@ _CACHE_DEFS: list[dict] = [
 _ID_TO_DEF: dict[str, dict] = {d["id"]: d for d in _CACHE_DEFS}
 
 
+def _load_cache_config() -> dict:
+    """Return the 'cache' block from user config, or {} on failure."""
+    try:
+        _doc = get_settings_manager().load_user_document()
+        return _doc.get("cache", {})
+    except Exception:
+        return {}
+
+
+def _dynamic_ttl_description(cache_id: str, fallback: str, cache_cfg: dict) -> str:
+    """Return config-derived ttl_description for configurable caches, fallback otherwise."""
+    if cache_id == "ticker_meta":
+        n = cache_cfg.get("ticker_meta_ttl_days", 30)
+        return f"{int(round(n))} days"
+    if cache_id == "ohlcv_polygon":
+        n = cache_cfg.get("polygon_cache_ttl_days", 7)
+        return f"{int(round(n))} days"
+    return fallback
+
+
 def _scan_dir(path: str, ext: str) -> tuple[Optional[str], int]:
     """Single rglob pass: returns (newest_mtime_iso, count_of_matching_files)."""
     p = Path(path)
@@ -167,6 +188,7 @@ def _entry_count(path: str, kind: str) -> Optional[int]:
 
 class CacheService:
     def status(self) -> list[CacheStatusEntry]:
+        cache_cfg = _load_cache_config()
         entries = []
         for d in _CACHE_DEFS:
             path = d.get("path")
@@ -182,7 +204,7 @@ class CacheService:
                     id=d["id"],
                     label=d["label"],
                     storage=d["storage"],
-                    ttl_description=d["ttl_description"],
+                    ttl_description=_dynamic_ttl_description(d["id"], d["ttl_description"], cache_cfg),
                     can_clear=d["can_clear"],
                     last_modified_at=last_modified_at,
                     entry_count=entry_count,

--- a/tests/api/test_cache_router.py
+++ b/tests/api/test_cache_router.py
@@ -77,3 +77,35 @@ def test_scan_dir_returns_none_for_dir_with_only_subdirs(tmp_path):
         assert count == 0
     finally:
         _ID_TO_DEF["intelligence_evidence"]["path"] = original_path
+
+
+def test_ttl_description_reads_from_config():
+    """status() derives ticker_meta/ohlcv_polygon TTL labels from config, not hardcoded literals."""
+    from unittest.mock import MagicMock, patch
+    from api.services.cache_service import CacheService
+
+    mock_mgr = MagicMock()
+    mock_mgr.load_user_document.return_value = {
+        "cache": {"ticker_meta_ttl_days": 14, "polygon_cache_ttl_days": 3}
+    }
+    with patch("api.services.cache_service.get_settings_manager", return_value=mock_mgr):
+        entries = CacheService().status()
+
+    by_id = {e.id: e for e in entries}
+    assert by_id["ticker_meta"].ttl_description == "14 days"
+    assert by_id["ohlcv_polygon"].ttl_description == "3 days"
+
+
+def test_ttl_description_falls_back_to_defaults_on_empty_config():
+    """status() falls back to '30 days'/'7 days' when config returns empty cache block."""
+    from unittest.mock import MagicMock, patch
+    from api.services.cache_service import CacheService
+
+    mock_mgr = MagicMock()
+    mock_mgr.load_user_document.return_value = {}
+    with patch("api.services.cache_service.get_settings_manager", return_value=mock_mgr):
+        entries = CacheService().status()
+
+    by_id = {e.id: e for e in entries}
+    assert by_id["ticker_meta"].ttl_description == "30 days"
+    assert by_id["ohlcv_polygon"].ttl_description == "7 days"


### PR DESCRIPTION
Stacked on `fix/cache-review-pr1`.

The Cache card showed hardcoded `30 days` / `7 days` regardless of `cache.ticker_meta_ttl_days` and `cache.polygon_cache_ttl_days`. `status()` now reads the `cache` config block once per call and derives `ttl_description` for `ticker_meta` and `ohlcv_polygon` from the configured values, falling back to the literals if config can't be read.