### PR TITLE
Resolve screener universe from a taxonomy-filtered symbol pool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,7 @@ data/screener_history.json
 data/orders.json
 data/positions.json
 data/watchlist.json
+data/review_queue.json
 orders.json
 positions.json
 # =========================

--- a/api/README.md
+++ b/api/README.md
@@ -38,9 +38,16 @@ Strategy (`/api/strategy`):
 - `DELETE /api/strategy/{strategy_id}`
 
 Screener (`/api/screener`):
-- `POST /api/screener/run` (sync locally, async job launch on dyno by default)
+- `POST /api/screener/run` (sync locally, async job launch on dyno by default). Accepts `taxonomy_filter` (region / market_cap_tier / sector / index_memberships / instrument_type_detail / provider / currency / exchange_mics / liquidity_tier) and `preset` to pre-filter the unified symbol pool. The `universe` field is **deprecated** — it now resolves to `taxonomy_filter.index_memberships=[universe]` and will be removed in a later release.
 - `GET /api/screener/run/{job_id}` (poll async screener status/result)
 - `GET /api/screener/recurrence`
+
+Symbol pool (`/api/pool`):
+- `GET /api/pool/symbols` — browse the unified pool with taxonomy query params (`region`, `market_cap_tier`, `sector`, `index_memberships`, `instrument_type_detail`, `provider`, `currency`, `exchange_mics`, `liquidity_tier`), paginated (`page`, `page_size`). Returns `{symbols, total, page, page_size}`.
+- `GET /api/pool/review-queue` — symbols flagged after repeated OHLCV fetch failures. Returns `{entries}`.
+- `POST /api/pool/review-queue/{symbol}/remove` — clear the symbol's review-queue entry. Returns `{removed: bool}`. (Clears the queue entry only; the symbol re-enters screening on the next run unless it fails again. Hard removal from `symbol_pool.json` is deferred with the pool-edit work.)
+- `POST /api/pool/review-queue/{symbol}/restore` — reset the symbol's failure counter and return it to the active pool. Returns `{restored: bool}`.
+- `GET /api/pool/presets` — list taxonomy presets from `config/taxonomy_presets.yaml`. Returns `{presets: [{id, label, filter}]}`.
 
 Screener responses label data freshness as `intraday` while a relevant market is still open and `final_close` once the daily bars are final. Intraday responses are previews, not final end-of-day recommendations.
 

--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -1,4 +1,5 @@
 """Shared dependencies for API routers."""
+
 from __future__ import annotations
 
 import threading
@@ -14,7 +15,9 @@ from api.repositories.config_repo import ConfigRepository
 from api.repositories.fundamentals_config_repo import FundamentalsConfigRepository
 from api.repositories.orders_repo import OrdersRepository
 from api.repositories.positions_repo import PositionsRepository
+from api.repositories.review_queue_repo import ReviewQueueRepository
 from api.repositories.screener_history_repo import ScreenerHistoryRepository
+from api.repositories.symbol_pool_repo import SymbolPoolRepository
 from api.repositories.strategy_repo import StrategyRepository
 from api.repositories.watchlist_repo import WatchlistRepository
 from api.repositories.weekly_reviews_repo import WeeklyReviewsRepository
@@ -29,7 +32,9 @@ from api.utils.files import get_today_str
 from swing_screener.settings import data_dir, get_settings_manager
 from swing_screener.runtime_env import get_env_value
 from swing_screener.fundamentals.finnhub_client import FinnhubEnrichmentClient
-from swing_screener.fundamentals import FundamentalsAnalysisService as _FundamentalsAnalysisService
+from swing_screener.fundamentals import (
+    FundamentalsAnalysisService as _FundamentalsAnalysisService,
+)
 
 _finnhub_client: FinnhubEnrichmentClient | None = None
 _finnhub_client_api_key: str | None = None
@@ -56,11 +61,22 @@ def get_finnhub_client() -> FinnhubEnrichmentClient | None:
             _finnhub_client_api_key = api_key
         return _finnhub_client
 
+
 # Repository root
 DATA_DIR = data_dir()
-POSITIONS_FILE = get_settings_manager().resolve_runtime_path("positions_file", DATA_DIR / "positions.json")
+POSITIONS_FILE = get_settings_manager().resolve_runtime_path(
+    "positions_file", DATA_DIR / "positions.json"
+)
 ORDERS_FILE = DATA_DIR / "orders.json"
-WATCHLIST_FILE = get_settings_manager().resolve_runtime_path("watchlist_file", DATA_DIR / "watchlist.json")
+WATCHLIST_FILE = get_settings_manager().resolve_runtime_path(
+    "watchlist_file", DATA_DIR / "watchlist.json"
+)
+SYMBOL_POOL_FILE = get_settings_manager().resolve_runtime_path(
+    "symbol_pool_file", DATA_DIR / "symbol_pool.json"
+)
+REVIEW_QUEUE_FILE = get_settings_manager().resolve_runtime_path(
+    "review_queue_file", DATA_DIR / "review_queue.json"
+)
 
 # Patchable path aliases used by tests (monkeypatch these to redirect I/O).
 # Set to None to fall through to the module-level constants.
@@ -75,7 +91,10 @@ _config_repository_lock = threading.Lock()
 def get_positions_path() -> Path:
     """Get path to positions.json."""
     import api.dependencies as _self
-    return _self._positions_path if _self._positions_path is not None else POSITIONS_FILE
+
+    return (
+        _self._positions_path if _self._positions_path is not None else POSITIONS_FILE
+    )
 
 
 def get_watchlist_path() -> Path:
@@ -87,15 +106,18 @@ def get_positions_repo() -> PositionsRepository:
     path = get_positions_path()
     if not path.exists():
         from api.utils.file_lock import locked_write_json
+
         locked_write_json(path, {"asof": get_today_str(), "positions": []})
     return PositionsRepository(path)
 
 
 def get_orders_repo() -> OrdersRepository:
     import api.dependencies as _self
+
     path = _self._orders_path if _self._orders_path is not None else ORDERS_FILE
     if not path.exists():
         from api.utils.file_lock import locked_write_json
+
         locked_write_json(path, {"asof": get_today_str(), "orders": []})
     return OrdersRepository(path)
 
@@ -121,7 +143,7 @@ def get_fundamentals_config_repo() -> FundamentalsConfigRepository:
 
 def get_config_repo() -> ConfigRepository:
     """Get the singleton config repository (thread-safe).
-    
+
     Returns a singleton instance to maintain config state across requests.
     Uses double-checked locking for thread-safe lazy initialization.
     """
@@ -160,15 +182,27 @@ def get_strategy_service(
     return StrategyService(strategy_repo=strategy_repo)
 
 
+def get_symbol_pool_repo() -> SymbolPoolRepository:
+    return SymbolPoolRepository(SYMBOL_POOL_FILE)
+
+
+def get_review_queue_repo() -> ReviewQueueRepository:
+    return ReviewQueueRepository(REVIEW_QUEUE_FILE)
+
+
 def get_screener_service(
     strategy_repo: StrategyRepository = Depends(get_strategy_repo),
     portfolio_service: PortfolioService = Depends(get_portfolio_service),
     orders_service: OrdersService = Depends(get_orders_service),
+    pool_repo: SymbolPoolRepository = Depends(get_symbol_pool_repo),
+    review_repo: ReviewQueueRepository = Depends(get_review_queue_repo),
 ) -> ScreenerService:
     return ScreenerService(
         strategy_repo=strategy_repo,
         portfolio_service=portfolio_service,
         orders_service=orders_service,
+        pool_repo=pool_repo,
+        review_repo=review_repo,
     )
 
 
@@ -185,9 +219,10 @@ def get_fundamentals_service(
 ) -> FundamentalsService:
     return FundamentalsService(
         config_repo=config_repo,
-        analysis_service=_FundamentalsAnalysisService(finnhub_client=get_finnhub_client()),
+        analysis_service=_FundamentalsAnalysisService(
+            finnhub_client=get_finnhub_client()
+        ),
     )
-
 
 
 from api.services.datasources_service import DatasourcesService
@@ -216,11 +251,13 @@ def get_cache_service() -> CacheService:
 
 SCREENER_HISTORY_FILE = DATA_DIR / "screener_history.json"
 
+
 def get_screener_history_repo() -> ScreenerHistoryRepository:
     return ScreenerHistoryRepository(SCREENER_HISTORY_FILE)
 
 
 WEEKLY_REVIEWS_FILE = DATA_DIR / "weekly_reviews.json"
+
 
 def get_weekly_reviews_repo() -> WeeklyReviewsRepository:
     return WeeklyReviewsRepository(WEEKLY_REVIEWS_FILE)

--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -1,5 +1,4 @@
 """Shared dependencies for API routers."""
-
 from __future__ import annotations
 
 import threading
@@ -17,8 +16,8 @@ from api.repositories.orders_repo import OrdersRepository
 from api.repositories.positions_repo import PositionsRepository
 from api.repositories.review_queue_repo import ReviewQueueRepository
 from api.repositories.screener_history_repo import ScreenerHistoryRepository
-from api.repositories.symbol_pool_repo import SymbolPoolRepository
 from api.repositories.strategy_repo import StrategyRepository
+from api.repositories.symbol_pool_repo import SymbolPoolRepository
 from api.repositories.watchlist_repo import WatchlistRepository
 from api.repositories.weekly_reviews_repo import WeeklyReviewsRepository
 from api.services.fundamentals_service import FundamentalsService
@@ -32,9 +31,7 @@ from api.utils.files import get_today_str
 from swing_screener.settings import data_dir, get_settings_manager
 from swing_screener.runtime_env import get_env_value
 from swing_screener.fundamentals.finnhub_client import FinnhubEnrichmentClient
-from swing_screener.fundamentals import (
-    FundamentalsAnalysisService as _FundamentalsAnalysisService,
-)
+from swing_screener.fundamentals import FundamentalsAnalysisService as _FundamentalsAnalysisService
 
 _finnhub_client: FinnhubEnrichmentClient | None = None
 _finnhub_client_api_key: str | None = None
@@ -61,22 +58,13 @@ def get_finnhub_client() -> FinnhubEnrichmentClient | None:
             _finnhub_client_api_key = api_key
         return _finnhub_client
 
-
 # Repository root
 DATA_DIR = data_dir()
-POSITIONS_FILE = get_settings_manager().resolve_runtime_path(
-    "positions_file", DATA_DIR / "positions.json"
-)
+POSITIONS_FILE = get_settings_manager().resolve_runtime_path("positions_file", DATA_DIR / "positions.json")
 ORDERS_FILE = DATA_DIR / "orders.json"
-WATCHLIST_FILE = get_settings_manager().resolve_runtime_path(
-    "watchlist_file", DATA_DIR / "watchlist.json"
-)
-SYMBOL_POOL_FILE = get_settings_manager().resolve_runtime_path(
-    "symbol_pool_file", DATA_DIR / "symbol_pool.json"
-)
-REVIEW_QUEUE_FILE = get_settings_manager().resolve_runtime_path(
-    "review_queue_file", DATA_DIR / "review_queue.json"
-)
+WATCHLIST_FILE = get_settings_manager().resolve_runtime_path("watchlist_file", DATA_DIR / "watchlist.json")
+SYMBOL_POOL_FILE = get_settings_manager().resolve_runtime_path("symbol_pool_file", DATA_DIR / "symbol_pool.json")
+REVIEW_QUEUE_FILE = get_settings_manager().resolve_runtime_path("review_queue_file", DATA_DIR / "review_queue.json")
 
 # Patchable path aliases used by tests (monkeypatch these to redirect I/O).
 # Set to None to fall through to the module-level constants.
@@ -91,10 +79,7 @@ _config_repository_lock = threading.Lock()
 def get_positions_path() -> Path:
     """Get path to positions.json."""
     import api.dependencies as _self
-
-    return (
-        _self._positions_path if _self._positions_path is not None else POSITIONS_FILE
-    )
+    return _self._positions_path if _self._positions_path is not None else POSITIONS_FILE
 
 
 def get_watchlist_path() -> Path:
@@ -106,18 +91,15 @@ def get_positions_repo() -> PositionsRepository:
     path = get_positions_path()
     if not path.exists():
         from api.utils.file_lock import locked_write_json
-
         locked_write_json(path, {"asof": get_today_str(), "positions": []})
     return PositionsRepository(path)
 
 
 def get_orders_repo() -> OrdersRepository:
     import api.dependencies as _self
-
     path = _self._orders_path if _self._orders_path is not None else ORDERS_FILE
     if not path.exists():
         from api.utils.file_lock import locked_write_json
-
         locked_write_json(path, {"asof": get_today_str(), "orders": []})
     return OrdersRepository(path)
 
@@ -143,7 +125,7 @@ def get_fundamentals_config_repo() -> FundamentalsConfigRepository:
 
 def get_config_repo() -> ConfigRepository:
     """Get the singleton config repository (thread-safe).
-
+    
     Returns a singleton instance to maintain config state across requests.
     Uses double-checked locking for thread-safe lazy initialization.
     """
@@ -219,10 +201,9 @@ def get_fundamentals_service(
 ) -> FundamentalsService:
     return FundamentalsService(
         config_repo=config_repo,
-        analysis_service=_FundamentalsAnalysisService(
-            finnhub_client=get_finnhub_client()
-        ),
+        analysis_service=_FundamentalsAnalysisService(finnhub_client=get_finnhub_client()),
     )
+
 
 
 from api.services.datasources_service import DatasourcesService
@@ -251,13 +232,11 @@ def get_cache_service() -> CacheService:
 
 SCREENER_HISTORY_FILE = DATA_DIR / "screener_history.json"
 
-
 def get_screener_history_repo() -> ScreenerHistoryRepository:
     return ScreenerHistoryRepository(SCREENER_HISTORY_FILE)
 
 
 WEEKLY_REVIEWS_FILE = DATA_DIR / "weekly_reviews.json"
-
 
 def get_weekly_reviews_repo() -> WeeklyReviewsRepository:
     return WeeklyReviewsRepository(WEEKLY_REVIEWS_FILE)

--- a/api/main.py
+++ b/api/main.py
@@ -26,6 +26,7 @@ from api.routers import (
     fundamentals,
     intelligence,
     market_data,
+    pool as pool_router,
     portfolio,
     screener,
     screener_history,
@@ -320,6 +321,7 @@ app.include_router(market_data.router, prefix="/api", tags=["market-data"])
 app.include_router(weekly_reviews.router, prefix="/api/weekly-reviews", tags=["weekly-reviews"])
 app.include_router(backtest.router, prefix="/api/backtest", tags=["backtest"])
 app.include_router(cache_router.router, prefix="/api/cache", tags=["cache"])
+app.include_router(pool_router.router, prefix="/api/pool", tags=["pool"])
 
 
 @app.api_route(

--- a/api/models/screener.py
+++ b/api/models/screener.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any, Literal, Optional
 from pydantic import BaseModel, Field, field_validator
 from api.models.recommendation import Recommendation
+from swing_screener.data.symbol_pool import TaxonomyFilterSpec
 from swing_screener.fundamentals.models import FundamentalSnapshot
 from swing_screener.recommendation.models import DecisionSummary
 
@@ -117,9 +118,41 @@ class ScreenerCandidate(BaseModel):
     pattern_stop_reason: str | None = None
 
 
+class TaxonomyFilter(BaseModel):
+    region: Optional[list[str]] = None
+    market_cap_tier: Optional[list[str]] = None
+    sector: Optional[list[str]] = None
+    index_memberships: Optional[list[str]] = None
+    instrument_type_detail: Optional[list[str]] = None
+    provider: Optional[list[str]] = None
+    currency: Optional[list[str]] = None
+    exchange_mics: Optional[list[str]] = None
+    liquidity_tier: Optional[list[str]] = None
+
+    def to_spec(self) -> TaxonomyFilterSpec:
+        def _t(v: Optional[list[str]]) -> Optional[tuple[str, ...]]:
+            return tuple(v) if v else None
+
+        return TaxonomyFilterSpec(
+            region=_t(self.region),
+            market_cap_tier=_t(self.market_cap_tier),
+            sector=_t(self.sector),
+            index_memberships=_t(self.index_memberships),
+            instrument_type_detail=_t(self.instrument_type_detail),
+            provider=_t(self.provider),
+            currency=_t(self.currency),
+            exchange_mics=_t(self.exchange_mics),
+            liquidity_tier=_t(self.liquidity_tier),
+        )
+
+
 class ScreenerRequest(BaseModel):
     universe: Optional[str] = Field(
-        default=None, description="Named universe (e.g., 'sp500')"
+        default=None,
+        description=(
+            "DEPRECATED alias: resolves to taxonomy_filter.index_memberships=[universe]. "
+            "Removed in a later release."
+        ),
     )
     tickers: Optional[list[str]] = Field(
         default=None, description="Explicit ticker list"
@@ -178,6 +211,14 @@ class ScreenerRequest(BaseModel):
     force_refresh: bool = Field(
         default=False,
         description="Bypass the per-symbol eval cache and recompute all symbols",
+    )
+    taxonomy_filter: Optional[TaxonomyFilter] = Field(
+        default=None,
+        description="Taxonomy pre-filter applied to the unified symbol pool.",
+    )
+    preset: Optional[str] = Field(
+        default=None,
+        description="Named taxonomy preset id (config/taxonomy_presets.yaml).",
     )
 
     @field_validator("currencies")

--- a/api/repositories/review_queue_repo.py
+++ b/api/repositories/review_queue_repo.py
@@ -1,4 +1,10 @@
-"""Review queue JSON repository."""
+"""Review queue / fetch-health JSON repository.
+
+This is the single runtime store for per-symbol OHLCV fetch health. The
+committed ``symbol_pool.json`` is immutable; all mutable counters live here so
+the pool file never drifts from its built state. Symbols whose consecutive
+failure count reaches the threshold are the "review queue" shown in the UI.
+"""
 
 from __future__ import annotations
 
@@ -18,37 +24,71 @@ class ReviewQueueRepository:
 
     def read(self) -> dict:
         if not self.path.exists():
-            return {"entries": []}
-        return locked_read_json(self.path)
+            return {"symbols": {}}
+        data = locked_read_json(self.path)
+        data.setdefault("symbols", {})
+        return data
 
     def write(self, data: dict) -> None:
         locked_write_json(self.path, data)
 
-    def list_entries(self) -> list[dict]:
-        return self.read().get("entries", [])
-
-    def upsert(self, entries: list[dict]) -> None:
-        incoming = {str(e["symbol"]).upper(): e for e in entries}
+    def apply_fetch_results(
+        self, ok: list[str], failed: list[str], asof: str, threshold: int
+    ) -> None:
+        """Reset counters for fetched symbols; increment for failed ones."""
+        ok_set = {s.upper() for s in ok}
+        failed_set = {s.upper() for s in failed}
 
         def _modify(data: dict) -> dict:
-            data.setdefault("entries", [])
-            by_symbol = {str(e["symbol"]).upper(): e for e in data["entries"]}
-            by_symbol.update(incoming)
-            data["entries"] = list(by_symbol.values())
+            symbols = data.setdefault("symbols", {})
+            for name in ok_set:
+                entry = symbols.get(name)
+                if entry is not None:
+                    entry["fetch_failure_count"] = 0
+                    entry["last_fetch_ok_at"] = asof
+            for name in failed_set:
+                entry = symbols.get(name)
+                if entry is None:
+                    entry = {
+                        "symbol": name,
+                        "fetch_failure_count": 0,
+                        "first_failed_at": asof,
+                        "last_fetch_ok_at": None,
+                    }
+                    symbols[name] = entry
+                entry["fetch_failure_count"] = (
+                    int(entry.get("fetch_failure_count") or 0) + 1
+                )
+                entry.setdefault("first_failed_at", asof)
+                entry["last_failed_at"] = asof
+                entry["reason"] = "OHLCV fetch returned no data"
             return data
 
         self._ensure_file()
         locked_read_modify_write(self.path, _modify)
+
+    def queued_symbols(self, threshold: int) -> set[str]:
+        return {
+            name
+            for name, e in self.read().get("symbols", {}).items()
+            if int(e.get("fetch_failure_count") or 0) >= threshold
+        }
+
+    def list_entries(self, threshold: int) -> list[dict]:
+        """Threshold-crossed entries shown in the review queue UI."""
+        return [
+            e
+            for e in self.read().get("symbols", {}).values()
+            if int(e.get("fetch_failure_count") or 0) >= threshold
+        ]
 
     def remove(self, symbol: str) -> bool:
         target = symbol.upper()
         removed = {"flag": False}
 
         def _modify(data: dict) -> dict:
-            entries = data.get("entries", [])
-            kept = [e for e in entries if str(e["symbol"]).upper() != target]
-            removed["flag"] = len(kept) != len(entries)
-            data["entries"] = kept
+            symbols = data.setdefault("symbols", {})
+            removed["flag"] = symbols.pop(target, None) is not None
             return data
 
         self._ensure_file()
@@ -60,14 +100,10 @@ class ReviewQueueRepository:
         popped: dict = {}
 
         def _modify(data: dict) -> dict:
-            entries = data.get("entries", [])
-            kept = []
-            for e in entries:
-                if str(e["symbol"]).upper() == target and not popped:
-                    popped.update(e)
-                else:
-                    kept.append(e)
-            data["entries"] = kept
+            symbols = data.setdefault("symbols", {})
+            entry = symbols.pop(target, None)
+            if entry is not None:
+                popped.update(entry)
             return data
 
         self._ensure_file()
@@ -77,4 +113,4 @@ class ReviewQueueRepository:
     def _ensure_file(self) -> None:
         if not self.path.exists():
             self.path.parent.mkdir(parents=True, exist_ok=True)
-            self.write({"entries": []})
+            self.write({"symbols": {}})

--- a/api/repositories/review_queue_repo.py
+++ b/api/repositories/review_queue_repo.py
@@ -1,0 +1,80 @@
+"""Review queue JSON repository."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from api.utils.file_lock import (
+    locked_read_json,
+    locked_read_modify_write,
+    locked_write_json,
+)
+
+
+@dataclass
+class ReviewQueueRepository:
+    path: Path
+
+    def read(self) -> dict:
+        if not self.path.exists():
+            return {"entries": []}
+        return locked_read_json(self.path)
+
+    def write(self, data: dict) -> None:
+        locked_write_json(self.path, data)
+
+    def list_entries(self) -> list[dict]:
+        return self.read().get("entries", [])
+
+    def upsert(self, entries: list[dict]) -> None:
+        incoming = {str(e["symbol"]).upper(): e for e in entries}
+
+        def _modify(data: dict) -> dict:
+            data.setdefault("entries", [])
+            by_symbol = {str(e["symbol"]).upper(): e for e in data["entries"]}
+            by_symbol.update(incoming)
+            data["entries"] = list(by_symbol.values())
+            return data
+
+        self._ensure_file()
+        locked_read_modify_write(self.path, _modify)
+
+    def remove(self, symbol: str) -> bool:
+        target = symbol.upper()
+        removed = {"flag": False}
+
+        def _modify(data: dict) -> dict:
+            entries = data.get("entries", [])
+            kept = [e for e in entries if str(e["symbol"]).upper() != target]
+            removed["flag"] = len(kept) != len(entries)
+            data["entries"] = kept
+            return data
+
+        self._ensure_file()
+        locked_read_modify_write(self.path, _modify)
+        return removed["flag"]
+
+    def restore(self, symbol: str) -> dict | None:
+        target = symbol.upper()
+        popped: dict = {}
+
+        def _modify(data: dict) -> dict:
+            entries = data.get("entries", [])
+            kept = []
+            for e in entries:
+                if str(e["symbol"]).upper() == target and not popped:
+                    popped.update(e)
+                else:
+                    kept.append(e)
+            data["entries"] = kept
+            return data
+
+        self._ensure_file()
+        locked_read_modify_write(self.path, _modify)
+        return popped or None
+
+    def _ensure_file(self) -> None:
+        if not self.path.exists():
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            self.write({"entries": []})

--- a/api/repositories/symbol_pool_repo.py
+++ b/api/repositories/symbol_pool_repo.py
@@ -1,15 +1,16 @@
-"""Symbol pool JSON repository."""
+"""Symbol pool JSON repository (read-only at runtime).
+
+The committed ``symbol_pool.json`` is an immutable build artifact. Runtime
+fetch-health counters live in the review-queue store, never here, so the pool
+file never drifts from its built state.
+"""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
 
-from api.utils.file_lock import (
-    locked_read_json,
-    locked_read_modify_write,
-    locked_write_json,
-)
+from api.utils.file_lock import locked_read_json, locked_write_json
 
 
 @dataclass
@@ -24,28 +25,3 @@ class SymbolPoolRepository:
 
     def list_symbols(self) -> list[dict]:
         return self.read().get("symbols", [])
-
-    def apply_fetch_results(
-        self, ok: list[str], failed: list[str], asof: str, threshold: int
-    ) -> list[dict]:
-        """Reset/increment per-symbol fetch counters; return symbols that crossed threshold."""
-        ok_set = {s.upper() for s in ok}
-        failed_set = {s.upper() for s in failed}
-        crossed: list[dict] = []
-
-        def _modify(data: dict) -> dict:
-            crossed.clear()
-            for sym in data.get("symbols", []):
-                name = str(sym.get("symbol", "")).upper()
-                if name in ok_set:
-                    sym["fetch_failure_count"] = 0
-                    sym["last_fetch_ok_at"] = asof
-                elif name in failed_set:
-                    prev = int(sym.get("fetch_failure_count") or 0)
-                    sym["fetch_failure_count"] = prev + 1
-                    if prev < threshold <= sym["fetch_failure_count"]:
-                        crossed.append(dict(sym))
-            return data
-
-        locked_read_modify_write(self.path, _modify)
-        return crossed

--- a/api/repositories/symbol_pool_repo.py
+++ b/api/repositories/symbol_pool_repo.py
@@ -1,0 +1,51 @@
+"""Symbol pool JSON repository."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from api.utils.file_lock import (
+    locked_read_json,
+    locked_read_modify_write,
+    locked_write_json,
+)
+
+
+@dataclass
+class SymbolPoolRepository:
+    path: Path
+
+    def read(self) -> dict:
+        return locked_read_json(self.path)
+
+    def write(self, data: dict) -> None:
+        locked_write_json(self.path, data)
+
+    def list_symbols(self) -> list[dict]:
+        return self.read().get("symbols", [])
+
+    def apply_fetch_results(
+        self, ok: list[str], failed: list[str], asof: str, threshold: int
+    ) -> list[dict]:
+        """Reset/increment per-symbol fetch counters; return symbols that crossed threshold."""
+        ok_set = {s.upper() for s in ok}
+        failed_set = {s.upper() for s in failed}
+        crossed: list[dict] = []
+
+        def _modify(data: dict) -> dict:
+            crossed.clear()
+            for sym in data.get("symbols", []):
+                name = str(sym.get("symbol", "")).upper()
+                if name in ok_set:
+                    sym["fetch_failure_count"] = 0
+                    sym["last_fetch_ok_at"] = asof
+                elif name in failed_set:
+                    prev = int(sym.get("fetch_failure_count") or 0)
+                    sym["fetch_failure_count"] = prev + 1
+                    if prev < threshold <= sym["fetch_failure_count"]:
+                        crossed.append(dict(sym))
+            return data
+
+        locked_read_modify_write(self.path, _modify)
+        return crossed

--- a/api/routers/pool.py
+++ b/api/routers/pool.py
@@ -1,0 +1,72 @@
+"""Symbol pool API: taxonomy-filtered browse, review queue, presets."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Query
+
+from api.dependencies import get_review_queue_repo, get_symbol_pool_repo
+from api.models.screener import TaxonomyFilter
+from api.repositories.review_queue_repo import ReviewQueueRepository
+from api.repositories.symbol_pool_repo import SymbolPoolRepository
+from api.services.pool_service import list_pool_symbols, load_taxonomy_presets
+
+router = APIRouter()
+
+
+@router.get("/symbols")
+def get_symbols(
+    region: Optional[list[str]] = Query(default=None),
+    market_cap_tier: Optional[list[str]] = Query(default=None),
+    sector: Optional[list[str]] = Query(default=None),
+    index_memberships: Optional[list[str]] = Query(default=None),
+    instrument_type_detail: Optional[list[str]] = Query(default=None),
+    provider: Optional[list[str]] = Query(default=None),
+    currency: Optional[list[str]] = Query(default=None),
+    exchange_mics: Optional[list[str]] = Query(default=None),
+    liquidity_tier: Optional[list[str]] = Query(default=None),
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=100, ge=1, le=1000),
+    repo: SymbolPoolRepository = Depends(get_symbol_pool_repo),
+):
+    tf = TaxonomyFilter(
+        region=region,
+        market_cap_tier=market_cap_tier,
+        sector=sector,
+        index_memberships=index_memberships,
+        instrument_type_detail=instrument_type_detail,
+        provider=provider,
+        currency=currency,
+        exchange_mics=exchange_mics,
+        liquidity_tier=liquidity_tier,
+    )
+    return list_pool_symbols(repo, tf, page, page_size)
+
+
+@router.get("/review-queue")
+def get_review_queue(repo: ReviewQueueRepository = Depends(get_review_queue_repo)):
+    from swing_screener.data.symbol_pool import load_symbol_pool_thresholds
+
+    _, _, threshold = load_symbol_pool_thresholds()
+    return {"entries": repo.list_entries(threshold)}
+
+
+@router.post("/review-queue/{symbol}/remove")
+def remove_from_pool(
+    symbol: str, repo: ReviewQueueRepository = Depends(get_review_queue_repo)
+):
+    return {"removed": repo.remove(symbol)}
+
+
+@router.post("/review-queue/{symbol}/restore")
+def restore_to_pool(
+    symbol: str, repo: ReviewQueueRepository = Depends(get_review_queue_repo)
+):
+    restored = repo.restore(symbol)
+    return {"restored": restored is not None}
+
+
+@router.get("/presets")
+def get_presets():
+    return {"presets": load_taxonomy_presets()}

--- a/api/services/pool_service.py
+++ b/api/services/pool_service.py
@@ -1,0 +1,69 @@
+"""Symbol pool service: taxonomy presets and pool listing."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+from api.models.screener import TaxonomyFilter
+from swing_screener.data.symbol_pool import (
+    deserialize_pool,
+    filter_pool_by_taxonomy,
+    pool_symbol_to_dict,
+)
+from swing_screener.settings.paths import config_dir
+
+
+def _presets_path() -> Path:
+    return config_dir() / "taxonomy_presets.yaml"
+
+
+@lru_cache(maxsize=1)
+def _load_presets_document() -> dict:
+    path = _presets_path()
+    if not path.exists():
+        return {}
+    with open(path, encoding="utf-8") as f:
+        payload = yaml.safe_load(f) or {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def load_taxonomy_presets() -> list[dict]:
+    doc = _load_presets_document()
+    presets = doc.get("presets", {}) or {}
+    out: list[dict] = []
+    for pid, body in presets.items():
+        out.append(
+            {
+                "id": pid,
+                "label": (body or {}).get("label", pid),
+                "filter": (body or {}).get("filter", {}) or {},
+            }
+        )
+    return out
+
+
+def resolve_preset(preset_id: str) -> Optional[TaxonomyFilter]:
+    for p in load_taxonomy_presets():
+        if p["id"] == preset_id:
+            return TaxonomyFilter(**p["filter"])
+    return None
+
+
+def list_pool_symbols(
+    repo, tax_filter: TaxonomyFilter, page: int, page_size: int
+) -> dict:
+    pool = deserialize_pool({"symbols": repo.list_symbols()})
+    filtered = filter_pool_by_taxonomy(pool, tax_filter.to_spec())
+    total = len(filtered)
+    start = max(0, (page - 1) * page_size)
+    page_items = filtered[start : start + page_size]
+    return {
+        "symbols": [pool_symbol_to_dict(s) for s in page_items],
+        "total": total,
+        "page": page,
+        "page_size": page_size,
+    }

--- a/api/services/screener_service.py
+++ b/api/services/screener_service.py
@@ -307,7 +307,19 @@ class ScreenerService:
             if request.universe not in existing:
                 existing.append(request.universe)
             base = base.model_copy(update={"index_memberships": existing})
-        return base.to_spec()
+        spec = base.to_spec()
+        # Backward-compat: legacy top-level filter fields map onto unset dimensions
+        # (the web UI sends these until the taxonomy filter bar lands).
+        overrides: dict = {}
+        if spec.currency is None and request.currencies:
+            overrides["currency"] = tuple(request.currencies)
+        if spec.exchange_mics is None and request.exchange_mics:
+            overrides["exchange_mics"] = tuple(request.exchange_mics)
+        if request.instrument_types:
+            overrides["instrument_type"] = tuple(request.instrument_types)
+        if overrides:
+            spec = replace(spec, **overrides)
+        return spec
 
     def _resolve_strategy(
         self, strategy_id: Optional[str], strategy_override: Optional[dict] = None
@@ -352,15 +364,19 @@ class ScreenerService:
                     )
                     ctx.benchmark = uni_benchmark
 
+            from swing_screener.data.symbol_pool import load_symbol_pool_thresholds
+
+            _, _, fail_threshold = load_symbol_pool_thresholds()
             spec = self._build_taxonomy_spec(request)
             pool = deserialize_pool({"symbols": self._pool_repo.list_symbols()})
-            queued = {
-                str(e.get("symbol", "")).upper()
-                for e in self._review_repo.list_entries()
-            }
+            queued = self._review_repo.queued_symbols(fail_threshold)
             pool = [s for s in pool if s.symbol not in queued]
             pool = [s for s in pool if self._provider_available(s.primary_provider)]
+            pool_size = len(pool)
             filtered = filter_pool_by_taxonomy(pool, spec)
+            # Legacy include_otc=False drops OTC listings (XOTC).
+            if request.include_otc is False:
+                filtered = [s for s in filtered if (s.exchange_mic or "") != "XOTC"]
             universe_cap = max(500, requested_top * 2)
             symbols = [s.symbol for s in filtered]
             if len(symbols) > universe_cap:
@@ -369,6 +385,11 @@ class ScreenerService:
                     f"capped to {universe_cap}."
                 )
                 symbols = symbols[:universe_cap]
+            if len(symbols) < pool_size:
+                ctx.warnings.append(
+                    f"Taxonomy filters reduced the working list from {pool_size} "
+                    f"to {len(symbols)} tickers."
+                )
             if ctx.benchmark not in symbols:
                 symbols.append(ctx.benchmark)
             ctx.tickers = symbols
@@ -533,22 +554,7 @@ class ScreenerService:
             requested = list(ctx.screening_tickers)
             ok = [t for t in requested if t in present]
             failed = [t for t in requested if t not in present]
-            crossed = self._pool_repo.apply_fetch_results(
-                ok, failed, ctx.asof_str, threshold
-            )
-            if crossed:
-                entries = [
-                    {
-                        "symbol": c["symbol"],
-                        "exchange_mic": c.get("exchange_mic"),
-                        "failure_count": c.get("fetch_failure_count"),
-                        "first_failed_at": c.get("last_fetch_ok_at") or ctx.asof_str,
-                        "last_failed_at": ctx.asof_str,
-                        "reason": "OHLCV fetch returned no data",
-                    }
-                    for c in crossed
-                ]
-                self._review_repo.upsert(entries)
+            self._review_repo.apply_fetch_results(ok, failed, ctx.asof_str, threshold)
         except (
             Exception
         ) as exc:  # noqa: BLE001 - health tracking must never break a screen

--- a/api/services/screener_service.py
+++ b/api/services/screener_service.py
@@ -1,4 +1,5 @@
 """Screener service."""
+
 from __future__ import annotations
 
 from dataclasses import replace, asdict, dataclass, field
@@ -33,13 +34,10 @@ from swing_screener.indicators.candles import detect_patterns, CandleConfig
 from swing_screener.execution.guidance import apply_pattern_stop, ExecutionConfig
 from api.repositories.strategy_repo import StrategyRepository
 from swing_screener.data.universe import (
-    filter_tickers_by_metadata,
     get_instrument_record,
-    load_universe_from_package,
-    list_package_universes,
-    UniverseConfig as DataUniverseConfig,
     get_universe_benchmark,
 )
+from swing_screener.data.symbol_pool import deserialize_pool, filter_pool_by_taxonomy
 from swing_screener.data.providers import MarketDataProvider, get_default_provider
 from swing_screener.data.currency import detect_currency
 from swing_screener.data.ticker_info import get_multiple_ticker_info
@@ -47,7 +45,10 @@ from swing_screener.data import sector_rotation
 from swing_screener.reporting.report import ReportConfig, build_daily_report
 from swing_screener.reporting.concentration import sector_concentration_warnings
 from swing_screener.fundamentals.earnings_proximity import fetch_next_earnings_days
-from swing_screener.recommendation.priority import CombinedPriorityConfig, compute_combined_priority
+from swing_screener.recommendation.priority import (
+    CombinedPriorityConfig,
+    compute_combined_priority,
+)
 from swing_screener.settings import get_settings_manager
 from swing_screener.strategy.config import (
     build_entry_config,
@@ -138,7 +139,9 @@ logger = logging.getLogger(__name__)
 
 
 def _min_days_to_earnings_default() -> int:
-    selection_defaults = get_settings_manager().get_low_level_defaults_payload("selection")
+    selection_defaults = get_settings_manager().get_low_level_defaults_payload(
+        "selection"
+    )
     universe_defaults = selection_defaults.get("universe", {})
     if not isinstance(universe_defaults, dict):
         return 0
@@ -180,6 +183,7 @@ class _RunContext:
     Holds everything the steps hand to each other so step signatures stay
     small. Created fresh per run_screener call; never shared across calls.
     """
+
     request: ScreenerRequest
     strategy: dict
     warnings: list[str] = field(default_factory=list)
@@ -217,6 +221,8 @@ class ScreenerService:
         provider: Optional[MarketDataProvider] = None,
         orders_service=None,
         eval_cache: Optional[EvalCache] = None,
+        pool_repo=None,
+        review_repo=None,
     ) -> None:
         self._strategy_repo = strategy_repo
         self._portfolio_service = portfolio_service
@@ -226,10 +232,86 @@ class ScreenerService:
             self._eval_cache: EvalCache = eval_cache
         else:
             self._eval_cache = EvalCache(
-                root=get_settings_manager().resolve_runtime_path("eval_cache_dir", ".cache/eval")
+                root=get_settings_manager().resolve_runtime_path(
+                    "eval_cache_dir", ".cache/eval"
+                )
             )
+        if pool_repo is not None:
+            self._pool_repo = pool_repo
+        else:
+            from api.repositories.symbol_pool_repo import SymbolPoolRepository
 
-    def _resolve_strategy(self, strategy_id: Optional[str], strategy_override: Optional[dict] = None) -> dict:
+            self._pool_repo = SymbolPoolRepository(
+                get_settings_manager().resolve_runtime_path(
+                    "symbol_pool_file", "data/symbol_pool.json"
+                )
+            )
+        if review_repo is not None:
+            self._review_repo = review_repo
+        else:
+            from api.repositories.review_queue_repo import ReviewQueueRepository
+
+            self._review_repo = ReviewQueueRepository(
+                get_settings_manager().resolve_runtime_path(
+                    "review_queue_file", "data/review_queue.json"
+                )
+            )
+        self._available_providers = self._resolve_available_providers()
+
+    @staticmethod
+    def _resolve_available_providers() -> set[str]:
+        import os
+
+        from swing_screener.integrations.degiro.credentials import (
+            credentials_configured,
+        )
+
+        available = {"yfinance"}
+        if credentials_configured():
+            available.add("degiro")
+        if os.getenv("POLYGON_IO_API_KEY") or os.getenv("POLYGON_API_KEY"):
+            available.add("polygon")
+        if os.getenv("EODHD_API_KEY"):
+            available.add("eodhd")
+        return available
+
+    def _provider_available(self, provider: str | None) -> bool:
+        if provider in (None, "yfinance"):
+            return True
+        return provider in self._available_providers
+
+    @staticmethod
+    def _safe_universe_benchmark(universe_id: str) -> str | None:
+        try:
+            return get_universe_benchmark(universe_id)
+        except Exception:  # noqa: BLE001 - unknown id just yields no benchmark override
+            return None
+
+    def _build_taxonomy_spec(self, request: ScreenerRequest):
+        from api.models.screener import TaxonomyFilter
+        from api.services.pool_service import resolve_preset
+
+        base = TaxonomyFilter()
+        if request.preset:
+            resolved = resolve_preset(request.preset)
+            if resolved is not None:
+                base = resolved
+        if request.taxonomy_filter is not None:
+            data = base.model_dump()
+            for key, value in request.taxonomy_filter.model_dump().items():
+                if value:
+                    data[key] = value
+            base = TaxonomyFilter(**data)
+        if request.universe:  # deprecated alias → index membership
+            existing = list(base.index_memberships or [])
+            if request.universe not in existing:
+                existing.append(request.universe)
+            base = base.model_copy(update={"index_memberships": existing})
+        return base.to_spec()
+
+    def _resolve_strategy(
+        self, strategy_id: Optional[str], strategy_override: Optional[dict] = None
+    ) -> dict:
         if strategy_override is not None:
             return strategy_override
         if strategy_id:
@@ -254,59 +336,48 @@ class ScreenerService:
         ctx.universe_cfg = build_universe_config(ctx.strategy)
         ctx.now_utc = dt.datetime.now(dt.timezone.utc)
         ctx.benchmark = ctx.universe_cfg.mom.benchmark
-        if request.universe:
-            valid_ids = set(list_package_universes())
-            if request.universe not in valid_ids:
-                replacement = _REMOVED_UNIVERSE_IDS.get(request.universe)
-                if replacement:
-                    detail = (
-                        f"Universe '{request.universe}' was removed. "
-                        f"Use '{replacement}' instead."
-                    )
-                else:
-                    detail = (
-                        f"Universe '{request.universe}' is not available. "
-                        f"Available universes: {sorted(valid_ids)}"
-                    )
-                raise UnprocessableError(detail)
-            uni_benchmark = get_universe_benchmark(request.universe)
-            if uni_benchmark and uni_benchmark != ctx.benchmark:
-                ctx.universe_cfg = replace(
-                    ctx.universe_cfg,
-                    mom=replace(ctx.universe_cfg.mom, benchmark=uni_benchmark),
-                )
-                ctx.benchmark = uni_benchmark
 
         if request.tickers:
             ctx.tickers = [t.upper() for t in request.tickers]
             if ctx.benchmark not in ctx.tickers:
                 ctx.tickers.append(ctx.benchmark)
-        elif request.universe:
-            universe_cap = max(500, requested_top * 2)
-            ucfg = DataUniverseConfig(benchmark=ctx.benchmark, ensure_benchmark=True, max_tickers=universe_cap)
-            ctx.tickers = load_universe_from_package(request.universe, ucfg)
         else:
-            universe_cap = max(500, requested_top * 2)
-            ucfg = DataUniverseConfig(benchmark=ctx.benchmark, ensure_benchmark=True, max_tickers=universe_cap)
-            ctx.tickers = load_universe_from_package("broad_market_stocks", ucfg)
+            # Deprecated alias: a universe id still informs the benchmark override.
+            if request.universe:
+                uni_benchmark = self._safe_universe_benchmark(request.universe)
+                if uni_benchmark and uni_benchmark != ctx.benchmark:
+                    ctx.universe_cfg = replace(
+                        ctx.universe_cfg,
+                        mom=replace(ctx.universe_cfg.mom, benchmark=uni_benchmark),
+                    )
+                    ctx.benchmark = uni_benchmark
 
-        filtered_tickers = filter_tickers_by_metadata(
-            ctx.tickers,
-            currencies=request.currencies,
-            exchange_mics=request.exchange_mics,
-            include_otc=request.include_otc if request.include_otc is not None else True,
-            instrument_types=request.instrument_types,
-        )
-        if ctx.benchmark not in filtered_tickers:
-            filtered_tickers.append(ctx.benchmark)
-        if len(filtered_tickers) < len(ctx.tickers):
-            ctx.warnings.append(
-                f"Universe filters reduced the working list from {len(ctx.tickers)} to {len(filtered_tickers)} tickers."
-            )
-        ctx.tickers = filtered_tickers
+            spec = self._build_taxonomy_spec(request)
+            pool = deserialize_pool({"symbols": self._pool_repo.list_symbols()})
+            queued = {
+                str(e.get("symbol", "")).upper()
+                for e in self._review_repo.list_entries()
+            }
+            pool = [s for s in pool if s.symbol not in queued]
+            pool = [s for s in pool if self._provider_available(s.primary_provider)]
+            filtered = filter_pool_by_taxonomy(pool, spec)
+            universe_cap = max(500, requested_top * 2)
+            symbols = [s.symbol for s in filtered]
+            if len(symbols) > universe_cap:
+                ctx.warnings.append(
+                    f"Symbol pool filter matched {len(symbols)} symbols; "
+                    f"capped to {universe_cap}."
+                )
+                symbols = symbols[:universe_cap]
+            if ctx.benchmark not in symbols:
+                symbols.append(ctx.benchmark)
+            ctx.tickers = symbols
+
         ctx.market_health = self._provider.get_source_health().to_dict()
 
-        ctx.screening_tickers = [ticker for ticker in ctx.tickers if ticker != ctx.benchmark]
+        ctx.screening_tickers = [
+            ticker for ticker in ctx.tickers if ticker != ctx.benchmark
+        ]
         ctx.active_currencies = resolve_screening_currencies(
             request,
             strategy_currencies=ctx.universe_cfg.filt.currencies,
@@ -316,14 +387,18 @@ class ScreenerService:
         if request.asof_date:
             ctx.asof_str = request.asof_date
         else:
-            ctx.asof_str = resolve_default_asof_date(ctx.now_utc, ctx.active_currencies).isoformat()
+            ctx.asof_str = resolve_default_asof_date(
+                ctx.now_utc, ctx.active_currencies
+            ).isoformat()
 
         if len(ctx.tickers) <= 1 and ctx.benchmark in ctx.tickers:
             raise NotFoundError("No tickers left after applying screener filters")
 
         return requested_top
 
-    def _build_signals_and_fetch_ohlcv(self, ctx: _RunContext, requested_top: int) -> None:
+    def _build_signals_and_fetch_ohlcv(
+        self, ctx: _RunContext, requested_top: int
+    ) -> None:
         """Build signals config, fetch and shape OHLCV, compute freshness + last-bar maps.
 
         Populates ctx.signals_cfg, start_date, end_date, ohlcv, last_bar_map,
@@ -333,14 +408,25 @@ class ScreenerService:
         fields_set = ctx.request.model_fields_set
 
         ctx.signals_cfg = build_entry_config(ctx.strategy)
-        if "breakout_lookback" in fields_set and ctx.request.breakout_lookback is not None:
-            ctx.signals_cfg = replace(ctx.signals_cfg, breakout_lookback=ctx.request.breakout_lookback)
+        if (
+            "breakout_lookback" in fields_set
+            and ctx.request.breakout_lookback is not None
+        ):
+            ctx.signals_cfg = replace(
+                ctx.signals_cfg, breakout_lookback=ctx.request.breakout_lookback
+            )
         if "pullback_ma" in fields_set and ctx.request.pullback_ma is not None:
-            ctx.signals_cfg = replace(ctx.signals_cfg, pullback_ma=ctx.request.pullback_ma)
+            ctx.signals_cfg = replace(
+                ctx.signals_cfg, pullback_ma=ctx.request.pullback_ma
+            )
         if "min_history" in fields_set and ctx.request.min_history is not None:
-            ctx.signals_cfg = replace(ctx.signals_cfg, min_history=ctx.request.min_history)
+            ctx.signals_cfg = replace(
+                ctx.signals_cfg, min_history=ctx.request.min_history
+            )
 
-        ctx.start_date = resolve_fetch_start_date(ctx.asof_str, ctx.signals_cfg.min_history)
+        ctx.start_date = resolve_fetch_start_date(
+            ctx.asof_str, ctx.signals_cfg.min_history
+        )
         ctx.end_date = ctx.asof_str
         force_refresh = bool(getattr(ctx.request, "force_refresh", False))
         sector_context_tickers = ["SPY", *sector_rotation.SECTOR_ETFS.keys()]
@@ -364,26 +450,55 @@ class ScreenerService:
         )
 
         if len(ctx.tickers) > 120:
-            ctx.ohlcv = _fetch_ohlcv_chunked(self._provider, ctx.tickers, ctx.start_date, ctx.end_date, chunk_size=100, force_refresh=force_refresh)
+            ctx.ohlcv = _fetch_ohlcv_chunked(
+                self._provider,
+                ctx.tickers,
+                ctx.start_date,
+                ctx.end_date,
+                chunk_size=100,
+                force_refresh=force_refresh,
+            )
         else:
-            ctx.ohlcv = self._provider.fetch_ohlcv(ctx.tickers, start_date=ctx.start_date, end_date=ctx.end_date, force_refresh=force_refresh)
+            ctx.ohlcv = self._provider.fetch_ohlcv(
+                ctx.tickers,
+                start_date=ctx.start_date,
+                end_date=ctx.end_date,
+                force_refresh=force_refresh,
+            )
 
         if ctx.ohlcv is None or ctx.ohlcv.empty:
-            logger.error("OHLCV fetch returned empty data (tickers=%s)", len(ctx.tickers))
+            logger.error(
+                "OHLCV fetch returned empty data (tickers=%s)", len(ctx.tickers)
+            )
             raise NotFoundError("No market data found for requested tickers")
 
         ctx.ohlcv = merge_ohlcv(ctx.ohlcv, sector_ohlcv)
 
-        if "Close" not in ctx.ohlcv.columns.get_level_values(0) or ctx.benchmark not in ctx.ohlcv["Close"].columns:
-            logger.warning("Benchmark %s missing from OHLCV; fetching separately.", ctx.benchmark)
-            bench_df = self._provider.fetch_ohlcv([ctx.benchmark], start_date=ctx.start_date, end_date=ctx.end_date, force_refresh=force_refresh)
+        if (
+            "Close" not in ctx.ohlcv.columns.get_level_values(0)
+            or ctx.benchmark not in ctx.ohlcv["Close"].columns
+        ):
+            logger.warning(
+                "Benchmark %s missing from OHLCV; fetching separately.", ctx.benchmark
+            )
+            bench_df = self._provider.fetch_ohlcv(
+                [ctx.benchmark],
+                start_date=ctx.start_date,
+                end_date=ctx.end_date,
+                force_refresh=force_refresh,
+            )
             ctx.ohlcv = merge_ohlcv(ctx.ohlcv, bench_df)
-            if "Close" not in ctx.ohlcv.columns.get_level_values(0) or ctx.benchmark not in ctx.ohlcv["Close"].columns:
+            if (
+                "Close" not in ctx.ohlcv.columns.get_level_values(0)
+                or ctx.benchmark not in ctx.ohlcv["Close"].columns
+            ):
                 raise ServiceError("Benchmark data missing; cannot compute momentum.")
 
         ctx.last_bar_map = last_bar_map(ctx.ohlcv)
         ctx.overall_last_bar = _to_iso(ctx.ohlcv.index.max())
-        ctx.data_freshness = resolve_data_freshness(ctx.asof_str, ctx.now_utc, ctx.active_currencies)
+        ctx.data_freshness = resolve_data_freshness(
+            ctx.asof_str, ctx.now_utc, ctx.active_currencies
+        )
 
         # Detect tickers that failed to download and surface them as warnings
         if "Close" in ctx.ohlcv.columns.get_level_values(0):
@@ -407,9 +522,20 @@ class ScreenerService:
 
         if "min_price" in fields_set or "max_price" in fields_set:
             filt = ctx.universe_cfg.filt
-            min_price = ctx.request.min_price if ctx.request.min_price is not None else filt.min_price
-            max_price = ctx.request.max_price if ctx.request.max_price is not None else filt.max_price
-            ctx.universe_cfg = replace(ctx.universe_cfg, filt=replace(filt, min_price=min_price, max_price=max_price))
+            min_price = (
+                ctx.request.min_price
+                if ctx.request.min_price is not None
+                else filt.min_price
+            )
+            max_price = (
+                ctx.request.max_price
+                if ctx.request.max_price is not None
+                else filt.max_price
+            )
+            ctx.universe_cfg = replace(
+                ctx.universe_cfg,
+                filt=replace(filt, min_price=min_price, max_price=max_price),
+            )
         if "currencies" in fields_set and ctx.request.currencies is not None:
             filt = ctx.universe_cfg.filt
             requested_currencies = [
@@ -419,10 +545,20 @@ class ScreenerService:
             ]
             if not requested_currencies:
                 requested_currencies = ["USD", "EUR"]
-            ctx.universe_cfg = replace(ctx.universe_cfg, filt=replace(filt, currencies=requested_currencies))
-        if "require_weekly_uptrend" in fields_set and ctx.request.require_weekly_uptrend is not None:
+            ctx.universe_cfg = replace(
+                ctx.universe_cfg, filt=replace(filt, currencies=requested_currencies)
+            )
+        if (
+            "require_weekly_uptrend" in fields_set
+            and ctx.request.require_weekly_uptrend is not None
+        ):
             filt = ctx.universe_cfg.filt
-            ctx.universe_cfg = replace(ctx.universe_cfg, filt=replace(filt, require_weekly_uptrend=ctx.request.require_weekly_uptrend))
+            ctx.universe_cfg = replace(
+                ctx.universe_cfg,
+                filt=replace(
+                    filt, require_weekly_uptrend=ctx.request.require_weekly_uptrend
+                ),
+            )
 
         ctx.ranking_cfg = build_ranking_config(ctx.strategy)
         # Rank a pool of top * prefilter_multiplier so the combined-priority
@@ -432,14 +568,22 @@ class ScreenerService:
             ctx.ranking_cfg = replace(ctx.ranking_cfg, top_n=prefilter_pool)
 
         ctx.risk_cfg = build_risk_config(ctx.strategy)
-        multiplier, regime_meta = compute_regime_risk_multiplier(ctx.ohlcv, ctx.benchmark, ctx.risk_cfg)
+        multiplier, regime_meta = compute_regime_risk_multiplier(
+            ctx.ohlcv, ctx.benchmark, ctx.risk_cfg
+        )
         if multiplier != 1.0:
-            ctx.risk_cfg = replace(ctx.risk_cfg, risk_pct=ctx.risk_cfg.risk_pct * multiplier)
+            ctx.risk_cfg = replace(
+                ctx.risk_cfg, risk_pct=ctx.risk_cfg.risk_pct * multiplier
+            )
             if regime_meta.get("reasons"):
                 reasons = ", ".join(regime_meta["reasons"])
-                ctx.warnings.append(f"Risk scaled by {multiplier:.2f}x due to regime: {reasons}")
+                ctx.warnings.append(
+                    f"Risk scaled by {multiplier:.2f}x due to regime: {reasons}"
+                )
             else:
-                ctx.warnings.append(f"Risk scaled by {multiplier:.2f}x due to regime conditions.")
+                ctx.warnings.append(
+                    f"Risk scaled by {multiplier:.2f}x due to regime conditions."
+                )
 
         ctx.report_cfg = ReportConfig(
             universe=ctx.universe_cfg,
@@ -448,14 +592,20 @@ class ScreenerService:
             risk=ctx.risk_cfg,
         )
 
-    def _run_daily_report(self, ctx: _RunContext, requested_top: int) -> "pd.DataFrame | None":
+    def _run_daily_report(
+        self, ctx: _RunContext, requested_top: int
+    ) -> "pd.DataFrame | None":
         """Build sector context and run the daily report.
 
         Returns the ranked results DataFrame, or None when there are no
         candidates (orchestrator then returns the empty ScreenerResponse).
         Populates ctx.ticker_info and ctx.sector_rotation_by_name.
         """
-        ticker_info = get_multiple_ticker_info(ctx.screening_tickers) if ctx.screening_tickers else {}
+        ticker_info = (
+            get_multiple_ticker_info(ctx.screening_tickers)
+            if ctx.screening_tickers
+            else {}
+        )
         etf_returns = sector_rotation.compute_sector_benchmark_returns(ctx.ohlcv)
         rotation_scores = sector_rotation.compute_sector_rotation_scores(ctx.ohlcv)
         ticker_sectors = {
@@ -501,7 +651,9 @@ class ScreenerService:
             results = results.sort_values("confidence", ascending=False)
             if ctx.request.top:
                 # Stage 1: widen prefilter to allow combined priority stage to re-rank
-                prefilter_n = ctx.request.top * ctx.combined_priority_cfg.prefilter_multiplier
+                prefilter_n = (
+                    ctx.request.top * ctx.combined_priority_cfg.prefilter_multiplier
+                )
                 results = results.head(prefilter_n)
             results["rank"] = range(1, len(results) + 1)
 
@@ -512,7 +664,9 @@ class ScreenerService:
 
         return results
 
-    def _build_candidates(self, ctx: _RunContext, results: "pd.DataFrame") -> list[ScreenerCandidate]:
+    def _build_candidates(
+        self, ctx: _RunContext, results: "pd.DataFrame"
+    ) -> list[ScreenerCandidate]:
         """Construct ScreenerCandidate objects for each ranked result row.
 
         Reads ctx.ohlcv, ticker_info, benchmark, last_bar_map, overall_last_bar,
@@ -536,7 +690,9 @@ class ScreenerService:
         price_history_by_ticker = price_history_map(ohlcv, tickers=ticker_list)
         patterns_map = detect_patterns(ohlcv, tickers=ticker_list, cfg=CandleConfig())
         exec_cfg = ExecutionConfig()
-        benchmark_history = price_history_map(ohlcv, tickers=[benchmark]).get(benchmark, [])
+        benchmark_history = price_history_map(ohlcv, tickers=[benchmark]).get(
+            benchmark, []
+        )
         benchmark_change_pct = price_history_change_pct(benchmark_history)
         benchmark_last_bar = last_bar_map.get(benchmark) or overall_last_bar
 
@@ -549,8 +705,16 @@ class ScreenerService:
             sma200_dist = safe_float(row.get("dist_sma200_pct"))
             last_price = safe_float(row.get("last"))
 
-            sma50 = last_price / (1 + sma50_dist / 100) if last_price and sma50_dist else last_price
-            sma200 = last_price / (1 + sma200_dist / 100) if last_price and sma200_dist else last_price
+            sma50 = (
+                last_price / (1 + sma50_dist / 100)
+                if last_price and sma50_dist
+                else last_price
+            )
+            sma200 = (
+                last_price / (1 + sma200_dist / 100)
+                if last_price and sma200_dist
+                else last_price
+            )
 
             ticker_str = str(idx)
             info = ticker_info.get(ticker_str, {})
@@ -575,7 +739,11 @@ class ScreenerService:
             shares_val = safe_optional_int(row.get("shares"))
             position_size = safe_optional_float(row.get("position_value"))
             risk_usd = safe_optional_float(row.get("realized_risk"))
-            risk_pct = (risk_usd / risk_cfg.account_size) if risk_usd and risk_cfg.account_size else None
+            risk_pct = (
+                (risk_usd / risk_cfg.account_size)
+                if risk_usd and risk_cfg.account_size
+                else None
+            )
 
             # Anchor the entry stop to the setup's structural invalidation when a
             # tighter pattern stop is available, so 1R reflects the real risk level
@@ -599,7 +767,9 @@ class ScreenerService:
                 risk_pct = None
 
             rr_target = safe_float(getattr(risk_cfg, "rr_target", 2.0), default=2.0)
-            commission_pct = safe_float(getattr(risk_cfg, "commission_pct", 0.0), default=0.0)
+            commission_pct = safe_float(
+                getattr(risk_cfg, "commission_pct", 0.0), default=0.0
+            )
 
             rec_payload = evaluate_recommendation(
                 signal=str(signal) if not is_na_scalar(signal) else None,
@@ -622,15 +792,17 @@ class ScreenerService:
                 sma_200=sma200,
                 atr=safe_float(row.get(atr_col)),
                 momentum_6m=safe_float(row.get("mom_6m")),
-                    momentum_12m=safe_float(row.get("mom_12m")),
-                    rel_strength=safe_float(row.get("rs_6m")),
-                    confidence=safe_float(row.get("confidence")),
+                momentum_12m=safe_float(row.get("mom_12m")),
+                rel_strength=safe_float(row.get("rs_6m")),
+                confidence=safe_float(row.get("confidence")),
             )
             recommendation = Recommendation.model_validate(asdict(rec_payload))
             rec_risk = recommendation.risk
             candidate_history = price_history_by_ticker.get(ticker_str, [])
             symbol_change_pct = price_history_change_pct(candidate_history)
-            benchmark_price_history = aligned_benchmark_price_history(candidate_history, benchmark_history)
+            benchmark_price_history = aligned_benchmark_price_history(
+                candidate_history, benchmark_history
+            )
             benchmark_outperformance_pct = (
                 symbol_change_pct - benchmark_change_pct
                 if symbol_change_pct is not None and benchmark_change_pct is not None
@@ -655,8 +827,10 @@ class ScreenerService:
                 ScreenerCandidate(
                     ticker=ticker_str,
                     currency=currency,
-                    exchange_mic=str(instrument.get("exchange_mic") or "").upper() or None,
-                    instrument_type=str(instrument.get("instrument_type") or "").lower() or None,
+                    exchange_mic=str(instrument.get("exchange_mic") or "").upper()
+                    or None,
+                    instrument_type=str(instrument.get("instrument_type") or "").lower()
+                    or None,
                     is_otc=str(instrument.get("exchange_mic") or "").upper() == "XOTC",
                     name=info.get("name"),
                     sector=info.get("sector"),
@@ -675,9 +849,15 @@ class ScreenerService:
                     rank=int(row.get("rank", len(candidates) + 1)),
                     sma20_slope=safe_optional_float(row.get("sma20_slope")),
                     sma50_slope=safe_optional_float(row.get("sma50_slope")),
-                    consolidation_tightness=safe_optional_float(row.get("consolidation_tightness")),
-                    close_location_in_range=safe_optional_float(row.get("close_location_in_range")),
-                    above_breakout_extension=safe_optional_float(row.get("above_breakout_extension")),
+                    consolidation_tightness=safe_optional_float(
+                        row.get("consolidation_tightness")
+                    ),
+                    close_location_in_range=safe_optional_float(
+                        row.get("close_location_in_range")
+                    ),
+                    above_breakout_extension=safe_optional_float(
+                        row.get("above_breakout_extension")
+                    ),
                     breakout_volume_confirmation=(
                         bool(row.get("breakout_volume_confirmation"))
                         if not is_na_scalar(row.get("breakout_volume_confirmation"))
@@ -695,10 +875,14 @@ class ScreenerService:
                         else None
                     ),
                     volume_ratio=safe_optional_float(row.get("volume_ratio")),
-                    avg_daily_volume_eur=safe_optional_float(row.get("avg_daily_volume_eur")),
+                    avg_daily_volume_eur=safe_optional_float(
+                        row.get("avg_daily_volume_eur")
+                    ),
                     symbol_change_pct=symbol_change_pct,
                     benchmark_outperformance_pct=benchmark_outperformance_pct,
-                    sector_rotation_context=sector_rotation_by_name.get(info.get("sector")),
+                    sector_rotation_context=sector_rotation_by_name.get(
+                        info.get("sector")
+                    ),
                     data_source_summary={"market_data": market_health},
                     signal=str(signal) if not is_na_scalar(signal) else None,
                     entry=rec_risk.entry,
@@ -706,7 +890,11 @@ class ScreenerService:
                     target=rec_risk.target,
                     rr=rec_risk.rr,
                     shares=shares_val if shares_val is not None else rec_risk.shares,
-                    position_size_usd=position_size if position_size is not None else rec_risk.position_size,
+                    position_size_usd=(
+                        position_size
+                        if position_size is not None
+                        else rec_risk.position_size
+                    ),
                     risk_usd=risk_usd if risk_usd is not None else rec_risk.risk_amount,
                     risk_pct=risk_pct if risk_pct is not None else rec_risk.risk_pct,
                     recommendation=recommendation,
@@ -720,7 +908,9 @@ class ScreenerService:
                         if not is_na_scalar(row.get("suggested_order_type"))
                         else None
                     ),
-                    suggested_order_price=safe_optional_float(row.get("suggested_order_price")),
+                    suggested_order_price=safe_optional_float(
+                        row.get("suggested_order_price")
+                    ),
                     execution_note=(
                         str(row.get("execution_note"))
                         if not is_na_scalar(row.get("execution_note"))
@@ -744,14 +934,22 @@ class ScreenerService:
         strategy = ctx.strategy
         risk_cfg = ctx.risk_cfg
 
-        portfolio_positions = self._portfolio_service.list_positions(status="open").positions
-        portfolio_closed = self._portfolio_service.list_positions(status="closed").positions
+        portfolio_positions = self._portfolio_service.list_positions(
+            status="open"
+        ).positions
+        portfolio_closed = self._portfolio_service.list_positions(
+            status="closed"
+        ).positions
         portfolio_orders: list = []
         if self._orders_service is not None:
             try:
-                portfolio_orders = self._orders_service.list_local_orders().get("orders", [])
+                portfolio_orders = self._orders_service.list_local_orders().get(
+                    "orders", []
+                )
             except Exception as exc:
-                logger.warning("Failed to load orders for same-symbol evaluation: %s", exc)
+                logger.warning(
+                    "Failed to load orders for same-symbol evaluation: %s", exc
+                )
         same_symbol_evaluator = SameSymbolReentryEvaluator(self._portfolio_service)
         same_symbol_suppressed_count = 0
         same_symbol_add_on_count = 0
@@ -786,7 +984,11 @@ class ScreenerService:
             if enriched_candidate is not None:
                 filtered_candidates.append(enriched_candidate)
 
-        return filtered_candidates, same_symbol_suppressed_count, same_symbol_add_on_count
+        return (
+            filtered_candidates,
+            same_symbol_suppressed_count,
+            same_symbol_add_on_count,
+        )
 
     def _enrich_and_rank(
         self,
@@ -809,8 +1011,12 @@ class ScreenerService:
         warnings = ctx.warnings
 
         fundamentals_snapshots = load_fundamentals_snapshots(candidates)
-        candidates = apply_cached_fundamentals_context(candidates, snapshots=fundamentals_snapshots)
-        candidates = apply_decision_summary_context(candidates, snapshots=fundamentals_snapshots)
+        candidates = apply_cached_fundamentals_context(
+            candidates, snapshots=fundamentals_snapshots
+        )
+        candidates = apply_decision_summary_context(
+            candidates, snapshots=fundamentals_snapshots
+        )
 
         finnhub_key = os.environ.get("FINNHUB_API_KEY")
         earnings_asof_date = dt.date.fromisoformat(asof_str)
@@ -821,7 +1027,9 @@ class ScreenerService:
             cache_path=".cache/earnings_days.json",
         )
         candidates = [
-            candidate.model_copy(update={"days_to_earnings": earnings_days.get(candidate.ticker)})
+            candidate.model_copy(
+                update={"days_to_earnings": earnings_days.get(candidate.ticker)}
+            )
             for candidate in candidates
         ]
 
@@ -830,7 +1038,8 @@ class ScreenerService:
             candidates = [
                 candidate
                 for candidate in candidates
-                if candidate.days_to_earnings is None or candidate.days_to_earnings >= min_days_to_earnings
+                if candidate.days_to_earnings is None
+                or candidate.days_to_earnings >= min_days_to_earnings
             ]
 
         # Stage 2: combined priority re-ranks prefilter set and trims to final top-N
@@ -840,7 +1049,9 @@ class ScreenerService:
             candidates,
             risk_cfg=risk_cfg,
             rr_target=safe_float(getattr(risk_cfg, "rr_target", 2.0), default=2.0),
-            commission_pct=safe_float(getattr(risk_cfg, "commission_pct", 0.0), default=0.0),
+            commission_pct=safe_float(
+                getattr(risk_cfg, "commission_pct", 0.0), default=0.0
+            ),
         )
         candidates = apply_decision_priority_ranking(candidates)
         if same_symbol_suppressed_count > 0:
@@ -855,7 +1066,9 @@ class ScreenerService:
 
         return candidates
 
-    def run_screener(self, request: ScreenerRequest, strategy_override: Optional[dict] = None) -> ScreenerResponse:
+    def run_screener(
+        self, request: ScreenerRequest, strategy_override: Optional[dict] = None
+    ) -> ScreenerResponse:
         try:
             ctx = _RunContext(
                 request=request,
@@ -916,12 +1129,15 @@ class ScreenerService:
             logger.exception("Unexpected screener error")
             raise ServiceError("Screener failed unexpectedly")
 
-    def start_run_async(self, request: ScreenerRequest, on_complete=None) -> ScreenerRunLaunchResponse:
+    def start_run_async(
+        self, request: ScreenerRequest, on_complete=None
+    ) -> ScreenerRunLaunchResponse:
         """Start screener run in background and return job metadata.
 
         ``on_complete`` is invoked with the ScreenerResponse after a successful
         run (e.g. to record screener history); its failures never fail the job.
         """
+
         def _run() -> ScreenerResponse:
             result = self.run_screener(request)
             if on_complete is not None:

--- a/api/services/screener_service.py
+++ b/api/services/screener_service.py
@@ -512,6 +512,49 @@ class ScreenerService:
                     f"{', '.join(missing)}"
                 )
 
+        self._record_fetch_health(ctx)
+
+    def _record_fetch_health(self, ctx: _RunContext) -> None:
+        """Update per-symbol fetch counters; enqueue symbols that cross the threshold.
+
+        Best-effort: a failure here never aborts the screen.
+        """
+        try:
+            from swing_screener.data.symbol_pool import load_symbol_pool_thresholds
+
+            _, _, threshold = load_symbol_pool_thresholds()
+            present: set[str] = set()
+            if (
+                ctx.ohlcv is not None
+                and not ctx.ohlcv.empty
+                and "Close" in ctx.ohlcv.columns.get_level_values(0)
+            ):
+                present = set(ctx.ohlcv["Close"].columns)
+            requested = list(ctx.screening_tickers)
+            ok = [t for t in requested if t in present]
+            failed = [t for t in requested if t not in present]
+            crossed = self._pool_repo.apply_fetch_results(
+                ok, failed, ctx.asof_str, threshold
+            )
+            if crossed:
+                entries = [
+                    {
+                        "symbol": c["symbol"],
+                        "exchange_mic": c.get("exchange_mic"),
+                        "failure_count": c.get("fetch_failure_count"),
+                        "first_failed_at": c.get("last_fetch_ok_at") or ctx.asof_str,
+                        "last_failed_at": ctx.asof_str,
+                        "reason": "OHLCV fetch returned no data",
+                    }
+                    for c in crossed
+                ]
+                self._review_repo.upsert(entries)
+        except (
+            Exception
+        ) as exc:  # noqa: BLE001 - health tracking must never break a screen
+            logger.warning("Fetch-health tracking failed: %s", exc)
+            ctx.warnings.append("Fetch-health tracking unavailable this run.")
+
     def _build_run_configs(self, ctx: _RunContext, requested_top: int) -> None:
         """Apply request filter overrides and build ranking/risk/report configs.
 

--- a/config/taxonomy_presets.yaml
+++ b/config/taxonomy_presets.yaml
@@ -1,0 +1,24 @@
+# Named taxonomy presets for the unified symbol pool screener.
+# Each preset pre-fills the quick filter bar. Selecting one then editing a
+# chip marks the selection "custom" in the UI.
+presets:
+  us_large_cap_equities:
+    label: "US Large Cap Equities"
+    filter:
+      region: [us]
+      market_cap_tier: [large]
+      instrument_type_detail: [equity]
+  eu_blue_chips:
+    label: "EU Blue Chips"
+    filter:
+      region: [europe]
+      market_cap_tier: [large]
+      instrument_type_detail: [equity]
+  sector_etfs:
+    label: "Sector ETFs"
+    filter:
+      instrument_type_detail: [etf_sector]
+  broad_market:
+    label: "Broad Market"
+    filter:
+      index_memberships: [broad_market_stocks]

--- a/data/symbol_pool.json
+++ b/data/symbol_pool.json
@@ -1,0 +1,34360 @@
+{
+  "schema_version": 1,
+  "asof": "2026-06-30",
+  "symbols": [
+    {
+      "symbol": "ABN.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_aex",
+        "amsterdam_all",
+        "financial_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ADYEN.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_aex",
+        "amsterdam_all",
+        "europe_eurostoxx50"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "AGN.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_aex",
+        "amsterdam_all"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "AD.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_aex",
+        "amsterdam_all",
+        "broad_market_stocks",
+        "europe_eurostoxx50",
+        "europe_large_caps"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "AKZA.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_aex",
+        "amsterdam_all"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MT.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_aex",
+        "amsterdam_all",
+        "france_cac40"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ASM.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_aex",
+        "amsterdam_all",
+        "semiconductor_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ASML.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_aex",
+        "amsterdam_all",
+        "broad_market_stocks",
+        "europe_eurostoxx50",
+        "europe_large_caps",
+        "semiconductor_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ASRNL.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_aex",
+        "amsterdam_all",
+        "financial_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BESI.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_aex",
+        "amsterdam_all",
+        "semiconductor_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CVC.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_aex",
+        "amsterdam_all"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "DSFIR.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_aex",
+        "amsterdam_all"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "EXO.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_aex",
+        "amsterdam_all"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "HEIA.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_aex",
+        "amsterdam_all",
+        "broad_market_stocks",
+        "europe_large_caps"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "IMCD.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_aex",
+        "amsterdam_all"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "INGA.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_aex",
+        "amsterdam_all",
+        "europe_eurostoxx50",
+        "financial_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "INPST.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_aex",
+        "amsterdam_all"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "JDEP.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_aex",
+        "amsterdam_all"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "TKWY.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_aex",
+        "amsterdam_all"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "KPN.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_aex",
+        "amsterdam_all",
+        "broad_market_stocks",
+        "europe_large_caps"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "NN.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_aex",
+        "amsterdam_all",
+        "financial_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "PHIA.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_aex",
+        "amsterdam_all"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "PRX.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_aex",
+        "amsterdam_all",
+        "europe_eurostoxx50"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "REN.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_aex",
+        "amsterdam_all"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SHELL.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_aex",
+        "amsterdam_all",
+        "energy_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "UMG.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_aex",
+        "amsterdam_all"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "UNA.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_aex",
+        "amsterdam_all",
+        "broad_market_stocks",
+        "europe_large_caps"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "WDP.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_aex",
+        "amsterdam_all"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "WKL.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_aex",
+        "amsterdam_all",
+        "europe_eurostoxx50"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SBMO.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_aex",
+        "amsterdam_all"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "AALB.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_all",
+        "amsterdam_amx"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "AF.PA",
+      "exchange_mic": "XPAR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_all",
+        "amsterdam_amx"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ALLFG.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_all",
+        "amsterdam_amx"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "AMG.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_all",
+        "amsterdam_amx"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "APAM.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_all",
+        "amsterdam_amx"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ARCAD.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_all",
+        "amsterdam_amx"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BAMNB.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_all",
+        "amsterdam_amx"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BFIT.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_all",
+        "amsterdam_amx"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CRBN.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_all",
+        "amsterdam_amx"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CTPNV.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_all",
+        "amsterdam_amx"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ECMPA.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_all",
+        "amsterdam_amx"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "FAGR.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_all",
+        "amsterdam_amx"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "FLOW.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_all",
+        "amsterdam_amx"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "FUR.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_all",
+        "amsterdam_amx"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "GLPG.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_all",
+        "amsterdam_amx",
+        "healthcare_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "HAL.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_all",
+        "amsterdam_amx"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "HAVAS.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_all",
+        "amsterdam_amx"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "HEIJM.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_all",
+        "amsterdam_amx"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "PHARM.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_all",
+        "amsterdam_amx",
+        "healthcare_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "LIGHT.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_all",
+        "amsterdam_amx"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "TWEKA.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_all",
+        "amsterdam_amx"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "VLK.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_all",
+        "amsterdam_amx"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "VPK.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_all",
+        "amsterdam_amx"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "RAND.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_all",
+        "amsterdam_amx",
+        "broad_market_stocks",
+        "europe_large_caps"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "THEON.AS",
+      "exchange_mic": "XAMS",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "amsterdam_all",
+        "amsterdam_amx",
+        "defense_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SPY",
+      "exchange_mic": "ARCX",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_etfs"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "etf",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "QQQ",
+      "exchange_mic": "ARCX",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_etfs"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "etf",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "DIA",
+      "exchange_mic": "ARCX",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_etfs"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "etf",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "IWM",
+      "exchange_mic": "ARCX",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_etfs"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "etf",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "XLB",
+      "exchange_mic": "ARCX",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_etfs"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "etf",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "XLC",
+      "exchange_mic": "ARCX",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_etfs"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "etf",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "XLE",
+      "exchange_mic": "ARCX",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_etfs"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "etf",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "XLF",
+      "exchange_mic": "ARCX",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_etfs"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "etf",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "XLI",
+      "exchange_mic": "ARCX",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_etfs"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "etf",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "XLK",
+      "exchange_mic": "ARCX",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_etfs"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "etf",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "XLP",
+      "exchange_mic": "ARCX",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_etfs"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "etf",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "XLU",
+      "exchange_mic": "ARCX",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_etfs"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "etf",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "XLV",
+      "exchange_mic": "ARCX",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_etfs",
+        "healthcare_etfs"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "etf",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "XLY",
+      "exchange_mic": "ARCX",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_etfs"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "etf",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "XLRE",
+      "exchange_mic": "ARCX",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_etfs"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "etf",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "EUNL.DE",
+      "exchange_mic": "XETR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_etfs"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "etf",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SXR8.DE",
+      "exchange_mic": "XETR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_etfs"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "etf",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "EXS1.DE",
+      "exchange_mic": "XETR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_etfs"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "etf",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "LYP6.DE",
+      "exchange_mic": "XETR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_etfs"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "etf",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SPPE.DE",
+      "exchange_mic": "XETR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_etfs"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "etf",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "AAPL",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "us_dow30",
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MSFT",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "us_dow30",
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "NVDA",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "semiconductor_stocks",
+        "us_dow30",
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "AMZN",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "us_dow30",
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "META",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "GOOGL",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "GOOG",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "TSLA",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BRK-B",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "financial_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "JPM",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "financial_stocks",
+        "us_dow30",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BAC",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "financial_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "WFC",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "financial_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "GS",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "financial_stocks",
+        "us_dow30",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MS",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "financial_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "V",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "financial_stocks",
+        "us_dow30",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MA",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "financial_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "AXP",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "financial_stocks",
+        "us_dow30",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "UNH",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "healthcare_stocks",
+        "us_dow30",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "LLY",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "healthcare_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "JNJ",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "healthcare_stocks",
+        "us_dow30",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MRK",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "healthcare_stocks",
+        "us_dow30",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "PFE",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "healthcare_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "AMGN",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "healthcare_stocks",
+        "us_dow30",
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ABBV",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "healthcare_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "TMO",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "healthcare_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "DHR",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "healthcare_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ISRG",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "healthcare_stocks",
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "XOM",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "energy_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CVX",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "energy_stocks",
+        "us_dow30",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "COP",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "energy_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SLB",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "energy_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "PG",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "us_dow30",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "KO",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "us_dow30",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "PEP",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "COST",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "WMT",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "us_dow30",
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "HD",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "us_dow30",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "LOW",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MCD",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "us_dow30",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "NKE",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "us_dow30",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SBUX",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "AVGO",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "semiconductor_stocks",
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "AMD",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "semiconductor_stocks",
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "INTC",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "semiconductor_stocks",
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "QCOM",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "semiconductor_stocks",
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "TXN",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "semiconductor_stocks",
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "AMAT",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "semiconductor_stocks",
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "LRCX",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "semiconductor_stocks",
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MU",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "semiconductor_stocks",
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CSCO",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "us_dow30",
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ORCL",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "IBM",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "us_dow30",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ADBE",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CRM",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "us_dow30",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "NOW",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "INTU",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CMCSA",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "DIS",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "us_dow30",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "NFLX",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "TMUS",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "T",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "VZ",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "us_dow30",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "UNP",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "UPS",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "RTX",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "defense_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "HON",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "defense_stocks",
+        "us_dow30",
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CAT",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "us_dow30",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "GE",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "defense_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BA",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "defense_stocks",
+        "us_dow30",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SPGI",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BLK",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BKNG",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "UBER",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ABNB",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "PLTR",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "defense_stocks",
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "PANW",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CRWD",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SNOW",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MDB",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BHP",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SHOP",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "us_nasdaq100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "TD",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BNS",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BMO",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "RY",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CM",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ENB",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "TRP",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SU",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CNQ",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CP",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CNI",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BCE",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "NU",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MELI",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "us_nasdaq100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SE",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SAP.DE",
+      "exchange_mic": "XETR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "europe_eurostoxx50",
+        "europe_large_caps",
+        "germany_dax"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SIE.DE",
+      "exchange_mic": "XETR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "europe_eurostoxx50",
+        "europe_large_caps",
+        "germany_dax"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "DTE.DE",
+      "exchange_mic": "XETR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "europe_eurostoxx50",
+        "europe_large_caps",
+        "germany_dax"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ALV.DE",
+      "exchange_mic": "XETR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "europe_eurostoxx50",
+        "europe_large_caps",
+        "financial_stocks",
+        "germany_dax"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BMW.DE",
+      "exchange_mic": "XETR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "europe_eurostoxx50",
+        "europe_large_caps",
+        "germany_dax"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MBG.DE",
+      "exchange_mic": "XETR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "europe_eurostoxx50",
+        "europe_large_caps",
+        "germany_dax"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "VOW3.DE",
+      "exchange_mic": "XETR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "europe_large_caps",
+        "germany_dax"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BAS.DE",
+      "exchange_mic": "XETR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "europe_eurostoxx50",
+        "europe_large_caps",
+        "germany_dax"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BAYN.DE",
+      "exchange_mic": "XETR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "europe_eurostoxx50",
+        "europe_large_caps",
+        "germany_dax",
+        "healthcare_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "IFX.DE",
+      "exchange_mic": "XETR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "europe_eurostoxx50",
+        "europe_large_caps",
+        "germany_dax",
+        "semiconductor_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MUV2.DE",
+      "exchange_mic": "XETR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "europe_eurostoxx50",
+        "europe_large_caps",
+        "financial_stocks",
+        "germany_dax"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "RWE.DE",
+      "exchange_mic": "XETR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "europe_large_caps",
+        "germany_dax"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "VNA.DE",
+      "exchange_mic": "XETR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "europe_large_caps",
+        "germany_dax"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "PUM.DE",
+      "exchange_mic": "XETR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "europe_large_caps"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "FRE.DE",
+      "exchange_mic": "XETR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "europe_large_caps",
+        "germany_dax",
+        "healthcare_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "FME.DE",
+      "exchange_mic": "XETR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "europe_large_caps",
+        "germany_dax",
+        "healthcare_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "HNR1.DE",
+      "exchange_mic": "XETR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "europe_large_caps",
+        "germany_dax"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MC.PA",
+      "exchange_mic": "XPAR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "europe_eurostoxx50",
+        "europe_large_caps",
+        "france_cac40"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "OR.PA",
+      "exchange_mic": "XPAR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "europe_eurostoxx50",
+        "europe_large_caps",
+        "france_cac40"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "AIR.PA",
+      "exchange_mic": "XPAR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "defense_stocks",
+        "europe_eurostoxx50",
+        "europe_large_caps",
+        "france_cac40",
+        "germany_dax"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SAN.PA",
+      "exchange_mic": "XPAR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "europe_eurostoxx50",
+        "europe_large_caps",
+        "france_cac40",
+        "healthcare_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BNP.PA",
+      "exchange_mic": "XPAR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "europe_eurostoxx50",
+        "europe_large_caps",
+        "financial_stocks",
+        "france_cac40"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ACA.PA",
+      "exchange_mic": "XPAR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "europe_large_caps",
+        "financial_stocks",
+        "france_cac40"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "GLE.PA",
+      "exchange_mic": "XPAR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "europe_large_caps",
+        "financial_stocks",
+        "france_cac40"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SU.PA",
+      "exchange_mic": "XPAR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "europe_eurostoxx50",
+        "europe_large_caps",
+        "france_cac40"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "DG.PA",
+      "exchange_mic": "XPAR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "europe_eurostoxx50",
+        "europe_large_caps",
+        "france_cac40"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "HO.PA",
+      "exchange_mic": "XPAR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "defense_stocks",
+        "europe_large_caps",
+        "france_cac40"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "KER.PA",
+      "exchange_mic": "XPAR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "europe_large_caps",
+        "france_cac40"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "RI.PA",
+      "exchange_mic": "XPAR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "europe_large_caps",
+        "france_cac40"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "TTE.PA",
+      "exchange_mic": "XPAR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "energy_stocks",
+        "europe_eurostoxx50",
+        "europe_large_caps",
+        "france_cac40"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ENGI.PA",
+      "exchange_mic": "XPAR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "europe_large_caps",
+        "france_cac40"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SGO.PA",
+      "exchange_mic": "XPAR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "europe_eurostoxx50",
+        "europe_large_caps",
+        "france_cac40"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CAP.PA",
+      "exchange_mic": "XPAR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "europe_large_caps",
+        "france_cac40"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ITX.MC",
+      "exchange_mic": "XMAD",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "europe_eurostoxx50",
+        "europe_large_caps",
+        "spain_ibex35"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "IBE.MC",
+      "exchange_mic": "XMAD",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "europe_eurostoxx50",
+        "europe_large_caps",
+        "spain_ibex35"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SAN.MC",
+      "exchange_mic": "XMAD",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "europe_eurostoxx50",
+        "europe_large_caps",
+        "financial_stocks",
+        "spain_ibex35"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BBVA.MC",
+      "exchange_mic": "XMAD",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "europe_eurostoxx50",
+        "europe_large_caps",
+        "financial_stocks",
+        "spain_ibex35"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "TEF.MC",
+      "exchange_mic": "XMAD",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "europe_large_caps",
+        "spain_ibex35"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "REP.MC",
+      "exchange_mic": "XMAD",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "energy_stocks",
+        "europe_large_caps",
+        "spain_ibex35"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ENEL.MI",
+      "exchange_mic": "XMIL",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "europe_eurostoxx50",
+        "europe_large_caps",
+        "italy_ftse_mib"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ENI.MI",
+      "exchange_mic": "XMIL",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "energy_stocks",
+        "europe_eurostoxx50",
+        "europe_large_caps",
+        "italy_ftse_mib"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ISP.MI",
+      "exchange_mic": "XMIL",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "europe_eurostoxx50",
+        "europe_large_caps",
+        "financial_stocks",
+        "italy_ftse_mib"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "UCG.MI",
+      "exchange_mic": "XMIL",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "broad_market_stocks",
+        "europe_eurostoxx50",
+        "europe_large_caps",
+        "financial_stocks",
+        "italy_ftse_mib"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600519.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601318.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "300750.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600036.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "000333.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "000858.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600900.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601166.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601899.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600030.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600276.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601398.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600887.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "300059.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "000651.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "300760.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "002594.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601328.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600309.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "000725.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600919.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "002475.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "300124.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601288.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "002415.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "000568.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601012.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601088.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601816.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600028.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600809.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601668.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "603259.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "002714.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "000001.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "300498.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600016.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601857.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601225.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "300308.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "688981.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "000063.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601988.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "002352.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600406.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600941.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "000338.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600050.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "002230.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600690.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601728.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "300274.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "002142.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "000792.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601601.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "000100.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601888.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600000.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600031.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601985.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600150.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "688041.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601766.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601169.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "002371.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600089.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601688.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601138.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "000625.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600438.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600048.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "603501.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600104.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600660.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "000002.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "300015.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601211.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "603288.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600436.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601919.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600905.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601390.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601229.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "300122.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "002027.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "688012.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "688111.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601006.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "002304.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601818.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600019.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "688271.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "603019.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600585.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "002050.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "002466.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601658.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600938.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600999.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "688036.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "000938.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601628.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "603986.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "002049.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601600.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600111.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "688008.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "300014.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601939.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600958.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600893.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "002460.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601009.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "000538.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601669.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600009.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "002129.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "603993.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600886.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600760.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "000425.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "000776.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601916.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600795.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "000661.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "000166.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600426.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600015.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "300782.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601377.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601186.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "000157.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "002241.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600926.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600547.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600011.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "000977.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "002252.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600674.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "603799.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600584.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600570.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "002236.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "002179.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "000596.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "002311.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600188.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "300896.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "688256.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600010.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "002271.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601111.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "001979.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "300408.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600845.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "603369.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600989.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600745.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601788.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600115.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600029.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "002601.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601360.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601901.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "002493.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600196.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "002459.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601699.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601995.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600085.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601100.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601800.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "000895.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "002555.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "003816.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600489.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601066.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "000963.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "300142.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "300033.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "000768.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601633.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "000786.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "002920.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600600.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601868.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "002648.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601021.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "603392.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "000301.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "002001.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600741.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601336.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601689.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "688599.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "002812.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600346.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "000983.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601881.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600588.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600515.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601117.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601838.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "688126.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "300450.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "002736.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "002821.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "300316.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "300433.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600176.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "002709.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "300347.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601618.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601872.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "000408.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "002180.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "300661.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600372.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601898.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "688396.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "300496.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "000733.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601877.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600233.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "000999.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600219.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "002007.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600023.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "002074.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "002202.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "300759.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600332.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "603806.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600362.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "000876.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600183.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601607.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601799.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "301269.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601238.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601878.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601998.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600918.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "300999.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "300223.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "603260.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "688303.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "300413.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601615.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "002410.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600875.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "002603.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600061.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "688223.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600460.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600803.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "300751.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600025.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601319.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "002841.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600732.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "603659.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "300454.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "300919.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600132.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "000617.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "300763.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "000069.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600018.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "000708.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "300628.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "002938.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "002916.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "605117.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600039.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "605499.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "603195.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600754.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "603899.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "603290.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "603833.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601865.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "688363.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "000877.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "688065.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "300957.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601236.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601698.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "688187.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "688561.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601155.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "600606.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "300979.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601808.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "603486.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "000800.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "601059.SS",
+      "exchange_mic": "XSHG",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "001289.SZ",
+      "exchange_mic": "XSHE",
+      "currency": "CNY",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "china_csi300"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ITA",
+      "exchange_mic": "ARCX",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "defense_etfs"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "etf",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "XAR",
+      "exchange_mic": "ARCX",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "defense_etfs"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "etf",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "PPA",
+      "exchange_mic": "ARCX",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "defense_etfs"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "etf",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "DFEN",
+      "exchange_mic": "ARCX",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "defense_etfs"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "etf",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "DFNS.PA",
+      "exchange_mic": "XPAR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "defense_etfs"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "etf",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "DFNS.MI",
+      "exchange_mic": "XMIL",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "defense_etfs"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "etf",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "LMT",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "defense_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "NOC",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "defense_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "LHX",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "defense_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "GD",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "defense_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "TDG",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "defense_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "HWM",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "defense_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "AXON",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "defense_stocks",
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "HII",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "defense_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SAIC",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "defense_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CACI",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "defense_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "LDOS",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "defense_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "KTOS",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "defense_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "AVAV",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "defense_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "TXT",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "defense_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BWXT",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "defense_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "HEI",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "defense_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MRCY",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "defense_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "DRS",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "defense_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CW",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "defense_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "WWD",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "defense_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "HXL",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "defense_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "TDY",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "defense_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BAH",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "defense_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "OSIS",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "defense_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "KBR",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "defense_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "FLR",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "defense_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "PKE",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "defense_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "VSEC",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "defense_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "RKLB",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "defense_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ADS.DE",
+      "exchange_mic": "XETR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "europe_eurostoxx50",
+        "germany_dax"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "AI.PA",
+      "exchange_mic": "XPAR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "europe_eurostoxx50",
+        "france_cac40"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ABI.BR",
+      "exchange_mic": "XBRU",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "europe_eurostoxx50"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ARGX.BR",
+      "exchange_mic": "XBRU",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "europe_eurostoxx50"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CS.PA",
+      "exchange_mic": "XPAR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "europe_eurostoxx50",
+        "france_cac40"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BN.PA",
+      "exchange_mic": "XPAR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "europe_eurostoxx50",
+        "france_cac40"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "DBK.DE",
+      "exchange_mic": "XETR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "europe_eurostoxx50",
+        "germany_dax"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "DB1.DE",
+      "exchange_mic": "XETR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "europe_eurostoxx50",
+        "germany_dax"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "DHL.DE",
+      "exchange_mic": "XETR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "europe_eurostoxx50",
+        "germany_dax"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "EL.PA",
+      "exchange_mic": "XPAR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "europe_eurostoxx50",
+        "france_cac40"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "RACE.MI",
+      "exchange_mic": "XMIL",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "europe_eurostoxx50",
+        "italy_ftse_mib"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "RMS.PA",
+      "exchange_mic": "XPAR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "europe_eurostoxx50",
+        "france_cac40"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "NDA-FI.HE",
+      "exchange_mic": "XHEL",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "europe_eurostoxx50"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "RHM.DE",
+      "exchange_mic": "XETR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "europe_eurostoxx50",
+        "germany_dax"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SAF.PA",
+      "exchange_mic": "XPAR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "europe_eurostoxx50",
+        "france_cac40"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ENR.DE",
+      "exchange_mic": "XETR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "europe_eurostoxx50",
+        "germany_dax"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "VOW.DE",
+      "exchange_mic": "XETR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "europe_eurostoxx50"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "AC.PA",
+      "exchange_mic": "XPAR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "france_cac40"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "EN.PA",
+      "exchange_mic": "XPAR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "france_cac40"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BVI.PA",
+      "exchange_mic": "XPAR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "france_cac40"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CA.PA",
+      "exchange_mic": "XPAR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "france_cac40"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "DSY.PA",
+      "exchange_mic": "XPAR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "france_cac40"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "EDEN.PA",
+      "exchange_mic": "XPAR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "france_cac40"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ERF.PA",
+      "exchange_mic": "XPAR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "france_cac40"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "LR.PA",
+      "exchange_mic": "XPAR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "france_cac40"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ML.PA",
+      "exchange_mic": "XPAR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "france_cac40"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ORA.PA",
+      "exchange_mic": "XPAR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "france_cac40"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "PUB.PA",
+      "exchange_mic": "XPAR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "france_cac40"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "RNO.PA",
+      "exchange_mic": "XPAR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "france_cac40"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "STLAP.PA",
+      "exchange_mic": "XPAR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "france_cac40"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "STMPA.PA",
+      "exchange_mic": "XPAR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "france_cac40"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "TEP.PA",
+      "exchange_mic": "XPAR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "france_cac40"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "URW.PA",
+      "exchange_mic": "XPAR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "france_cac40"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "VIE.PA",
+      "exchange_mic": "XPAR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "france_cac40"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BEI.DE",
+      "exchange_mic": "XETR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "germany_dax"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BNR.DE",
+      "exchange_mic": "XETR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "germany_dax"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CBK.DE",
+      "exchange_mic": "XETR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "germany_dax"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CON.DE",
+      "exchange_mic": "XETR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "germany_dax"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "DTG.DE",
+      "exchange_mic": "XETR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "germany_dax"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "EOAN.DE",
+      "exchange_mic": "XETR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "germany_dax"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "G1A.DE",
+      "exchange_mic": "XETR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "germany_dax"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "HEI.DE",
+      "exchange_mic": "XETR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "germany_dax"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "HEN3.DE",
+      "exchange_mic": "XETR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "germany_dax"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MRK.DE",
+      "exchange_mic": "XETR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "germany_dax"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MTX.DE",
+      "exchange_mic": "XETR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "germany_dax"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "PAH3.DE",
+      "exchange_mic": "XETR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "germany_dax"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "QIA.DE",
+      "exchange_mic": "XETR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "germany_dax"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "G24.DE",
+      "exchange_mic": "XETR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "germany_dax"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SHL.DE",
+      "exchange_mic": "XETR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "germany_dax"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SY1.DE",
+      "exchange_mic": "XETR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "germany_dax"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ZAL.DE",
+      "exchange_mic": "XETR",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "germany_dax"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ASML",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "global_proxy_stocks",
+        "us_nasdaq100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SAP",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "global_proxy_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "NVO",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "global_proxy_stocks",
+        "healthcare_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "NVS",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "global_proxy_stocks",
+        "healthcare_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SNY",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "global_proxy_stocks",
+        "healthcare_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "UL",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "global_proxy_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "DEO",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "global_proxy_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "GSK",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "global_proxy_stocks",
+        "healthcare_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "AZN",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "global_proxy_stocks",
+        "healthcare_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BP",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "global_proxy_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SHEL",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "global_proxy_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "HSBC",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "global_proxy_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "RIO",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "global_proxy_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BTI",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "global_proxy_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "RELX",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "global_proxy_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ING",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "global_proxy_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "UBS",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "global_proxy_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "DB",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "global_proxy_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SAN",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "global_proxy_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BBVA",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "global_proxy_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "TEF",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "global_proxy_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "EADSY",
+      "exchange_mic": "XOTC",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "global_proxy_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BAESY",
+      "exchange_mic": "XOTC",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "global_proxy_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SAFRY",
+      "exchange_mic": "XOTC",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "global_proxy_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "RYCEY",
+      "exchange_mic": "XOTC",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "global_proxy_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "LVMUY",
+      "exchange_mic": "XOTC",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "global_proxy_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "RHHBY",
+      "exchange_mic": "XOTC",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "global_proxy_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "TTE",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "global_proxy_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "TAK",
+      "exchange_mic": "XOTC",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "global_proxy_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BAYRY",
+      "exchange_mic": "XOTC",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "global_proxy_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CSLLY",
+      "exchange_mic": "XOTC",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "global_proxy_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "FINMY",
+      "exchange_mic": "XOTC",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "global_proxy_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "THLLY",
+      "exchange_mic": "XOTC",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "global_proxy_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "RNMBY",
+      "exchange_mic": "XOTC",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "global_proxy_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SAABY",
+      "exchange_mic": "XOTC",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "global_proxy_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "QNTQY",
+      "exchange_mic": "XOTC",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "global_proxy_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MTLHY",
+      "exchange_mic": "XOTC",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "global_proxy_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "VHT",
+      "exchange_mic": "ARCX",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_etfs"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "etf",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "IBB",
+      "exchange_mic": "ARCX",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_etfs"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "etf",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "XBI",
+      "exchange_mic": "ARCX",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_etfs"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "etf",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "IHE",
+      "exchange_mic": "ARCX",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_etfs"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "etf",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "IXJ",
+      "exchange_mic": "ARCX",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_etfs"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "etf",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "PJP",
+      "exchange_mic": "ARCX",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_etfs"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "etf",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "HLTW.MI",
+      "exchange_mic": "XMIL",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_etfs"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "etf",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BMY",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "GILD",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks",
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "VRTX",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks",
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "REGN",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks",
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BIIB",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ALNY",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks",
+        "us_nasdaq100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MRNA",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BNTX",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "TEVA",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MDT",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ABT",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SYK",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BSX",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ZBH",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "EW",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "HOLX",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "DXCM",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks",
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "RMD",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BDX",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BAX",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "STE",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "PEN",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "IDXX",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks",
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ZTS",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "WAT",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MTD",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "IQV",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "LH",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "DGX",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ILMN",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "EXAS",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "NTRA",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ALKS",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "HALO",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "KRYS",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "FOLD",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "RVMD",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "PCVX",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MIRM",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "PRAX",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "INSM",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks",
+        "us_nasdaq100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ARGX",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SRPT",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CRSP",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "NTLA",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BEAM",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "EDIT",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ELV",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CI",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "HUM",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CVS",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "HCA",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CNC",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "UHS",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "THC",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MCK",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CAH",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "COR",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "healthcare_stocks",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "0005.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "0388.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "0939.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "1299.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "1398.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "2318.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "2388.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "2628.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "3968.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "3988.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "0002.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "0003.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "0006.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "0836.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "1038.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "2688.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "0012.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "0016.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "0101.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "0688.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "0823.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "0960.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "1109.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "1113.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "1209.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "1997.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "0001.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "0027.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "0066.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "0175.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "0241.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "0267.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "0285.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "0288.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "0291.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "0300.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "0316.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "0322.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "0386.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "0669.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "0700.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "0762.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "0857.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "0868.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "0881.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "0883.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "0941.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "0968.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "0981.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "0992.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "1024.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "1044.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "1088.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "1093.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "1099.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "1177.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "1211.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "1378.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "1810.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "1876.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "1928.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "1929.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "2015.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "2020.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "2057.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "2269.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "2313.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "2319.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "2331.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "2359.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "2382.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "2618.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "2899.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "3690.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "3692.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "6618.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "6690.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "6862.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "9618.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "9633.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "9888.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "9961.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "9988.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "9992.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "9999.HK",
+      "exchange_mic": "XHKG",
+      "currency": "HKD",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "hongkong_hsi"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "A2A.MI",
+      "exchange_mic": "XMIL",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "italy_ftse_mib"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "AMP.MI",
+      "exchange_mic": "XMIL",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "italy_ftse_mib"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "AZM.MI",
+      "exchange_mic": "XMIL",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "italy_ftse_mib"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BAMI.MI",
+      "exchange_mic": "XMIL",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "italy_ftse_mib"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BMED.MI",
+      "exchange_mic": "XMIL",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "italy_ftse_mib"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BMPS.MI",
+      "exchange_mic": "XMIL",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "italy_ftse_mib"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BPE.MI",
+      "exchange_mic": "XMIL",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "italy_ftse_mib"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BUZZI.MI",
+      "exchange_mic": "XMIL",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "italy_ftse_mib"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CNH.MI",
+      "exchange_mic": "XMIL",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "italy_ftse_mib"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CPR.MI",
+      "exchange_mic": "XMIL",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "italy_ftse_mib"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "DIA.MI",
+      "exchange_mic": "XMIL",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "italy_ftse_mib"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "DLGI.MI",
+      "exchange_mic": "XMIL",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "italy_ftse_mib"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ERG.MI",
+      "exchange_mic": "XMIL",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "italy_ftse_mib"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "FBK.MI",
+      "exchange_mic": "XMIL",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "italy_ftse_mib"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "G.MI",
+      "exchange_mic": "XMIL",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "italy_ftse_mib"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "HER.MI",
+      "exchange_mic": "XMIL",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "italy_ftse_mib"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "IG.MI",
+      "exchange_mic": "XMIL",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "italy_ftse_mib"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "INW.MI",
+      "exchange_mic": "XMIL",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "italy_ftse_mib"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "IP.MI",
+      "exchange_mic": "XMIL",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "italy_ftse_mib"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "LDO.MI",
+      "exchange_mic": "XMIL",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "italy_ftse_mib"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MB.MI",
+      "exchange_mic": "XMIL",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "italy_ftse_mib"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MONC.MI",
+      "exchange_mic": "XMIL",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "italy_ftse_mib"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "NEXI.MI",
+      "exchange_mic": "XMIL",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "italy_ftse_mib"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "PIRC.MI",
+      "exchange_mic": "XMIL",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "italy_ftse_mib"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "PRY.MI",
+      "exchange_mic": "XMIL",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "italy_ftse_mib"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "PST.MI",
+      "exchange_mic": "XMIL",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "italy_ftse_mib"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "REC.MI",
+      "exchange_mic": "XMIL",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "italy_ftse_mib"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SPM.MI",
+      "exchange_mic": "XMIL",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "italy_ftse_mib"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SRG.MI",
+      "exchange_mic": "XMIL",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "italy_ftse_mib"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "STLAM.MI",
+      "exchange_mic": "XMIL",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "italy_ftse_mib"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "STM.MI",
+      "exchange_mic": "XMIL",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "italy_ftse_mib"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "TEN.MI",
+      "exchange_mic": "XMIL",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "italy_ftse_mib"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "TIT.MI",
+      "exchange_mic": "XMIL",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "italy_ftse_mib"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "TRN.MI",
+      "exchange_mic": "XMIL",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "italy_ftse_mib"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "UNI.MI",
+      "exchange_mic": "XMIL",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "italy_ftse_mib"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "090430.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "002790.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "278470.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "002030.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "282330.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "138930.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "068270.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "030000.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "185750.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "001040.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "097950.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "000120.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "192820.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "005420.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "021240.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "112610.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "001680.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "047040.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "003090.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "069620.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "005830.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "000210.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "375500.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "007340.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "026960.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "006040.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "014820.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "000150.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "241560.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "034020.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "454910.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "192080.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "450080.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "139480.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "383220.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "093370.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "114090.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "006280.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "005250.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "078930.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "006360.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "007070.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "086790.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "009420.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "300720.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "180640.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "161390.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "000240.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "128940.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "008930.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "042700.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "018880.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "014680.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "009240.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "000880.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "012450.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "082740.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "088350.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "042660.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "009830.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "272210.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "267250.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "267260.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "329180.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "071970.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "443060.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "009540.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "017960.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "000080.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "204320.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "011200.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "008770.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "298050.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "352820.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "298040.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "298020.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "307950.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "069960.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "000720.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "017800.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "086280.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "001450.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "012330.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "005380.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "064350.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "004020.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "011210.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "139130.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "024110.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "007660.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "457190.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "175330.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "035720.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "323410.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "377300.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "035250.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "105560.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "002380.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "015760.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "052690.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "051600.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "000270.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "039490.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "161890.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "120110.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "047810.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "071320.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "036460.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "071050.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "006650.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "010130.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "003490.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "259960.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "030200.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "033780.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "011780.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "073240.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "066970.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "003550.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "051910.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "064400.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "034220.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "066570.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "373220.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "051900.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "011070.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "032640.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "079550.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "004990.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "011170.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "005300.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "004000.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "023530.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "280360.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "006260.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "010120.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "138040.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "006800.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "081660.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "002840.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "268280.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "035420.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "036570.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "251270.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "005940.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "004370.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "010060.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "271560.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "001800.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "007310.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "028670.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "034230.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "103140.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "005490.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "022100.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "003670.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "047050.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "012750.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "062040.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "207940.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "028260.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "029780.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "028050.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "009150.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "005930.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "001260.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "000810.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "010140.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "032830.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "006400.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "018260.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "016360.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "003230.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "137310.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "001430.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "003030.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "004490.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "055550.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "004170.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "034730.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "326030.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "302440.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "285130.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "000660.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "361610.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "096770.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "402340.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "017670.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "011790.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "005850.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "010950.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "003240.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "001440.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "069260.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "316140.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "008730.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "000670.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "111770.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "009970.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "000100.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ACS.MC",
+      "exchange_mic": "XMAD",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "spain_ibex35"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ACX.MC",
+      "exchange_mic": "XMAD",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "spain_ibex35"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "AMS.MC",
+      "exchange_mic": "XMAD",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "spain_ibex35"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ANA.MC",
+      "exchange_mic": "XMAD",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "spain_ibex35"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ANE.MC",
+      "exchange_mic": "XMAD",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "spain_ibex35"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BKT.MC",
+      "exchange_mic": "XMAD",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "spain_ibex35"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CABK.MC",
+      "exchange_mic": "XMAD",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "spain_ibex35"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CLNX.MC",
+      "exchange_mic": "XMAD",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "spain_ibex35"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "COL.MC",
+      "exchange_mic": "XMAD",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "spain_ibex35"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "AENA.MC",
+      "exchange_mic": "XMAD",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "spain_ibex35"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ELE.MC",
+      "exchange_mic": "XMAD",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "spain_ibex35"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ENG.MC",
+      "exchange_mic": "XMAD",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "spain_ibex35"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "FDR.MC",
+      "exchange_mic": "XMAD",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "spain_ibex35"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "FER.MC",
+      "exchange_mic": "XMAD",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "spain_ibex35"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "GRF.MC",
+      "exchange_mic": "XMAD",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "spain_ibex35"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "IAG.MC",
+      "exchange_mic": "XMAD",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "spain_ibex35"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "IDR.MC",
+      "exchange_mic": "XMAD",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "spain_ibex35"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "LOG.MC",
+      "exchange_mic": "XMAD",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "spain_ibex35"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MAP.MC",
+      "exchange_mic": "XMAD",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "spain_ibex35"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MRL.MC",
+      "exchange_mic": "XMAD",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "spain_ibex35"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MTS.MC",
+      "exchange_mic": "XMAD",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "spain_ibex35"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "NTGY.MC",
+      "exchange_mic": "XMAD",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "spain_ibex35"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "PUIG.MC",
+      "exchange_mic": "XMAD",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "spain_ibex35"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "RED.MC",
+      "exchange_mic": "XMAD",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "spain_ibex35"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ROVI.MC",
+      "exchange_mic": "XMAD",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "spain_ibex35"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SAB.MC",
+      "exchange_mic": "XMAD",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "spain_ibex35"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SCYR.MC",
+      "exchange_mic": "XMAD",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "spain_ibex35"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SLR.MC",
+      "exchange_mic": "XMAD",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "spain_ibex35"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "UNI.MC",
+      "exchange_mic": "XMAD",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "spain_ibex35"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "III.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ADM.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "AAF.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ALW.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "AAL.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ANTO.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ABF.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "AZN.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "AUTO.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "AV.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BAB.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BA.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BARC.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BTRW.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BEZ.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BKG.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BP.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BATS.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BLND.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BT-A.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BNZL.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BRBY.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CNA.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CCEP.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CCH.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CPG.L",
+      "exchange_mic": "XLON",
+      "currency": "USD",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CTEC.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CRDA.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "DCC.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "DGE.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "DPLM.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "EDV.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ENT.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "EXPN.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "FCIT.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "FRES.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "GAW.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "GLEN.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "GSK.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "HLN.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "HLMA.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "HSX.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "HWDN.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "HSBA.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ICG.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "IGG.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "IHG.L",
+      "exchange_mic": "XLON",
+      "currency": "USD",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "IMI.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "IMB.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "INF.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "IAG.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ITRK.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "JD.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BGEO.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "KGF.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "LAND.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "LGEN.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "LLOY.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "LMP.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "LSEG.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MNG.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MKS.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MRO.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MTLN.L",
+      "exchange_mic": "XLON",
+      "currency": "EUR",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MNDI.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "NG.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "NWG.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "NXT.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "PSON.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "PSH.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "PSN.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "PCT.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "PRU.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "RKT.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "REL.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "RTO.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "RMV.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "RIO.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "RR.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SGE.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SBRY.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SDR.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SMT.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SGRO.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SVT.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SHEL.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SMIN.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SN.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SPX.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SSE.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "STAN.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SDLF.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "STJ.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "TSCO.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BBOX.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ULVR.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "UU.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "VOD.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "WEIR.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "WTB.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MMM",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_dow30",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SHW",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_dow30",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "TRV",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_dow30",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "AEP",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ADI",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "APP",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ARM",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ADSK",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ADP",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BKR",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CDNS",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CHTR",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CTAS",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CCEP",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CTSH",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CEG",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CPRT",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CSX",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "DDOG",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "FANG",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "DASH",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "EA",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "EXC",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "FAST",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "FER",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "FTNT",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "GEHC",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "KDP",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "KLAC",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "KHC",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "LIN",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "LITE",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MAR",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MRVL",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MCHP",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MSTR",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MDLZ",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MPWR",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MNST",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "NXPI",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ORLY",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ODFL",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "PCAR",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "PAYX",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "PYPL",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "PDD",
+      "exchange_mic": "XOTC",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ROP",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ROST",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SNDK",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "STX",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SNPS",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "TTWO",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "TRI",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "VRSK",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "WBD",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "WDC",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "WDAY",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "XEL",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100",
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ZS",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "AOS",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ACN",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "AES",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "AFL",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "A",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "APD",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "AKAM",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ALB",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ARE",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ALGN",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ALLE",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "LNT",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ALL",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MO",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "AMCR",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "AEE",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "AIG",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "AMT",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "AWK",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "AMP",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "AME",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "APH",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "AON",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "APA",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "APO",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "APTV",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ACGL",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ADM",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ARES",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ANET",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "AJG",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "AIZ",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ATO",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "AZO",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "AVB",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "AVY",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BALL",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BBY",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "TECH",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BX",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "XYZ",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BNY",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BR",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BRO",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BF-B",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BLDR",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BG",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BXP",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CHRW",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CPT",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CPB",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "COF",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CCL",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CARR",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CVNA",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CASY",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CBOE",
+      "exchange_mic": "BATS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CBRE",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CDW",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CNP",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CF",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CRL",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SCHW",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CMG",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CB",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CHD",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CIEN",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CINF",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "C",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CFG",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CLX",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CME",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CMS",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "COHR",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "COIN",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CL",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "FIX",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CAG",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ED",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "STZ",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "COO",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "GLW",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CPAY",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CTVA",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CSGP",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CRH",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CCI",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CMI",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "DRI",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "DVA",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "DECK",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "DE",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "DELL",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "DAL",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "DVN",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "DLR",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "DG",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "DLTR",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "D",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "DPZ",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "DOV",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "DOW",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "DHI",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "DTE",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "DUK",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "DD",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ETN",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "EBAY",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SATS",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ECL",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "EIX",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "EME",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "EMR",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ETR",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "EOG",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "EQT",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "EFX",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "EQIX",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "EQR",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ERIE",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ESS",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "EL",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "EG",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "EVRG",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ES",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "EXE",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "EXPE",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "EXPD",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "EXR",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "FFIV",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "FDS",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "FICO",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "FRT",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "FDX",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "FDXF",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "FIS",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "FITB",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "FSLR",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "FE",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "FISV",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "F",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "FTV",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "FOXA",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "FOX",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "BEN",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "FCX",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "GRMN",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "IT",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "GEV",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "GEN",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "GNRC",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "GIS",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "GM",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "GPC",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "GPN",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "GL",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "GDDY",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "HAL",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "HIG",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "HAS",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "DOC",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "HSIC",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "HSY",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "HPE",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "HLT",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "HRL",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "HST",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "HPQ",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "HUBB",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "HBAN",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "IEX",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ITW",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "INCY",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "IR",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "PODD",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "IBKR",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ICE",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "IFF",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "IP",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "IVZ",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "INVH",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "IRM",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "JBHT",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "JBL",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "JKHY",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "J",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "JCI",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "KVUE",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "KEY",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "KEYS",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "KMB",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "KIM",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "KMI",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "KKR",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "KR",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "LVS",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "LEN",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "LII",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "LYV",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "L",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "LULU",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "LYB",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MTB",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MPC",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MRSH",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MLM",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MAS",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MKC",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MET",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MGM",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MAA",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "TAP",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MCO",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MOS",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MSI",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "MSCI",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "NDAQ",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "NTAP",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "NEM",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "NWSA",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "NWS",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "NEE",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "NI",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "NDSN",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "NSC",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "NTRS",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "NCLH",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "NRG",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "NUE",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "NVR",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "OXY",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "OMC",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ON",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "OKE",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "OTIS",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "PKG",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "PSKY",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "PH",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "PNR",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "PCG",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "PM",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "PSX",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "PNW",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "PNC",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "POOL",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "PPG",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "PPL",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "PFG",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "PGR",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "PLD",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "PRU",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "PEG",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "PTC",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "PSA",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "PHM",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "PWR",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "Q",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "RL",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "RJF",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "O",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "REG",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "RF",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "RSG",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "RVTY",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "HOOD",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ROK",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ROL",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "RCL",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SBAC",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SRE",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SPG",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SWKS",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SJM",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SW",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SNA",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SOLV",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SO",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "LUV",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SWK",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "STT",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "STLD",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SMCI",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SYF",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "SYY",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "TROW",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "TPR",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "TRGP",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "TGT",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "TEL",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "TER",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "TPL",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "TJX",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "TKO",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "TTD",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "TSCO",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "TT",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "TRMB",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "TFC",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "TYL",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "TSN",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "USB",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "UDR",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ULTA",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "UAL",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "URI",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "VLO",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "VEEV",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "VTR",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "VLTO",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "VRSN",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "VRT",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "VTRS",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "VICI",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "VST",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "VMC",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "WRB",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "GWW",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "WAB",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "WM",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "WEC",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "WELL",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "WST",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "WY",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "WSM",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "WMB",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "WTW",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "WYNN",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "XYL",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "YUM",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "ZBRA",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    }
+  ]
+}

--- a/src/swing_screener/data/symbol_pool.py
+++ b/src/swing_screener/data/symbol_pool.py
@@ -320,6 +320,7 @@ class TaxonomyFilterSpec:
     sector: tuple[str, ...] | None = None
     index_memberships: tuple[str, ...] | None = None
     instrument_type_detail: tuple[str, ...] | None = None
+    instrument_type: tuple[str, ...] | None = None
     provider: tuple[str, ...] | None = None
     currency: tuple[str, ...] | None = None
     exchange_mics: tuple[str, ...] | None = None
@@ -352,6 +353,8 @@ def filter_pool_by_taxonomy(
         if not _matches_scalar(s.sector, spec.sector):
             continue
         if not _matches_scalar(s.instrument_type_detail, spec.instrument_type_detail):
+            continue
+        if not _matches_scalar(s.instrument_type, spec.instrument_type):
             continue
         if not _matches_scalar(s.currency, spec.currency):
             continue

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,0 +1,27 @@
+"""Shared API test fixtures."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_review_queue(tmp_path_factory):
+    """Point the review-queue store at a tmp file for every API test.
+
+    The screener writes per-symbol fetch health on every run. Without isolation
+    those writes land in the repo's ``data/review_queue.json`` and leak across
+    tests (queued symbols get excluded from later screens). Override the FastAPI
+    dependency so each test session uses a throwaway file. The committed
+    ``symbol_pool.json`` is read-only, so it needs no isolation.
+    """
+    from api.main import app
+    from api.dependencies import get_review_queue_repo
+    from api.repositories.review_queue_repo import ReviewQueueRepository
+
+    queue_path = tmp_path_factory.mktemp("review_queue") / "review_queue.json"
+    app.dependency_overrides[get_review_queue_repo] = lambda: ReviewQueueRepository(
+        queue_path
+    )
+    yield
+    app.dependency_overrides.pop(get_review_queue_repo, None)

--- a/tests/api/test_pool_router.py
+++ b/tests/api/test_pool_router.py
@@ -1,0 +1,20 @@
+from api.models.screener import TaxonomyFilter
+
+
+def test_taxonomy_filter_to_spec():
+    tf = TaxonomyFilter(
+        region=["us"], market_cap_tier=["large", "mid"], provider=["yfinance"]
+    )
+    spec = tf.to_spec()
+    assert spec.region == ("us",)
+    assert spec.market_cap_tier == ("large", "mid")
+    assert spec.provider == ("yfinance",)
+    assert spec.sector is None
+
+
+def test_load_taxonomy_presets_returns_seeded_presets():
+    from api.services.pool_service import load_taxonomy_presets
+
+    presets = load_taxonomy_presets()
+    ids = {p["id"] for p in presets}
+    assert "us_large_cap_equities" in ids

--- a/tests/api/test_pool_router.py
+++ b/tests/api/test_pool_router.py
@@ -1,4 +1,47 @@
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
 from api.models.screener import TaxonomyFilter
+
+
+@pytest.fixture
+def pool_client(tmp_path):
+    from api.main import app
+    from api.dependencies import get_symbol_pool_repo, get_review_queue_repo
+    from api.repositories.symbol_pool_repo import SymbolPoolRepository
+    from api.repositories.review_queue_repo import ReviewQueueRepository
+
+    pool_path = tmp_path / "symbol_pool.json"
+    pool_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "asof": "2026-06-30",
+                "symbols": [
+                    {"symbol": "AAPL", "region": "us"},
+                    {"symbol": "MSFT", "region": "us"},
+                    {"symbol": "ASML", "region": "europe"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    queue_path = tmp_path / "review_queue.json"
+    queue_path.write_text(
+        json.dumps({"symbols": {"AAPL": {"symbol": "AAPL", "fetch_failure_count": 3}}}),
+        encoding="utf-8",
+    )
+
+    app.dependency_overrides[get_symbol_pool_repo] = lambda: SymbolPoolRepository(
+        pool_path
+    )
+    app.dependency_overrides[get_review_queue_repo] = lambda: ReviewQueueRepository(
+        queue_path
+    )
+    yield TestClient(app)
+    app.dependency_overrides.clear()
 
 
 def test_taxonomy_filter_to_spec():
@@ -18,3 +61,39 @@ def test_load_taxonomy_presets_returns_seeded_presets():
     presets = load_taxonomy_presets()
     ids = {p["id"] for p in presets}
     assert "us_large_cap_equities" in ids
+
+
+def test_get_presets_endpoint(pool_client):
+    resp = pool_client.get("/api/pool/presets")
+    assert resp.status_code == 200
+    ids = {p["id"] for p in resp.json()["presets"]}
+    assert "us_large_cap_equities" in ids
+
+
+def test_get_symbols_filters_and_paginates(pool_client):
+    resp = pool_client.get("/api/pool/symbols", params={"region": "us", "page_size": 1})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["page_size"] == 1
+    assert body["total"] == 2  # AAPL + MSFT are us; ASML is europe
+    assert all(s["region"] == "us" for s in body["symbols"])
+    assert len(body["symbols"]) == 1
+
+
+def test_review_queue_list_remove_restore(pool_client):
+    assert pool_client.get("/api/pool/review-queue").json()["entries"]
+    assert (
+        pool_client.post("/api/pool/review-queue/AAPL/restore").json()["restored"]
+        is True
+    )
+    assert pool_client.get("/api/pool/review-queue").json()["entries"] == []
+
+
+def test_review_queue_remove(pool_client):
+    assert (
+        pool_client.post("/api/pool/review-queue/AAPL/remove").json()["removed"] is True
+    )
+    assert (
+        pool_client.post("/api/pool/review-queue/AAPL/remove").json()["removed"]
+        is False
+    )

--- a/tests/api/test_review_queue.py
+++ b/tests/api/test_review_queue.py
@@ -1,0 +1,67 @@
+import json
+from pathlib import Path
+
+from api.repositories.review_queue_repo import ReviewQueueRepository
+from api.repositories.symbol_pool_repo import SymbolPoolRepository
+
+
+def _write(path: Path, data: dict):
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def test_pool_repo_apply_fetch_results(tmp_path):
+    path = tmp_path / "symbol_pool.json"
+    _write(
+        path,
+        {
+            "schema_version": 1,
+            "asof": "2026-06-29",
+            "symbols": [
+                {"symbol": "AAPL", "fetch_failure_count": 2},
+                {"symbol": "MSFT", "fetch_failure_count": 0},
+            ],
+        },
+    )
+    repo = SymbolPoolRepository(path)
+    crossed = repo.apply_fetch_results(
+        ok=["MSFT"], failed=["AAPL"], asof="2026-06-30", threshold=3
+    )
+    assert [c["symbol"] for c in crossed] == ["AAPL"]  # 2 -> 3 crosses threshold
+    data = repo.read()
+    by = {s["symbol"]: s for s in data["symbols"]}
+    assert by["AAPL"]["fetch_failure_count"] == 3
+    assert by["MSFT"]["fetch_failure_count"] == 0
+    assert by["MSFT"]["last_fetch_ok_at"] == "2026-06-30"
+
+
+def test_review_queue_upsert_remove_restore(tmp_path):
+    path = tmp_path / "review_queue.json"
+    _write(path, {"entries": []})
+    repo = ReviewQueueRepository(path)
+    repo.upsert(
+        [
+            {
+                "symbol": "AAPL",
+                "exchange_mic": "XNAS",
+                "failure_count": 3,
+                "first_failed_at": "2026-06-28",
+                "last_failed_at": "2026-06-30",
+                "reason": "no data",
+            }
+        ]
+    )
+    assert [e["symbol"] for e in repo.list_entries()] == ["AAPL"]
+    restored = repo.restore("AAPL")
+    assert restored["symbol"] == "AAPL"
+    assert repo.list_entries() == []
+    repo.upsert([{"symbol": "MSFT", "failure_count": 3}])
+    assert repo.remove("MSFT") is True
+    assert repo.remove("MSFT") is False
+
+
+def test_review_queue_self_creates_when_missing(tmp_path):
+    path = tmp_path / "review_queue.json"
+    repo = ReviewQueueRepository(path)
+    assert repo.list_entries() == []
+    repo.upsert([{"symbol": "TSLA", "failure_count": 3}])
+    assert [e["symbol"] for e in repo.list_entries()] == ["TSLA"]

--- a/tests/api/test_review_queue.py
+++ b/tests/api/test_review_queue.py
@@ -1,67 +1,43 @@
-import json
 from pathlib import Path
 
 from api.repositories.review_queue_repo import ReviewQueueRepository
-from api.repositories.symbol_pool_repo import SymbolPoolRepository
 
 
-def _write(path: Path, data: dict):
-    path.write_text(json.dumps(data), encoding="utf-8")
+def test_apply_fetch_results_increments_and_resets(tmp_path: Path):
+    repo = ReviewQueueRepository(tmp_path / "review_queue.json")
+    # AAPL fails twice → count 2 (below threshold 3).
+    repo.apply_fetch_results(ok=[], failed=["AAPL"], asof="2026-06-28", threshold=3)
+    repo.apply_fetch_results(ok=[], failed=["AAPL"], asof="2026-06-29", threshold=3)
+    assert repo.queued_symbols(3) == set()
+    # Third failure crosses the threshold.
+    repo.apply_fetch_results(ok=[], failed=["AAPL"], asof="2026-06-30", threshold=3)
+    assert repo.queued_symbols(3) == {"AAPL"}
+    entries = repo.list_entries(3)
+    assert [e["symbol"] for e in entries] == ["AAPL"]
+    assert entries[0]["fetch_failure_count"] == 3
+    assert entries[0]["first_failed_at"] == "2026-06-28"
+    assert entries[0]["last_failed_at"] == "2026-06-30"
+    # A successful fetch resets the counter.
+    repo.apply_fetch_results(ok=["AAPL"], failed=[], asof="2026-07-01", threshold=3)
+    assert repo.queued_symbols(3) == set()
 
 
-def test_pool_repo_apply_fetch_results(tmp_path):
-    path = tmp_path / "symbol_pool.json"
-    _write(
-        path,
-        {
-            "schema_version": 1,
-            "asof": "2026-06-29",
-            "symbols": [
-                {"symbol": "AAPL", "fetch_failure_count": 2},
-                {"symbol": "MSFT", "fetch_failure_count": 0},
-            ],
-        },
-    )
-    repo = SymbolPoolRepository(path)
-    crossed = repo.apply_fetch_results(
-        ok=["MSFT"], failed=["AAPL"], asof="2026-06-30", threshold=3
-    )
-    assert [c["symbol"] for c in crossed] == ["AAPL"]  # 2 -> 3 crosses threshold
-    data = repo.read()
-    by = {s["symbol"]: s for s in data["symbols"]}
-    assert by["AAPL"]["fetch_failure_count"] == 3
-    assert by["MSFT"]["fetch_failure_count"] == 0
-    assert by["MSFT"]["last_fetch_ok_at"] == "2026-06-30"
-
-
-def test_review_queue_upsert_remove_restore(tmp_path):
-    path = tmp_path / "review_queue.json"
-    _write(path, {"entries": []})
-    repo = ReviewQueueRepository(path)
-    repo.upsert(
-        [
-            {
-                "symbol": "AAPL",
-                "exchange_mic": "XNAS",
-                "failure_count": 3,
-                "first_failed_at": "2026-06-28",
-                "last_failed_at": "2026-06-30",
-                "reason": "no data",
-            }
-        ]
-    )
-    assert [e["symbol"] for e in repo.list_entries()] == ["AAPL"]
-    restored = repo.restore("AAPL")
-    assert restored["symbol"] == "AAPL"
-    assert repo.list_entries() == []
-    repo.upsert([{"symbol": "MSFT", "failure_count": 3}])
+def test_remove_and_restore(tmp_path: Path):
+    repo = ReviewQueueRepository(tmp_path / "review_queue.json")
+    for _ in range(3):
+        repo.apply_fetch_results(ok=[], failed=["MSFT"], asof="2026-06-30", threshold=3)
+    assert repo.queued_symbols(3) == {"MSFT"}
+    restored = repo.restore("MSFT")
+    assert restored["symbol"] == "MSFT"
+    assert repo.queued_symbols(3) == set()
+    # Re-flag then hard-remove.
+    for _ in range(3):
+        repo.apply_fetch_results(ok=[], failed=["MSFT"], asof="2026-06-30", threshold=3)
     assert repo.remove("MSFT") is True
     assert repo.remove("MSFT") is False
 
 
-def test_review_queue_self_creates_when_missing(tmp_path):
-    path = tmp_path / "review_queue.json"
-    repo = ReviewQueueRepository(path)
-    assert repo.list_entries() == []
-    repo.upsert([{"symbol": "TSLA", "failure_count": 3}])
-    assert [e["symbol"] for e in repo.list_entries()] == ["TSLA"]
+def test_self_creates_when_missing(tmp_path: Path):
+    repo = ReviewQueueRepository(tmp_path / "review_queue.json")
+    assert repo.list_entries(3) == []
+    assert repo.queued_symbols(3) == set()

--- a/tests/api/test_screener_endpoints.py
+++ b/tests/api/test_screener_endpoints.py
@@ -108,7 +108,9 @@ def _stub_earnings_proximity(monkeypatch):
     monkeypatch.setattr(
         screener_service,
         "fetch_next_earnings_days",
-        lambda tickers, finnhub_api_key, asof_date, **kwargs: {ticker: None for ticker in tickers},
+        lambda tickers, finnhub_api_key, asof_date, **kwargs: {
+            ticker: None for ticker in tickers
+        },
     )
 
 
@@ -116,7 +118,9 @@ def test_screener_top_over_100_returns_candidates(monkeypatch):
     ohlcv = _ohlcv_with_spy()
     mock_provider = _create_mock_provider(ohlcv)
 
-    def fake_build_daily_report(ohlcv, cfg, exclude_tickers=None, sector_benchmark_returns=None, **kwargs):
+    def fake_build_daily_report(
+        ohlcv, cfg, exclude_tickers=None, sector_benchmark_returns=None, **kwargs
+    ):
         idx = [f"T{i:03d}" for i in range(150)]
         data = {
             "atr14": [1.2] * len(idx),
@@ -134,12 +138,18 @@ def test_screener_top_over_100_returns_candidates(monkeypatch):
         return pd.DataFrame(data, index=idx)
 
     # Mock the provider factory to return our mock provider
-    monkeypatch.setattr(screener_service, "get_default_provider", lambda **kwargs: mock_provider)
+    monkeypatch.setattr(
+        screener_service, "get_default_provider", lambda **kwargs: mock_provider
+    )
     monkeypatch.setattr(screener_service, "build_daily_report", fake_build_daily_report)
-    monkeypatch.setattr(screener_service, "get_multiple_ticker_info", lambda tickers: {})
+    monkeypatch.setattr(
+        screener_service, "get_multiple_ticker_info", lambda tickers: {}
+    )
 
     client = TestClient(app)
-    res = client.post("/api/screener/run", json={"universe": "broad_market_stocks", "top": 200})
+    res = client.post(
+        "/api/screener/run", json={"universe": "broad_market_stocks", "top": 200}
+    )
     assert res.status_code == 200
     data = res.json()
     assert len(data["candidates"]) == 150
@@ -154,12 +164,16 @@ def test_screener_top_over_100_returns_candidates(monkeypatch):
 def test_screener_empty_ohlcv_returns_404(monkeypatch):
     empty_df = pd.DataFrame()
     mock_provider = _create_mock_provider(empty_df)
-    
+
     # Mock the provider factory to return our mock provider
-    monkeypatch.setattr(screener_service, "get_default_provider", lambda **kwargs: mock_provider)
+    monkeypatch.setattr(
+        screener_service, "get_default_provider", lambda **kwargs: mock_provider
+    )
 
     client = TestClient(app)
-    res = client.post("/api/screener/run", json={"universe": "broad_market_stocks", "top": 200})
+    res = client.post(
+        "/api/screener/run", json={"universe": "broad_market_stocks", "top": 200}
+    )
     assert res.status_code == 404
 
 
@@ -167,7 +181,9 @@ def test_screener_recommendation_payload_shape(monkeypatch):
     ohlcv = _ohlcv_with_spy()
     mock_provider = _create_mock_provider(ohlcv)
 
-    def fake_build_daily_report(ohlcv, cfg, exclude_tickers=None, sector_benchmark_returns=None, **kwargs):
+    def fake_build_daily_report(
+        ohlcv, cfg, exclude_tickers=None, sector_benchmark_returns=None, **kwargs
+    ):
         idx = ["AAA"]
         data = {
             "atr14": [1.2],
@@ -189,17 +205,25 @@ def test_screener_recommendation_payload_shape(monkeypatch):
             "realized_risk": [20.0],
             "suggested_order_type": ["BUY_STOP"],
             "suggested_order_price": [50.1],
-            "execution_note": ["Breakout not triggered yet. Place BUY STOP slightly above breakout_level."],
+            "execution_note": [
+                "Breakout not triggered yet. Place BUY STOP slightly above breakout_level."
+            ],
         }
         return pd.DataFrame(data, index=idx)
 
     # Mock the provider factory to return our mock provider
-    monkeypatch.setattr(screener_service, "get_default_provider", lambda **kwargs: mock_provider)
+    monkeypatch.setattr(
+        screener_service, "get_default_provider", lambda **kwargs: mock_provider
+    )
     monkeypatch.setattr(screener_service, "build_daily_report", fake_build_daily_report)
-    monkeypatch.setattr(screener_service, "get_multiple_ticker_info", lambda tickers: {})
+    monkeypatch.setattr(
+        screener_service, "get_multiple_ticker_info", lambda tickers: {}
+    )
 
     client = TestClient(app)
-    res = client.post("/api/screener/run", json={"universe": "broad_market_stocks", "top": 20})
+    res = client.post(
+        "/api/screener/run", json={"universe": "broad_market_stocks", "top": 20}
+    )
     assert res.status_code == 200
 
     candidate = res.json()["candidates"][0]
@@ -236,7 +260,9 @@ def test_screener_response_includes_market_data_source_summary(monkeypatch):
     ohlcv = _ohlcv_with_spy()
     mock_provider = _create_mock_provider(ohlcv)
 
-    def fake_build_daily_report(ohlcv, cfg, exclude_tickers=None, sector_benchmark_returns=None, **kwargs):
+    def fake_build_daily_report(
+        ohlcv, cfg, exclude_tickers=None, sector_benchmark_returns=None, **kwargs
+    ):
         return pd.DataFrame(
             {
                 "atr14": [1.2],
@@ -254,12 +280,18 @@ def test_screener_response_includes_market_data_source_summary(monkeypatch):
             index=["AAA"],
         )
 
-    monkeypatch.setattr(screener_service, "get_default_provider", lambda **kwargs: mock_provider)
+    monkeypatch.setattr(
+        screener_service, "get_default_provider", lambda **kwargs: mock_provider
+    )
     monkeypatch.setattr(screener_service, "build_daily_report", fake_build_daily_report)
-    monkeypatch.setattr(screener_service, "get_multiple_ticker_info", lambda tickers: {})
+    monkeypatch.setattr(
+        screener_service, "get_multiple_ticker_info", lambda tickers: {}
+    )
 
     client = TestClient(app)
-    res = client.post("/api/screener/run", json={"universe": "broad_market_stocks", "top": 1})
+    res = client.post(
+        "/api/screener/run", json={"universe": "broad_market_stocks", "top": 1}
+    )
     assert res.status_code == 200
 
     candidate = res.json()["candidates"][0]
@@ -273,7 +305,9 @@ def test_screener_candidate_includes_days_to_earnings(monkeypatch):
     ohlcv = _ohlcv_with_spy()
     mock_provider = _create_mock_provider(ohlcv)
 
-    def fake_report(ohlcv, cfg, exclude_tickers=None, sector_benchmark_returns=None, **kwargs):
+    def fake_report(
+        ohlcv, cfg, exclude_tickers=None, sector_benchmark_returns=None, **kwargs
+    ):
         return pd.DataFrame(
             {
                 "atr14": [1.2],
@@ -291,16 +325,22 @@ def test_screener_candidate_includes_days_to_earnings(monkeypatch):
             index=["AAA"],
         )
 
-    monkeypatch.setattr(screener_service, "get_default_provider", lambda **kwargs: mock_provider)
+    monkeypatch.setattr(
+        screener_service, "get_default_provider", lambda **kwargs: mock_provider
+    )
     monkeypatch.setattr(screener_service, "build_daily_report", fake_report)
-    monkeypatch.setattr(screener_service, "get_multiple_ticker_info", lambda tickers: {})
+    monkeypatch.setattr(
+        screener_service, "get_multiple_ticker_info", lambda tickers: {}
+    )
     monkeypatch.setattr(
         "api.services.screener_service.fetch_next_earnings_days",
         lambda tickers, finnhub_api_key, asof_date, **kwargs: {"AAA": 12},
     )
 
     client = TestClient(app)
-    res = client.post("/api/screener/run", json={"universe": "broad_market_stocks", "top": 1})
+    res = client.post(
+        "/api/screener/run", json={"universe": "broad_market_stocks", "top": 1}
+    )
     assert res.status_code == 200
     candidate = res.json()["candidates"][0]
     assert candidate.get("days_to_earnings") == 12
@@ -311,7 +351,9 @@ def test_screener_candidate_includes_sector_rotation_context(monkeypatch):
     mock_provider = _create_mock_provider(ohlcv)
     captured: dict[str, object] = {}
 
-    def fake_report(ohlcv, cfg, exclude_tickers=None, sector_benchmark_returns=None, **kwargs):
+    def fake_report(
+        ohlcv, cfg, exclude_tickers=None, sector_benchmark_returns=None, **kwargs
+    ):
         captured["sector_benchmark_returns"] = sector_benchmark_returns
         return pd.DataFrame(
             {
@@ -331,7 +373,9 @@ def test_screener_candidate_includes_sector_rotation_context(monkeypatch):
             index=["AAA"],
         )
 
-    monkeypatch.setattr(screener_service, "get_default_provider", lambda **kwargs: mock_provider)
+    monkeypatch.setattr(
+        screener_service, "get_default_provider", lambda **kwargs: mock_provider
+    )
     monkeypatch.setattr(screener_service, "build_daily_report", fake_report)
     monkeypatch.setattr(
         screener_service,
@@ -341,11 +385,15 @@ def test_screener_candidate_includes_sector_rotation_context(monkeypatch):
 
     from swing_screener.data import sector_rotation as sr
 
-    monkeypatch.setattr(sr, "compute_sector_benchmark_returns", lambda ohlcv, **kw: {"XLK": 0.07})
+    monkeypatch.setattr(
+        sr, "compute_sector_benchmark_returns", lambda ohlcv, **kw: {"XLK": 0.07}
+    )
     monkeypatch.setattr(
         sr,
         "compute_sector_rotation_scores",
-        lambda ohlcv, **kw: {"XLK": {"fast_rs": 0.04, "slow_rs": 0.02, "in_rotation": True}},
+        lambda ohlcv, **kw: {
+            "XLK": {"fast_rs": 0.04, "slow_rs": 0.02, "in_rotation": True}
+        },
     )
 
     client = TestClient(app)
@@ -365,7 +413,9 @@ def test_screener_filters_candidates_too_close_to_earnings(monkeypatch):
     ohlcv = _ohlcv_with_spy()
     mock_provider = _create_mock_provider(ohlcv)
 
-    def fake_report(ohlcv, cfg, exclude_tickers=None, sector_benchmark_returns=None, **kwargs):
+    def fake_report(
+        ohlcv, cfg, exclude_tickers=None, sector_benchmark_returns=None, **kwargs
+    ):
         return pd.DataFrame(
             {
                 "atr14": [1.2, 1.2],
@@ -383,9 +433,13 @@ def test_screener_filters_candidates_too_close_to_earnings(monkeypatch):
             index=["AAA", "BBB"],
         )
 
-    monkeypatch.setattr(screener_service, "get_default_provider", lambda **kwargs: mock_provider)
+    monkeypatch.setattr(
+        screener_service, "get_default_provider", lambda **kwargs: mock_provider
+    )
     monkeypatch.setattr(screener_service, "build_daily_report", fake_report)
-    monkeypatch.setattr(screener_service, "get_multiple_ticker_info", lambda tickers: {})
+    monkeypatch.setattr(
+        screener_service, "get_multiple_ticker_info", lambda tickers: {}
+    )
     monkeypatch.setattr(screener_service, "_min_days_to_earnings_default", lambda: 10)
     monkeypatch.setattr(
         "api.services.screener_service.fetch_next_earnings_days",
@@ -393,7 +447,9 @@ def test_screener_filters_candidates_too_close_to_earnings(monkeypatch):
     )
 
     client = TestClient(app)
-    res = client.post("/api/screener/run", json={"universe": "broad_market_stocks", "top": 2})
+    res = client.post(
+        "/api/screener/run", json={"universe": "broad_market_stocks", "top": 2}
+    )
     assert res.status_code == 200
     candidates = res.json()["candidates"]
     assert [candidate["ticker"] for candidate in candidates] == ["BBB"]
@@ -404,7 +460,9 @@ def test_screener_attaches_benchmark_comparison(monkeypatch):
     ohlcv = _ohlcv_with_symbol_and_spy()
     mock_provider = _create_mock_provider(ohlcv)
 
-    def fake_build_daily_report(ohlcv, cfg, exclude_tickers=None, sector_benchmark_returns=None, **kwargs):
+    def fake_build_daily_report(
+        ohlcv, cfg, exclude_tickers=None, sector_benchmark_returns=None, **kwargs
+    ):
         idx = ["AAA"]
         data = {
             "atr14": [1.2],
@@ -421,12 +479,18 @@ def test_screener_attaches_benchmark_comparison(monkeypatch):
         }
         return pd.DataFrame(data, index=idx)
 
-    monkeypatch.setattr(screener_service, "get_default_provider", lambda **kwargs: mock_provider)
+    monkeypatch.setattr(
+        screener_service, "get_default_provider", lambda **kwargs: mock_provider
+    )
     monkeypatch.setattr(screener_service, "build_daily_report", fake_build_daily_report)
-    monkeypatch.setattr(screener_service, "get_multiple_ticker_info", lambda tickers: {})
+    monkeypatch.setattr(
+        screener_service, "get_multiple_ticker_info", lambda tickers: {}
+    )
 
     client = TestClient(app)
-    res = client.post("/api/screener/run", json={"universe": "broad_market_stocks", "top": 20})
+    res = client.post(
+        "/api/screener/run", json={"universe": "broad_market_stocks", "top": 20}
+    )
     assert res.status_code == 200
 
     payload = res.json()
@@ -436,14 +500,20 @@ def test_screener_attaches_benchmark_comparison(monkeypatch):
     assert payload["benchmark_change_pct"] == 2.0
     assert candidate["symbol_change_pct"] == 20.0
     assert candidate["benchmark_outperformance_pct"] == 18.0
-    assert [point["close"] for point in candidate["benchmark_price_history"]] == pytest.approx([10.0, 10.1, 10.2])
+    assert [
+        point["close"] for point in candidate["benchmark_price_history"]
+    ] == pytest.approx([10.0, 10.1, 10.2])
 
 
-def test_screener_response_is_prioritized_by_decision_action_and_conviction(monkeypatch):
+def test_screener_response_is_prioritized_by_decision_action_and_conviction(
+    monkeypatch,
+):
     ohlcv = _ohlcv_with_spy()
     mock_provider = _create_mock_provider(ohlcv)
 
-    def fake_build_daily_report(ohlcv, cfg, exclude_tickers=None, sector_benchmark_returns=None, **kwargs):
+    def fake_build_daily_report(
+        ohlcv, cfg, exclude_tickers=None, sector_benchmark_returns=None, **kwargs
+    ):
         idx = ["AAA", "BBB", "CCC"]
         data = {
             "atr14": [1.2, 1.2, 1.2],
@@ -489,13 +559,23 @@ def test_screener_response_is_prioritized_by_decision_action_and_conviction(monk
             )
         return enriched
 
-    monkeypatch.setattr(screener_service, "get_default_provider", lambda **kwargs: mock_provider)
+    monkeypatch.setattr(
+        screener_service, "get_default_provider", lambda **kwargs: mock_provider
+    )
     monkeypatch.setattr(screener_service, "build_daily_report", fake_build_daily_report)
-    monkeypatch.setattr(screener_service, "get_multiple_ticker_info", lambda tickers: {})
-    monkeypatch.setattr(screener_service, "apply_decision_summary_context", fake_apply_decision_summary_context)
+    monkeypatch.setattr(
+        screener_service, "get_multiple_ticker_info", lambda tickers: {}
+    )
+    monkeypatch.setattr(
+        screener_service,
+        "apply_decision_summary_context",
+        fake_apply_decision_summary_context,
+    )
 
     client = TestClient(app)
-    res = client.post("/api/screener/run", json={"universe": "broad_market_stocks", "top": 20})
+    res = client.post(
+        "/api/screener/run", json={"universe": "broad_market_stocks", "top": 20}
+    )
     assert res.status_code == 200
 
     candidates = res.json()["candidates"]
@@ -508,7 +588,9 @@ def test_screener_currency_comes_from_metadata(monkeypatch):
     ohlcv = _ohlcv_with_spy()
     mock_provider = _create_mock_provider(ohlcv)
 
-    def fake_build_daily_report(ohlcv, cfg, exclude_tickers=None, sector_benchmark_returns=None, **kwargs):
+    def fake_build_daily_report(
+        ohlcv, cfg, exclude_tickers=None, sector_benchmark_returns=None, **kwargs
+    ):
         idx = ["ASML.AS"]
         data = {
             "atr14": [1.2],
@@ -525,16 +607,22 @@ def test_screener_currency_comes_from_metadata(monkeypatch):
         }
         return pd.DataFrame(data, index=idx)
 
-    monkeypatch.setattr(screener_service, "get_default_provider", lambda **kwargs: mock_provider)
+    monkeypatch.setattr(
+        screener_service, "get_default_provider", lambda **kwargs: mock_provider
+    )
     monkeypatch.setattr(screener_service, "build_daily_report", fake_build_daily_report)
     monkeypatch.setattr(
         screener_service,
         "get_multiple_ticker_info",
-        lambda tickers: {"ASML.AS": {"name": "ASML", "sector": "Technology", "currency": "EUR"}},
+        lambda tickers: {
+            "ASML.AS": {"name": "ASML", "sector": "Technology", "currency": "EUR"}
+        },
     )
 
     client = TestClient(app)
-    res = client.post("/api/screener/run", json={"universe": "broad_market_stocks", "top": 20})
+    res = client.post(
+        "/api/screener/run", json={"universe": "broad_market_stocks", "top": 20}
+    )
     assert res.status_code == 200
     candidate = res.json()["candidates"][0]
     assert candidate["currency"] == "EUR"
@@ -545,7 +633,9 @@ def test_screener_request_currency_filter_overrides_strategy(monkeypatch):
     mock_provider = _create_mock_provider(ohlcv)
     captured = {}
 
-    def fake_build_daily_report(ohlcv, cfg, exclude_tickers=None, sector_benchmark_returns=None, **kwargs):
+    def fake_build_daily_report(
+        ohlcv, cfg, exclude_tickers=None, sector_benchmark_returns=None, **kwargs
+    ):
         captured["currencies"] = cfg.universe.filt.currencies
         idx = ["AAPL"]
         data = {
@@ -563,9 +653,13 @@ def test_screener_request_currency_filter_overrides_strategy(monkeypatch):
         }
         return pd.DataFrame(data, index=idx)
 
-    monkeypatch.setattr(screener_service, "get_default_provider", lambda **kwargs: mock_provider)
+    monkeypatch.setattr(
+        screener_service, "get_default_provider", lambda **kwargs: mock_provider
+    )
     monkeypatch.setattr(screener_service, "build_daily_report", fake_build_daily_report)
-    monkeypatch.setattr(screener_service, "get_multiple_ticker_info", lambda tickers: {})
+    monkeypatch.setattr(
+        screener_service, "get_multiple_ticker_info", lambda tickers: {}
+    )
 
     client = TestClient(app)
     res = client.post(
@@ -576,7 +670,13 @@ def test_screener_request_currency_filter_overrides_strategy(monkeypatch):
     assert captured["currencies"] == ["EUR"]
 
 
-def test_screener_exchange_filter_reduces_working_list(monkeypatch):
+def test_screener_exchange_filter_reduces_working_list(monkeypatch, tmp_path):
+    """Legacy top-level exchange_mics still filters the pool (back-compat path)."""
+    import json
+
+    from api.dependencies import get_symbol_pool_repo
+    from api.repositories.symbol_pool_repo import SymbolPoolRepository
+
     ohlcv = _ohlcv_with_spy()
     captured: dict[str, list[str]] = {}
     mock_provider = _create_mock_provider(ohlcv)
@@ -586,7 +686,9 @@ def test_screener_exchange_filter_reduces_working_list(monkeypatch):
         captured["tickers"] = list(tickers)
         return ohlcv
 
-    def fake_build_daily_report(ohlcv, cfg, exclude_tickers=None, sector_benchmark_returns=None, **kwargs):
+    def fake_build_daily_report(
+        ohlcv, cfg, exclude_tickers=None, sector_benchmark_returns=None, **kwargs
+    ):
         del ohlcv, cfg, exclude_tickers
         return pd.DataFrame(
             {
@@ -605,24 +707,58 @@ def test_screener_exchange_filter_reduces_working_list(monkeypatch):
             index=["AAPL"],
         )
 
-    mock_provider.fetch_ohlcv.side_effect = fake_fetch_ohlcv
-    monkeypatch.setattr(screener_service, "get_default_provider", lambda **kwargs: mock_provider)
-    monkeypatch.setattr(screener_service, "load_universe_from_package", lambda name, cfg: ["AAPL", "ASML.AS", "ACWI"])
-    monkeypatch.setattr(screener_service, "build_daily_report", fake_build_daily_report)
-    monkeypatch.setattr(screener_service, "get_multiple_ticker_info", lambda tickers: {})
-
-    client = TestClient(app)
-    res = client.post(
-        "/api/screener/run",
-        json={
-            "universe": "broad_market_stocks",
-            "top": 20,
-            "exchange_mics": ["XNAS", "XNYS"],
-            "include_otc": False,
-        },
+    pool_path = tmp_path / "symbol_pool.json"
+    pool_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "asof": "2026-06-30",
+                "symbols": [
+                    {
+                        "symbol": "AAPL",
+                        "exchange_mic": "XNAS",
+                        "primary_provider": "yfinance",
+                    },
+                    {
+                        "symbol": "ASML.AS",
+                        "exchange_mic": "XAMS",
+                        "primary_provider": "yfinance",
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
     )
+    app.dependency_overrides[get_symbol_pool_repo] = lambda: SymbolPoolRepository(
+        pool_path
+    )
+
+    mock_provider.fetch_ohlcv.side_effect = fake_fetch_ohlcv
+    monkeypatch.setattr(
+        screener_service, "get_default_provider", lambda **kwargs: mock_provider
+    )
+    monkeypatch.setattr(screener_service, "build_daily_report", fake_build_daily_report)
+    monkeypatch.setattr(
+        screener_service, "get_multiple_ticker_info", lambda tickers: {}
+    )
+
+    try:
+        client = TestClient(app)
+        res = client.post(
+            "/api/screener/run",
+            json={
+                "top": 20,
+                "exchange_mics": ["XNAS", "XNYS"],
+                "include_otc": False,
+            },
+        )
+    finally:
+        app.dependency_overrides.pop(get_symbol_pool_repo, None)
+
     assert res.status_code == 200
-    assert captured["tickers"] == ["AAPL", "ACWI"]
+    # ASML.AS (XAMS) is excluded; AAPL (XNAS) survives. Benchmark SPY appended.
+    assert "ASML.AS" not in captured["tickers"]
+    assert "AAPL" in captured["tickers"]
     assert "reduced the working list" in res.json()["warnings"][0].lower()
 
 
@@ -630,7 +766,9 @@ def test_screener_returns_same_symbol_add_on_metadata(monkeypatch):
     ohlcv = _ohlcv_with_spy()
     mock_provider = _create_mock_provider(ohlcv)
 
-    def fake_build_daily_report(ohlcv, cfg, exclude_tickers=None, sector_benchmark_returns=None, **kwargs):
+    def fake_build_daily_report(
+        ohlcv, cfg, exclude_tickers=None, sector_benchmark_returns=None, **kwargs
+    ):
         idx = ["REP.MC"]
         data = {
             "atr14": [0.8],
@@ -682,18 +820,24 @@ def test_screener_returns_same_symbol_add_on_metadata(monkeypatch):
             del position_id
             return SimpleNamespace(action="NO_ACTION")
 
-    monkeypatch.setattr(screener_service, "get_default_provider", lambda **kwargs: mock_provider)
+    monkeypatch.setattr(
+        screener_service, "get_default_provider", lambda **kwargs: mock_provider
+    )
     monkeypatch.setattr(screener_service, "build_daily_report", fake_build_daily_report)
     monkeypatch.setattr(
         screener_service,
         "get_multiple_ticker_info",
-        lambda tickers: {"REP.MC": {"name": "Repsol", "sector": "Energy", "currency": "EUR"}},
+        lambda tickers: {
+            "REP.MC": {"name": "Repsol", "sector": "Energy", "currency": "EUR"}
+        },
     )
 
     app.dependency_overrides[get_portfolio_service] = lambda: StubPortfolioService()
     try:
         client = TestClient(app)
-        res = client.post("/api/screener/run", json={"universe": "broad_market_stocks", "top": 20})
+        res = client.post(
+            "/api/screener/run", json={"universe": "broad_market_stocks", "top": 20}
+        )
         assert res.status_code == 200
 
         body = res.json()
@@ -713,7 +857,9 @@ def test_screener_anchors_entry_stop_to_structural_pattern_stop(monkeypatch):
     ohlcv = _ohlcv_with_spy()
     mock_provider = _create_mock_provider(ohlcv)
 
-    def fake_build_daily_report(ohlcv, cfg, exclude_tickers=None, sector_benchmark_returns=None, **kwargs):
+    def fake_build_daily_report(
+        ohlcv, cfg, exclude_tickers=None, sector_benchmark_returns=None, **kwargs
+    ):
         idx = ["REP.MC"]
         data = {
             "atr14": [0.8],
@@ -752,12 +898,16 @@ def test_screener_anchors_entry_stop_to_structural_pattern_stop(monkeypatch):
             del position_id
             return SimpleNamespace(action="NO_ACTION")
 
-    monkeypatch.setattr(screener_service, "get_default_provider", lambda **kwargs: mock_provider)
+    monkeypatch.setattr(
+        screener_service, "get_default_provider", lambda **kwargs: mock_provider
+    )
     monkeypatch.setattr(screener_service, "build_daily_report", fake_build_daily_report)
     monkeypatch.setattr(
         screener_service,
         "get_multiple_ticker_info",
-        lambda tickers: {"REP.MC": {"name": "Repsol", "sector": "Energy", "currency": "EUR"}},
+        lambda tickers: {
+            "REP.MC": {"name": "Repsol", "sector": "Energy", "currency": "EUR"}
+        },
     )
     # Force a valid, tighter structural stop (above the 21.62 ATR stop, below entry).
     monkeypatch.setattr(
@@ -769,7 +919,9 @@ def test_screener_anchors_entry_stop_to_structural_pattern_stop(monkeypatch):
     app.dependency_overrides[get_portfolio_service] = lambda: StubPortfolioService()
     try:
         client = TestClient(app)
-        res = client.post("/api/screener/run", json={"universe": "broad_market_stocks", "top": 20})
+        res = client.post(
+            "/api/screener/run", json={"universe": "broad_market_stocks", "top": 20}
+        )
         assert res.status_code == 200
 
         candidate = res.json()["candidates"][0]
@@ -789,7 +941,9 @@ def test_screener_loads_each_fundamentals_snapshot_once(monkeypatch):
     mock_provider = _create_mock_provider(ohlcv)
     load_calls: list[str] = []
 
-    def fake_build_daily_report(ohlcv, cfg, exclude_tickers=None, sector_benchmark_returns=None, **kwargs):
+    def fake_build_daily_report(
+        ohlcv, cfg, exclude_tickers=None, sector_benchmark_returns=None, **kwargs
+    ):
         idx = ["AAA", "BBB"]
         data = {
             "atr14": [1.2, 1.1],
@@ -811,13 +965,21 @@ def test_screener_loads_each_fundamentals_snapshot_once(monkeypatch):
         load_calls.append(symbol)
         return None
 
-    monkeypatch.setattr(screener_service, "get_default_provider", lambda **kwargs: mock_provider)
+    monkeypatch.setattr(
+        screener_service, "get_default_provider", lambda **kwargs: mock_provider
+    )
     monkeypatch.setattr(screener_service, "build_daily_report", fake_build_daily_report)
-    monkeypatch.setattr(screener_service, "get_multiple_ticker_info", lambda tickers: {})
-    monkeypatch.setattr(decision_context.FundamentalsStorage, "load_snapshot", fake_load_snapshot)
+    monkeypatch.setattr(
+        screener_service, "get_multiple_ticker_info", lambda tickers: {}
+    )
+    monkeypatch.setattr(
+        decision_context.FundamentalsStorage, "load_snapshot", fake_load_snapshot
+    )
 
     client = TestClient(app)
-    res = client.post("/api/screener/run", json={"universe": "broad_market_stocks", "top": 5})
+    res = client.post(
+        "/api/screener/run", json={"universe": "broad_market_stocks", "top": 5}
+    )
     assert res.status_code == 200
     assert len(res.json()["candidates"]) == 2
 
@@ -852,12 +1014,18 @@ def test_screener_fetches_rolling_window_not_fixed_start(monkeypatch):
 
     mock_provider.fetch_ohlcv.side_effect = record_fetch
 
-    def fake_build_daily_report(ohlcv, cfg, exclude_tickers=None, sector_benchmark_returns=None, **kwargs):
+    def fake_build_daily_report(
+        ohlcv, cfg, exclude_tickers=None, sector_benchmark_returns=None, **kwargs
+    ):
         return pd.DataFrame()
 
-    monkeypatch.setattr(screener_service, "get_default_provider", lambda **kwargs: mock_provider)
+    monkeypatch.setattr(
+        screener_service, "get_default_provider", lambda **kwargs: mock_provider
+    )
     monkeypatch.setattr(screener_service, "build_daily_report", fake_build_daily_report)
-    monkeypatch.setattr(screener_service, "get_multiple_ticker_info", lambda tickers: {})
+    monkeypatch.setattr(
+        screener_service, "get_multiple_ticker_info", lambda tickers: {}
+    )
 
     client = TestClient(app)
     res = client.post(
@@ -880,7 +1048,9 @@ def test_screener_widens_ranking_pool_for_combined_priority(monkeypatch):
     mock_provider = _create_mock_provider(ohlcv)
     captured: dict = {}
 
-    def fake_build_daily_report(ohlcv, cfg, exclude_tickers=None, sector_benchmark_returns=None, **kwargs):
+    def fake_build_daily_report(
+        ohlcv, cfg, exclude_tickers=None, sector_benchmark_returns=None, **kwargs
+    ):
         captured["ranking_top_n"] = cfg.ranking.top_n
         idx = [f"T{i:03d}" for i in range(min(cfg.ranking.top_n, 200))]
         data = {
@@ -899,12 +1069,18 @@ def test_screener_widens_ranking_pool_for_combined_priority(monkeypatch):
         }
         return pd.DataFrame(data, index=idx)
 
-    monkeypatch.setattr(screener_service, "get_default_provider", lambda **kwargs: mock_provider)
+    monkeypatch.setattr(
+        screener_service, "get_default_provider", lambda **kwargs: mock_provider
+    )
     monkeypatch.setattr(screener_service, "build_daily_report", fake_build_daily_report)
-    monkeypatch.setattr(screener_service, "get_multiple_ticker_info", lambda tickers: {})
+    monkeypatch.setattr(
+        screener_service, "get_multiple_ticker_info", lambda tickers: {}
+    )
 
     client = TestClient(app)
-    res = client.post("/api/screener/run", json={"universe": "broad_market_stocks", "top": 50})
+    res = client.post(
+        "/api/screener/run", json={"universe": "broad_market_stocks", "top": 50}
+    )
     assert res.status_code == 200
 
     multiplier = CombinedPriorityConfig().prefilter_multiplier
@@ -912,12 +1088,13 @@ def test_screener_widens_ranking_pool_for_combined_priority(monkeypatch):
     assert len(res.json()["candidates"]) == 50
 
 
-
 def test_screener_pending_entry_order_blocks_add_on(monkeypatch):
     ohlcv = _ohlcv_with_spy()
     mock_provider = _create_mock_provider(ohlcv)
 
-    def fake_build_daily_report(ohlcv, cfg, exclude_tickers=None, sector_benchmark_returns=None, **kwargs):
+    def fake_build_daily_report(
+        ohlcv, cfg, exclude_tickers=None, sector_benchmark_returns=None, **kwargs
+    ):
         idx = ["REP.MC"]
         data = {
             "atr14": [0.8],
@@ -976,19 +1153,25 @@ def test_screener_pending_entry_order_blocks_add_on(monkeypatch):
                 ]
             }
 
-    monkeypatch.setattr(screener_service, "get_default_provider", lambda **kwargs: mock_provider)
+    monkeypatch.setattr(
+        screener_service, "get_default_provider", lambda **kwargs: mock_provider
+    )
     monkeypatch.setattr(screener_service, "build_daily_report", fake_build_daily_report)
     monkeypatch.setattr(
         screener_service,
         "get_multiple_ticker_info",
-        lambda tickers: {"REP.MC": {"name": "Repsol", "sector": "Energy", "currency": "EUR"}},
+        lambda tickers: {
+            "REP.MC": {"name": "Repsol", "sector": "Energy", "currency": "EUR"}
+        },
     )
 
     app.dependency_overrides[get_portfolio_service] = lambda: StubPortfolioService()
     app.dependency_overrides[get_orders_service] = lambda: StubOrdersService()
     try:
         client = TestClient(app)
-        res = client.post("/api/screener/run", json={"universe": "broad_market_stocks", "top": 20})
+        res = client.post(
+            "/api/screener/run", json={"universe": "broad_market_stocks", "top": 20}
+        )
         assert res.status_code == 200
 
         body = res.json()
@@ -1039,7 +1222,9 @@ def test_screener_uses_universe_currency_for_european_close(monkeypatch):
     ohlcv = _ohlcv_with_abn_and_aex()
     mock_provider = _create_mock_provider(ohlcv)
 
-    def fake_build_daily_report(ohlcv, cfg, exclude_tickers=None, sector_benchmark_returns=None, **kwargs):
+    def fake_build_daily_report(
+        ohlcv, cfg, exclude_tickers=None, sector_benchmark_returns=None, **kwargs
+    ):
         idx = ["ABN.AS"]
         data = {
             "atr14": [1.0],
@@ -1061,11 +1246,15 @@ def test_screener_uses_universe_currency_for_european_close(monkeypatch):
             "realized_risk": [142.0],
             "suggested_order_type": ["BUY_LIMIT"],
             "suggested_order_price": [35.18],
-            "execution_note": ["European session is closed; use the latest same-day close."],
+            "execution_note": [
+                "European session is closed; use the latest same-day close."
+            ],
         }
         return pd.DataFrame(data, index=idx)
 
-    monkeypatch.setattr(screener_service, "get_default_provider", lambda **kwargs: mock_provider)
+    monkeypatch.setattr(
+        screener_service, "get_default_provider", lambda **kwargs: mock_provider
+    )
     monkeypatch.setattr(screener_service, "build_daily_report", fake_build_daily_report)
     monkeypatch.setattr(
         screener_service,
@@ -1074,7 +1263,9 @@ def test_screener_uses_universe_currency_for_european_close(monkeypatch):
     )
 
     client = TestClient(app)
-    res = client.post("/api/screener/run", json={"universe": "amsterdam_aex", "top": 20})
+    res = client.post(
+        "/api/screener/run", json={"universe": "amsterdam_aex", "top": 20}
+    )
     assert res.status_code == 200
     payload = res.json()
 
@@ -1099,7 +1290,9 @@ def test_screener_async_mode_returns_job_and_status(monkeypatch):
     monkeypatch.setattr(screener_service.ScreenerService, "run_screener", fake_run)
 
     client = TestClient(app)
-    launch_res = client.post("/api/screener/run", json={"universe": "broad_market_stocks", "top": 20})
+    launch_res = client.post(
+        "/api/screener/run", json={"universe": "broad_market_stocks", "top": 20}
+    )
     assert launch_res.status_code == 202
     launch_payload = launch_res.json()
     assert launch_payload["status"] in {"queued", "running", "completed"}
@@ -1161,7 +1354,9 @@ def test_screener_async_mode_records_history(monkeypatch):
     app.dependency_overrides[get_screener_history_repo] = lambda: StubHistoryRepo()
     try:
         client = TestClient(app)
-        launch_res = client.post("/api/screener/run", json={"universe": "broad_market_stocks", "top": 20})
+        launch_res = client.post(
+            "/api/screener/run", json={"universe": "broad_market_stocks", "top": 20}
+        )
         assert launch_res.status_code == 202
         job_id = launch_res.json()["job_id"]
 
@@ -1207,26 +1402,14 @@ def test_screener_universes_route_removed_in_favor_of_canonical_universes():
     assert "exchange_mics" in body["universes"][0]
 
 
-def test_screener_run_returns_422_for_removed_universe_with_replacement():
+def test_screener_run_unknown_universe_alias_yields_no_matches():
+    # `universe` is now a deprecated alias for taxonomy_filter.index_memberships.
+    # A removed/unknown id simply matches no pool symbols → 404 (no tickers left),
+    # rather than the old 422 validation error.
     client = TestClient(app)
-    res = client.post("/api/screener/run", json={"universe": "mega_all", "top": 20})
-    assert res.status_code == 422
-    detail = res.json()["detail"]
-    assert "mega_all" in detail
-    assert "broad_market_stocks" in detail
-
-
-def test_screener_run_returns_422_for_removed_universe_no_replacement():
-    client = TestClient(app)
-    res = client.post("/api/screener/run", json={"universe": "eur_all", "top": 20})
-    assert res.status_code == 422
-    assert "eur_all" in res.json()["detail"]
-
-
-def test_screener_run_returns_422_for_unknown_universe():
-    client = TestClient(app)
-    res = client.post("/api/screener/run", json={"universe": "totally_unknown_id", "top": 20})
-    assert res.status_code == 422
+    for bogus in ("mega_all", "eur_all", "totally_unknown_id"):
+        res = client.post("/api/screener/run", json={"universe": bogus, "top": 20})
+        assert res.status_code == 404, bogus
 
 
 def test_screener_candidate_has_weekly_trend_field():
@@ -1269,7 +1452,9 @@ def test_screener_require_weekly_uptrend_overrides_strategy(monkeypatch):
     mock_provider = _create_mock_provider(ohlcv)
     captured: list = []
 
-    def fake_build_daily_report(ohlcv, cfg, exclude_tickers=None, sector_benchmark_returns=None, **kwargs):
+    def fake_build_daily_report(
+        ohlcv, cfg, exclude_tickers=None, sector_benchmark_returns=None, **kwargs
+    ):
         captured.append(cfg)
         idx = ["AAPL"]
         data = {
@@ -1287,14 +1472,22 @@ def test_screener_require_weekly_uptrend_overrides_strategy(monkeypatch):
         }
         return pd.DataFrame(data, index=idx)
 
-    monkeypatch.setattr(screener_service, "get_default_provider", lambda **kwargs: mock_provider)
+    monkeypatch.setattr(
+        screener_service, "get_default_provider", lambda **kwargs: mock_provider
+    )
     monkeypatch.setattr(screener_service, "build_daily_report", fake_build_daily_report)
-    monkeypatch.setattr(screener_service, "get_multiple_ticker_info", lambda tickers: {})
+    monkeypatch.setattr(
+        screener_service, "get_multiple_ticker_info", lambda tickers: {}
+    )
 
     client = TestClient(app)
     res = client.post(
         "/api/screener/run",
-        json={"universe": "broad_market_stocks", "top": 5, "require_weekly_uptrend": True},
+        json={
+            "universe": "broad_market_stocks",
+            "top": 5,
+            "require_weekly_uptrend": True,
+        },
     )
     assert res.status_code == 200
     assert captured, "build_daily_report was never called"
@@ -1341,12 +1534,18 @@ def test_screener_candidate_includes_52w_high_fields(monkeypatch):
             index=["AAA"],
         )
 
-    monkeypatch.setattr(screener_service, "get_default_provider", lambda **kwargs: mock_provider)
+    monkeypatch.setattr(
+        screener_service, "get_default_provider", lambda **kwargs: mock_provider
+    )
     monkeypatch.setattr(screener_service, "build_daily_report", fake_build_daily_report)
-    monkeypatch.setattr(screener_service, "get_multiple_ticker_info", lambda tickers: {})
+    monkeypatch.setattr(
+        screener_service, "get_multiple_ticker_info", lambda tickers: {}
+    )
 
     client = TestClient(app)
-    res = client.post("/api/screener/run", json={"universe": "broad_market_stocks", "top": 1})
+    res = client.post(
+        "/api/screener/run", json={"universe": "broad_market_stocks", "top": 1}
+    )
     assert res.status_code == 200
     candidate = res.json()["candidates"][0]
     assert "dist_52w_high_pct" in candidate

--- a/tests/data/test_symbol_pool.py
+++ b/tests/data/test_symbol_pool.py
@@ -222,6 +222,12 @@ def test_filter_index_membership_matches_any():
     assert {s.symbol for s in out} == {"A"}
 
 
+def test_filter_coarse_instrument_type():
+    pool = [_mk("A", instrument_type="equity"), _mk("B", instrument_type="etf")]
+    out = filter_pool_by_taxonomy(pool, TaxonomyFilterSpec(instrument_type=("equity",)))
+    assert {s.symbol for s in out} == {"A"}
+
+
 def test_filter_provider_matches_available():
     pool = [
         _mk("A", available_providers=["yfinance", "degiro"]),

--- a/tests/test_screener_service.py
+++ b/tests/test_screener_service.py
@@ -126,6 +126,7 @@ def test_mixed_universe_reuses_cached_symbols(tmp_path, monkeypatch):
     # downstream ranking (must have is_eligible, mom_6m, mom_12m, rs_6m so
     # build_momentum_report can rank and write to cache).
     import json
+
     computed_tickers: list[set] = []
 
     def _spying_compute(ohlcv, cfg, sector_benchmark_returns=None):
@@ -136,9 +137,20 @@ def test_mixed_universe_reuses_cached_symbols(tmp_path, monkeypatch):
         computed_tickers.append(close_tickers)
         # Return a minimal but valid records DataFrame so the cache can write.
         tickers_list = sorted(close_tickers)
-        feature_cols = ["mom_6m", "mom_12m", "rs_6m", "atr14", "atr_pct",
-                        "last", "currency", "dist_sma50_pct", "dist_sma200_pct",
-                        "trend_ok", "is_eligible", "signal"]
+        feature_cols = [
+            "mom_6m",
+            "mom_12m",
+            "rs_6m",
+            "atr14",
+            "atr_pct",
+            "last",
+            "currency",
+            "dist_sma50_pct",
+            "dist_sma200_pct",
+            "trend_ok",
+            "is_eligible",
+            "signal",
+        ]
         data = {
             "mom_6m": [0.10] * len(tickers_list),
             "mom_12m": [0.20] * len(tickers_list),
@@ -162,7 +174,9 @@ def test_mixed_universe_reuses_cached_symbols(tmp_path, monkeypatch):
     monkeypatch.setattr(momentum_mod, "compute_symbol_records", _spying_compute)
 
     # Stub out the heavy / network-dependent parts of _run_daily_report.
-    monkeypatch.setattr(screener_svc_mod, "get_multiple_ticker_info", lambda tickers: {})
+    monkeypatch.setattr(
+        screener_svc_mod, "get_multiple_ticker_info", lambda tickers: {}
+    )
     monkeypatch.setattr(
         screener_svc_mod.sector_rotation,
         "compute_sector_benchmark_returns",
@@ -180,7 +194,9 @@ def test_mixed_universe_reuses_cached_symbols(tmp_path, monkeypatch):
     )
 
     from swing_screener.strategy.report_config import ReportConfig
-    from swing_screener.selection.universe import UniverseConfig as SelectionUniverseConfig
+    from swing_screener.selection.universe import (
+        UniverseConfig as SelectionUniverseConfig,
+    )
     from swing_screener.selection.entries import EntrySignalConfig
     from swing_screener.selection.ranking import RankingConfig
     from swing_screener.risk.position_sizing import RiskConfig
@@ -201,6 +217,7 @@ def test_mixed_universe_reuses_cached_symbols(tmp_path, monkeypatch):
         ctx.ticker_info = {}
         ctx.sector_rotation_by_name = {}
         from swing_screener.recommendation.priority import CombinedPriorityConfig
+
         ctx.combined_priority_cfg = CombinedPriorityConfig()
         return ctx
 
@@ -219,16 +236,26 @@ def test_mixed_universe_reuses_cached_symbols(tmp_path, monkeypatch):
 
     # Run 1 must have computed at least AAA and BBB (SPY is the benchmark and
     # excluded from screening, so it may or may not appear).
-    all_computed_run1 = set().union(*computed_after_run1) if computed_after_run1 else set()
-    assert "AAA" in all_computed_run1, f"Run 1 should compute AAA; got {computed_after_run1}"
-    assert "BBB" in all_computed_run1, f"Run 1 should compute BBB; got {computed_after_run1}"
+    all_computed_run1 = (
+        set().union(*computed_after_run1) if computed_after_run1 else set()
+    )
+    assert (
+        "AAA" in all_computed_run1
+    ), f"Run 1 should compute AAA; got {computed_after_run1}"
+    assert (
+        "BBB" in all_computed_run1
+    ), f"Run 1 should compute BBB; got {computed_after_run1}"
 
     # Run 2 must NOT recompute BBB (cache hit) and MUST compute CCC (cache miss).
-    all_computed_run2 = set().union(*computed_after_run2) if computed_after_run2 else set()
-    assert "CCC" in all_computed_run2, f"Run 2 should compute CCC; got {computed_after_run2}"
-    assert "BBB" not in all_computed_run2, (
-        f"Run 2 should reuse cached BBB but recomputed it; got {computed_after_run2}"
+    all_computed_run2 = (
+        set().union(*computed_after_run2) if computed_after_run2 else set()
     )
+    assert (
+        "CCC" in all_computed_run2
+    ), f"Run 2 should compute CCC; got {computed_after_run2}"
+    assert (
+        "BBB" not in all_computed_run2
+    ), f"Run 2 should reuse cached BBB but recomputed it; got {computed_after_run2}"
 
 
 def test_force_refresh_bypasses_cache(tmp_path, monkeypatch):
@@ -246,6 +273,7 @@ def test_force_refresh_bypasses_cache(tmp_path, monkeypatch):
     svc, _eval_cache, _mock_provider = _make_screener_service(tmp_path)
 
     import json
+
     computed_tickers: list[set] = []
 
     def _spying_compute(ohlcv_arg, cfg, sector_benchmark_returns=None):
@@ -256,9 +284,18 @@ def test_force_refresh_bypasses_cache(tmp_path, monkeypatch):
         computed_tickers.append(close_tickers)
         tickers_list = sorted(close_tickers)
         feature_cols = [
-            "mom_6m", "mom_12m", "rs_6m", "atr14", "atr_pct",
-            "last", "currency", "dist_sma50_pct", "dist_sma200_pct",
-            "trend_ok", "is_eligible", "signal",
+            "mom_6m",
+            "mom_12m",
+            "rs_6m",
+            "atr14",
+            "atr_pct",
+            "last",
+            "currency",
+            "dist_sma50_pct",
+            "dist_sma200_pct",
+            "trend_ok",
+            "is_eligible",
+            "signal",
         ]
         data = {
             "mom_6m": [0.10] * len(tickers_list),
@@ -279,7 +316,9 @@ def test_force_refresh_bypasses_cache(tmp_path, monkeypatch):
 
     monkeypatch.setattr(momentum_mod, "compute_symbol_records", _spying_compute)
 
-    monkeypatch.setattr(screener_svc_mod, "get_multiple_ticker_info", lambda tickers: {})
+    monkeypatch.setattr(
+        screener_svc_mod, "get_multiple_ticker_info", lambda tickers: {}
+    )
     monkeypatch.setattr(
         screener_svc_mod.sector_rotation,
         "compute_sector_benchmark_returns",
@@ -303,7 +342,9 @@ def test_force_refresh_bypasses_cache(tmp_path, monkeypatch):
 
     def _make_ctx(tickers_list, ohlcv_df, asof="2024-01-05", force_refresh=False):
         req = ScreenerRequest(asof_date=asof, top=10, force_refresh=force_refresh)
-        ctx = _RunContext(request=req, strategy={}, combined_priority_cfg=CombinedPriorityConfig())
+        ctx = _RunContext(
+            request=req, strategy={}, combined_priority_cfg=CombinedPriorityConfig()
+        )
         ctx.ohlcv = ohlcv_df
         ctx.asof_str = asof
         ctx.screening_tickers = [t for t in tickers_list if t != "SPY"]
@@ -322,8 +363,12 @@ def test_force_refresh_bypasses_cache(tmp_path, monkeypatch):
     svc._run_daily_report(ctx2, requested_top=10)
 
     all_computed = set().union(*computed_tickers) if computed_tickers else set()
-    assert "AAA" in all_computed, f"force_refresh should recompute AAA; got {computed_tickers}"
-    assert "BBB" in all_computed, f"force_refresh should recompute BBB; got {computed_tickers}"
+    assert (
+        "AAA" in all_computed
+    ), f"force_refresh should recompute AAA; got {computed_tickers}"
+    assert (
+        "BBB" in all_computed
+    ), f"force_refresh should recompute BBB; got {computed_tickers}"
 
 
 def test_daily_review_reuses_manual_screen_cache(tmp_path, monkeypatch):
@@ -359,6 +404,7 @@ def test_daily_review_reuses_manual_screen_cache(tmp_path, monkeypatch):
 
     # --- Spy on compute_symbol_records ---
     import json
+
     computed_tickers: list[set] = []
 
     def _spying_compute(ohlcv_arg, cfg, sector_benchmark_returns=None):
@@ -369,9 +415,18 @@ def test_daily_review_reuses_manual_screen_cache(tmp_path, monkeypatch):
         computed_tickers.append(close_tickers)
         tickers_list = sorted(close_tickers)
         feature_cols = [
-            "mom_6m", "mom_12m", "rs_6m", "atr14", "atr_pct",
-            "last", "currency", "dist_sma50_pct", "dist_sma200_pct",
-            "trend_ok", "is_eligible", "signal",
+            "mom_6m",
+            "mom_12m",
+            "rs_6m",
+            "atr14",
+            "atr_pct",
+            "last",
+            "currency",
+            "dist_sma50_pct",
+            "dist_sma200_pct",
+            "trend_ok",
+            "is_eligible",
+            "signal",
         ]
         data = {
             "mom_6m": [0.10] * len(tickers_list),
@@ -392,7 +447,9 @@ def test_daily_review_reuses_manual_screen_cache(tmp_path, monkeypatch):
 
     monkeypatch.setattr(momentum_mod, "compute_symbol_records", _spying_compute)
 
-    monkeypatch.setattr(screener_svc_mod, "get_multiple_ticker_info", lambda tickers: {})
+    monkeypatch.setattr(
+        screener_svc_mod, "get_multiple_ticker_info", lambda tickers: {}
+    )
     monkeypatch.setattr(
         screener_svc_mod.sector_rotation,
         "compute_sector_benchmark_returns",
@@ -411,7 +468,9 @@ def test_daily_review_reuses_manual_screen_cache(tmp_path, monkeypatch):
 
     def _make_ctx(tickers_list, ohlcv_df, asof=ASOF):
         req = ScreenerRequest(asof_date=asof, top=10)
-        ctx = _RunContext(request=req, strategy={}, combined_priority_cfg=CombinedPriorityConfig())
+        ctx = _RunContext(
+            request=req, strategy={}, combined_priority_cfg=CombinedPriorityConfig()
+        )
         ctx.ohlcv = ohlcv_df
         ctx.asof_str = asof
         ctx.screening_tickers = [t for t in tickers_list if t != "SPY"]
@@ -450,14 +509,16 @@ def test_daily_review_reuses_manual_screen_cache(tmp_path, monkeypatch):
 
     computed_after_warmup = list(computed_tickers)
     all_warmed = set().union(*computed_after_warmup) if computed_after_warmup else set()
-    assert "AAA" in all_warmed and "BBB" in all_warmed, (
-        f"Warmup must compute AAA and BBB; got {computed_after_warmup}"
-    )
+    assert (
+        "AAA" in all_warmed and "BBB" in all_warmed
+    ), f"Warmup must compute AAA and BBB; got {computed_after_warmup}"
     computed_tickers.clear()
 
     # --- Build DailyReviewService whose screener shares the same EvalCache ---
     dr_portfolio = MagicMock(spec=PortfolioService)
-    dr_portfolio.list_positions.return_value = PositionsResponse(positions=[], asof="2024-01-05")
+    dr_portfolio.list_positions.return_value = PositionsResponse(
+        positions=[], asof="2024-01-05"
+    )
 
     dr_screener = ScreenerService(
         strategy_repo=mock_strategy_repo,
@@ -474,7 +535,9 @@ def test_daily_review_reuses_manual_screen_cache(tmp_path, monkeypatch):
     def _patched_run_screener(request, strategy_override=None):
         ctx = _make_ctx(tickers, ohlcv, asof=ASOF)
         dr_screener._run_daily_report(ctx, requested_top=10)
-        return ScreenerResponse(candidates=[], asof_date=ASOF, total_screened=len(tickers))
+        return ScreenerResponse(
+            candidates=[], asof_date=ASOF, total_screened=len(tickers)
+        )
 
     monkeypatch.setattr(dr_screener, "run_screener", _patched_run_screener)
 
@@ -490,17 +553,84 @@ def test_daily_review_reuses_manual_screen_cache(tmp_path, monkeypatch):
     all_computed_dr = set().union(*computed_after_dr) if computed_after_dr else set()
 
     # Neither AAA nor BBB should have been recomputed — they're both cache hits.
-    assert "AAA" not in all_computed_dr, (
-        f"daily-review should reuse cached AAA but recomputed it; got {computed_after_dr}"
+    assert (
+        "AAA" not in all_computed_dr
+    ), f"daily-review should reuse cached AAA but recomputed it; got {computed_after_dr}"
+    assert (
+        "BBB" not in all_computed_dr
+    ), f"daily-review should reuse cached BBB but recomputed it; got {computed_after_dr}"
+
+
+# ---------------------------------------------------------------------------
+# Taxonomy pool pre-filter (_resolve_universe_and_window)
+# ---------------------------------------------------------------------------
+
+
+class _FakePoolRepo:
+    def __init__(self, symbols):
+        self._symbols = symbols
+
+    def list_symbols(self):
+        return self._symbols
+
+
+class _FakeReviewRepo:
+    def __init__(self, entries=None):
+        self._entries = list(entries or [])
+
+    def list_entries(self):
+        return self._entries
+
+    def upsert(self, entries):
+        self._entries.extend(entries)
+
+
+def _pool_symbol(symbol, **kw):
+    base = {
+        "symbol": symbol,
+        "region": "us",
+        "available_providers": ["yfinance"],
+        "primary_provider": "yfinance",
+        "index_memberships": [],
+    }
+    base.update(kw)
+    return base
+
+
+def _make_screener_service_with_pool(tmp_path, symbols, queue=None):
+    from api.services.screener_service import ScreenerService
+    from api.repositories.strategy_repo import StrategyRepository
+    from api.services.portfolio_service import PortfolioService
+    from swing_screener.selection.eval_cache import EvalCache
+    from swing_screener.data.source_health import DataSourceHealth
+    from swing_screener.data.providers import MarketDataProvider
+
+    mock_strategy_repo = MagicMock(spec=StrategyRepository)
+    mock_strategy_repo.get_active_strategy.return_value = {}
+    mock_portfolio = MagicMock(spec=PortfolioService)
+    mock_portfolio.list_positions.return_value = MagicMock(positions=[])
+    mock_provider = MagicMock(spec=MarketDataProvider)
+    mock_provider.get_provider_name.return_value = "mock"
+    mock_provider.get_source_health.return_value = DataSourceHealth(
+        provider="mock",
+        domain="market_data",
+        status="ok",
+        quality_score=0.7,
+        delay_policy="test",
     )
-    assert "BBB" not in all_computed_dr, (
-        f"daily-review should reuse cached BBB but recomputed it; got {computed_after_dr}"
+    return ScreenerService(
+        strategy_repo=mock_strategy_repo,
+        portfolio_service=mock_portfolio,
+        provider=mock_provider,
+        eval_cache=EvalCache(root=tmp_path / "eval_cache"),
+        pool_repo=_FakePoolRepo(symbols),
+        review_repo=_FakeReviewRepo(queue),
     )
 
 
 def test_fetch_ohlcv_chunked_forwards_force_refresh():
     """_fetch_ohlcv_chunked must pass force_refresh through to provider.fetch_ohlcv."""
-    from unittest.mock import MagicMock, call
+    from unittest.mock import MagicMock
     from api.services.screener_service import _fetch_ohlcv_chunked
     from swing_screener.data.providers import MarketDataProvider
 
@@ -524,3 +654,52 @@ def test_fetch_ohlcv_chunked_forwards_force_refresh():
     assert kwargs.get("force_refresh") is True, (
         f"expected force_refresh=True forwarded to provider; got {kwargs}"
     )
+
+
+def test_resolve_universe_prefilters_from_pool(tmp_path):
+    from api.services.screener_service import _RunContext
+    from api.models.screener import ScreenerRequest, TaxonomyFilter
+
+    symbols = [
+        _pool_symbol("AAPL", region="us"),
+        _pool_symbol("ASML", region="europe"),
+        _pool_symbol("TSM", region="asia_pacific"),
+    ]
+    svc = _make_screener_service_with_pool(tmp_path, symbols)
+    req = ScreenerRequest(taxonomy_filter=TaxonomyFilter(region=["us"]), top=5)
+    ctx = _RunContext(request=req, strategy={})
+    svc._resolve_universe_and_window(ctx)
+    assert "AAPL" in ctx.screening_tickers
+    assert "ASML" not in ctx.screening_tickers
+    assert "TSM" not in ctx.screening_tickers
+
+
+def test_resolve_universe_excludes_review_queue(tmp_path):
+    from api.services.screener_service import _RunContext
+    from api.models.screener import ScreenerRequest, TaxonomyFilter
+
+    symbols = [_pool_symbol("AAPL", region="us"), _pool_symbol("MSFT", region="us")]
+    svc = _make_screener_service_with_pool(
+        tmp_path, symbols, queue=[{"symbol": "AAPL"}]
+    )
+    req = ScreenerRequest(taxonomy_filter=TaxonomyFilter(region=["us"]), top=5)
+    ctx = _RunContext(request=req, strategy={})
+    svc._resolve_universe_and_window(ctx)
+    assert "AAPL" not in ctx.screening_tickers
+    assert "MSFT" in ctx.screening_tickers
+
+
+def test_universe_alias_maps_to_index_membership(tmp_path):
+    from api.services.screener_service import _RunContext
+    from api.models.screener import ScreenerRequest
+
+    symbols = [
+        _pool_symbol("AAPL", index_memberships=["us_sp500"]),
+        _pool_symbol("XYZ", index_memberships=["other_index"]),
+    ]
+    svc = _make_screener_service_with_pool(tmp_path, symbols)
+    req = ScreenerRequest(universe="us_sp500", top=5)
+    ctx = _RunContext(request=req, strategy={})
+    svc._resolve_universe_and_window(ctx)
+    assert "AAPL" in ctx.screening_tickers
+    assert "XYZ" not in ctx.screening_tickers

--- a/tests/test_screener_service.py
+++ b/tests/test_screener_service.py
@@ -575,14 +575,17 @@ class _FakePoolRepo:
 
 
 class _FakeReviewRepo:
-    def __init__(self, entries=None):
-        self._entries = list(entries or [])
+    def __init__(self, queued=None):
+        # `queued` is a list of {"symbol": ...} dicts or plain symbol strings.
+        self._queued = {
+            (q["symbol"] if isinstance(q, dict) else q).upper() for q in (queued or [])
+        }
 
-    def list_entries(self):
-        return self._entries
+    def queued_symbols(self, threshold):
+        return set(self._queued)
 
-    def upsert(self, entries):
-        self._entries.extend(entries)
+    def apply_fetch_results(self, ok, failed, asof, threshold):
+        return None
 
 
 def _pool_symbol(symbol, **kw):
@@ -723,28 +726,31 @@ def test_record_fetch_health_enqueues_on_threshold(tmp_path):
             {
                 "schema_version": 1,
                 "asof": "2026-06-29",
-                "symbols": [
-                    {"symbol": "AAPL", "fetch_failure_count": 2},
-                    {"symbol": "MSFT", "fetch_failure_count": 0},
-                ],
+                "symbols": [{"symbol": "AAPL"}, {"symbol": "MSFT"}],
             }
         ),
         encoding="utf-8",
     )
+    # Review queue: AAPL already failed twice (count 2, below threshold 3).
     queue_path = tmp_path / "review_queue.json"
+    queue_path.write_text(
+        json.dumps({"symbols": {"AAPL": {"symbol": "AAPL", "fetch_failure_count": 2}}}),
+        encoding="utf-8",
+    )
 
     mock_strategy_repo = MagicMock(spec=StrategyRepository)
     mock_portfolio = MagicMock(spec=PortfolioService)
     mock_provider = MagicMock(spec=MarketDataProvider)
     mock_provider.get_provider_name.return_value = "mock"
 
+    review_repo = ReviewQueueRepository(queue_path)
     svc = ScreenerService(
         strategy_repo=mock_strategy_repo,
         portfolio_service=mock_portfolio,
         provider=mock_provider,
         eval_cache=EvalCache(root=tmp_path / "eval_cache"),
         pool_repo=SymbolPoolRepository(pool_path),
-        review_repo=ReviewQueueRepository(queue_path),
+        review_repo=review_repo,
     )
 
     # OHLCV contains MSFT only → AAPL failed this run, crossing 2 -> 3 (threshold 3).
@@ -760,11 +766,7 @@ def test_record_fetch_health_enqueues_on_threshold(tmp_path):
 
     svc._record_fetch_health(ctx)
 
-    queue_symbols = [
-        e["symbol"] for e in ReviewQueueRepository(queue_path).list_entries()
-    ]
-    assert "AAPL" in queue_symbols
-    # MSFT fetched OK → counter reset + last_fetch_ok_at stamped.
-    pool = {s["symbol"]: s for s in SymbolPoolRepository(pool_path).list_symbols()}
-    assert pool["MSFT"]["fetch_failure_count"] == 0
-    assert pool["MSFT"]["last_fetch_ok_at"] == "2026-06-30"
+    assert review_repo.queued_symbols(3) == {"AAPL"}
+    # The committed pool file is never mutated by a screener run.
+    pool_data = json.loads(pool_path.read_text(encoding="utf-8"))
+    assert all("fetch_failure_count" not in s for s in pool_data["symbols"])

--- a/tests/test_screener_service.py
+++ b/tests/test_screener_service.py
@@ -703,3 +703,68 @@ def test_universe_alias_maps_to_index_membership(tmp_path):
     svc._resolve_universe_and_window(ctx)
     assert "AAPL" in ctx.screening_tickers
     assert "XYZ" not in ctx.screening_tickers
+
+
+def test_record_fetch_health_enqueues_on_threshold(tmp_path):
+    import json
+
+    from api.services.screener_service import ScreenerService, _RunContext
+    from api.repositories.strategy_repo import StrategyRepository
+    from api.repositories.symbol_pool_repo import SymbolPoolRepository
+    from api.repositories.review_queue_repo import ReviewQueueRepository
+    from api.services.portfolio_service import PortfolioService
+    from api.models.screener import ScreenerRequest
+    from swing_screener.selection.eval_cache import EvalCache
+    from swing_screener.data.providers import MarketDataProvider
+
+    pool_path = tmp_path / "symbol_pool.json"
+    pool_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "asof": "2026-06-29",
+                "symbols": [
+                    {"symbol": "AAPL", "fetch_failure_count": 2},
+                    {"symbol": "MSFT", "fetch_failure_count": 0},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    queue_path = tmp_path / "review_queue.json"
+
+    mock_strategy_repo = MagicMock(spec=StrategyRepository)
+    mock_portfolio = MagicMock(spec=PortfolioService)
+    mock_provider = MagicMock(spec=MarketDataProvider)
+    mock_provider.get_provider_name.return_value = "mock"
+
+    svc = ScreenerService(
+        strategy_repo=mock_strategy_repo,
+        portfolio_service=mock_portfolio,
+        provider=mock_provider,
+        eval_cache=EvalCache(root=tmp_path / "eval_cache"),
+        pool_repo=SymbolPoolRepository(pool_path),
+        review_repo=ReviewQueueRepository(queue_path),
+    )
+
+    # OHLCV contains MSFT only → AAPL failed this run, crossing 2 -> 3 (threshold 3).
+    idx = pd.date_range("2024-01-01", periods=2, freq="B")
+    cols = pd.MultiIndex.from_tuples([("Close", "MSFT")], names=["field", "ticker"])
+    ohlcv = pd.DataFrame([[10.0], [10.5]], index=idx, columns=cols)
+
+    req = ScreenerRequest(top=5)
+    ctx = _RunContext(request=req, strategy={})
+    ctx.ohlcv = ohlcv
+    ctx.screening_tickers = ["AAPL", "MSFT"]
+    ctx.asof_str = "2026-06-30"
+
+    svc._record_fetch_health(ctx)
+
+    queue_symbols = [
+        e["symbol"] for e in ReviewQueueRepository(queue_path).list_entries()
+    ]
+    assert "AAPL" in queue_symbols
+    # MSFT fetched OK → counter reset + last_fetch_ok_at stamped.
+    pool = {s["symbol"]: s for s in SymbolPoolRepository(pool_path).list_symbols()}
+    assert pool["MSFT"]["fetch_failure_count"] == 0
+    assert pool["MSFT"]["last_fetch_ok_at"] == "2026-06-30"


### PR DESCRIPTION
Replaces one-at-a-time universe selection with a taxonomy pre-filter over the unified symbol pool. The screener now resolves its working ticker list from `data/symbol_pool.json` filtered by a `TaxonomyFilter` (region, market cap tier, sector, index membership, instrument type, provider, currency, exchange, liquidity tier), then fetches OHLCV only for the survivors. No more switching universes by hand.

Main pieces:

- `TaxonomyFilter` request model + `taxonomy_presets.yaml` (named filter combos, loaded via `pool_service`). `POST /api/screener/run` accepts `taxonomy_filter` and `preset`.
- `_resolve_universe_and_window` builds the spec from preset + `taxonomy_filter` + the deprecated `universe` alias, drops review-queued and provider-unavailable symbols, then filters the pool.
- New `/api/pool` router: `GET /symbols` (paginated taxonomy browse), `GET /review-queue`, `POST /review-queue/{symbol}/remove|restore`, `GET /presets`.

Fetch-health handling (changed from the original plan):

- The committed `symbol_pool.json` is treated as an immutable build artifact. All runtime fetch-health (per-symbol consecutive failure counts, last-ok timestamps) lives in the gitignored `data/review_queue.json` instead, so the committed pool never drifts. `ReviewQueueRepository` owns this state; `SymbolPoolRepository` is read-only.
- A symbol that fails to fetch `fetch_failure_threshold` times in a row (default `3`, in `low_level.symbol_pool`) crosses into the review queue and is excluded from future screens until restored.

Backward compatibility:

- The legacy top-level filter fields (`currencies`, `exchange_mics`, `instrument_types`, `include_otc`) still work: they map onto the taxonomy spec, so the current UI keeps filtering correctly until the filter-bar PR lands.
- `universe` is now a deprecated alias for `taxonomy_filter.index_memberships=[universe]`. An unknown or removed universe id now resolves to zero matches and returns `404` (no tickers left), instead of the old `422` validation error. Removal of the alias is a later stacked PR.

Note for reviewers: `tests/test_datasources_intelligence.py::test_sec_collector_probeable_in_inventory` fails under full-suite ordering on this branch, but it fails identically on the base branch (a `DatasourcesService` env/cache ordering issue), so it is pre-existing and unrelated to this change. It passes in isolation.