### PR TITLE
Replace the universe selector with a taxonomy quick filter bar

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -133,6 +133,21 @@ Runtime path keys are defined under `paths` in `defaults.yaml` and control where
 | Key | Default | Purpose |
 |-----|---------|---------|
 | `eval_cache_dir` | `.cache/eval` | Root directory for the per-symbol evaluation cache. Parquets are stored at `{eval_cache_dir}/{strategy_sig}/{asof_date}/{SYMBOL}.parquet`. Files older than 24 h are pruned automatically on each run. |
+| `symbol_pool_file` | `data/symbol_pool.json` | Committed taxonomy symbol pool the screener pre-filters. |
+| `review_queue_file` | `data/review_queue.json` | Runtime fetch-health / review queue (gitignored). |
+
+### `low_level.symbol_pool`
+
+Thresholds for the unified taxonomy symbol pool (`data/symbol_pool.json`),
+consumed by `swing_screener.data.symbol_pool.load_symbol_pool_thresholds()`.
+
+| Group | Keys | Purpose |
+|-------|------|---------|
+| `market_cap_thresholds` | `large`, `mid`, `small` | USD market-cap bounds (>= bound assigns the tier; below `small` = `micro`). |
+| `liquidity_thresholds` | `high`, `mid` | USD average daily dollar-volume bounds (below `mid` = `low`). |
+| `fetch_failure_threshold` | — | Consecutive OHLCV fetch failures before a symbol moves to the review queue (default 3). |
+
+See `data/README.md` for how to (re)build and enrich the pool.
 
 ## Notes
 

--- a/data/README.md
+++ b/data/README.md
@@ -88,6 +88,106 @@ python -m swing_screener.cli universes refresh --name <id> --apply
 Omit `--apply` for a dry-run preview. See
 `docs/engineering/MODULE_ARCHITECTURE.md` for the adapter modules.
 
+## Symbol Pool (`symbol_pool.json`)
+
+The unified, taxonomy-tagged set of symbols the screener is allowed to touch.
+It replaces one-at-a-time universe selection: the screener pre-filters this
+file by taxonomy (no network) and only then fetches OHLCV for the survivors.
+
+Schema:
+
+```json
+{
+  "schema_version": 1,
+  "asof": "2026-06-30",
+  "symbols": [ { /* PoolSymbol */ } ]
+}
+```
+
+`PoolSymbol` fields:
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| `symbol` | merge | uppercased ticker |
+| `exchange_mic`, `currency` | snapshots + instrument master | populated network-free |
+| `region` | derived from MIC/country | `us` / `europe` / `asia_pacific` / `other` |
+| `index_memberships` | which universe snapshots contained the symbol | replaces universe identity; filterable |
+| `instrument_type` | instrument master | coarse `equity` / `etf` (populated network-free) |
+| `available_providers`, `primary_provider` | `provider_symbol_map` | defaults to `["yfinance"]` / `yfinance` |
+| `sector`, `industry` | yfinance enrichment | **null until enrichment runs** |
+| `market_cap_tier` | yfinance enrichment | `large`/`mid`/`small`/`micro`; **null until enrichment** |
+| `liquidity_tier` | yfinance enrichment (avg $ volume) | `high`/`mid`/`low`; null unless a provider exposes volume+price |
+| `instrument_type_detail` | yfinance enrichment | `equity`/`etf_*`; **null until enrichment** |
+| `taxonomy_refreshed_at` | enrichment timestamp | |
+| `fetch_failure_count`, `last_fetch_ok_at` | review queue (runtime) | not stored here; the pool file is immutable |
+
+### Building / refreshing the pool
+
+The pool is a committed build artifact. There is no UI/CLI trigger yet, so
+(re)generate it with these one-off snippets from the repo root (use the project
+venv: `.venv/bin/python`).
+
+**1. Base build (network-free).** Merges the 25 universe snapshots with the
+instrument master. Populates everything except the yfinance-derived fields.
+
+```bash
+.venv/bin/python - <<'PY'
+import json
+from swing_screener.data.symbol_pool import build_pool_base, serialize_pool
+pool = build_pool_base()
+with open("data/symbol_pool.json", "w", encoding="utf-8") as f:
+    json.dump(serialize_pool(pool, asof_date="2026-06-30"), f, indent=2, ensure_ascii=False)
+print("symbols:", len(pool))
+PY
+```
+
+**2. Taxonomy enrichment (network, ~0.7s/symbol).** Required before
+`sector` / `market_cap_tier` / `instrument_type_detail` filters (and presets
+that use them, e.g. *EU Blue Chips*) return anything. Best-effort: per-symbol
+failures are skipped, not fatal. `liquidity_tier` stays null because
+`get_ticker_info` does not expose volume/price.
+
+```bash
+.venv/bin/python - <<'PY'
+import json
+from swing_screener.data.symbol_pool import (
+    deserialize_pool, enrich_pool_taxonomy, serialize_pool, load_symbol_pool_thresholds,
+)
+from swing_screener.data.providers.factory import get_default_provider
+
+with open("data/symbol_pool.json", encoding="utf-8") as f:
+    payload = json.load(f)
+pool = deserialize_pool(payload)
+provider = get_default_provider()
+cap, liq, _ = load_symbol_pool_thresholds()
+failed = enrich_pool_taxonomy(
+    pool, info_fn=lambda s: provider.get_ticker_info(s) or None,
+    asof_date=payload.get("asof", "2026-06-30"), cap_thresholds=cap, liquidity_thresholds=liq,
+)
+with open("data/symbol_pool.json", "w", encoding="utf-8") as f:
+    json.dump(serialize_pool(pool, asof_date=payload.get("asof")), f, indent=2, ensure_ascii=False)
+print(f"enriched sector={sum(1 for s in pool if s.sector)}/{len(pool)} failed={len(failed)}")
+PY
+```
+
+The backend reads the file fresh on each request, so a running server picks up
+the refreshed pool with no restart. **Migration:** no backfill — the file is a
+regenerable build artifact.
+
+## Review Queue (`review_queue.json`)
+
+The single runtime store for per-symbol OHLCV fetch health (the committed pool
+stays immutable). A symbol whose consecutive failure count reaches
+`fetch_failure_threshold` (default 3, `config/defaults.yaml` →
+`low_level.symbol_pool`) becomes a review-queue entry the UI surfaces for manual
+remove/restore. Gitignored. Schema:
+
+```json
+{ "symbols": { "AAPL": { "symbol": "AAPL", "fetch_failure_count": 3,
+  "first_failed_at": "2026-06-28", "last_failed_at": "2026-06-30",
+  "reason": "OHLCV fetch returned no data" } } }
+```
+
 ## Optional Database
 - `swing_screener.db`: SQLite database (module exists but not wired by default)
 - Migration notes: `docs/engineering/DATABASE_MIGRATION.md`

--- a/data/symbol_pool.json
+++ b/data/symbol_pool.json
@@ -7,9 +7,9 @@
       "exchange_mic": "XAMS",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Diversified",
       "index_memberships": [
         "amsterdam_aex",
         "amsterdam_all",
@@ -17,12 +17,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -31,9 +31,9 @@
       "exchange_mic": "XAMS",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Software - Infrastructure",
       "index_memberships": [
         "amsterdam_aex",
         "amsterdam_all",
@@ -41,12 +41,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -55,21 +55,21 @@
       "exchange_mic": "XAMS",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Insurance - Diversified",
       "index_memberships": [
         "amsterdam_aex",
         "amsterdam_all"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -78,9 +78,9 @@
       "exchange_mic": "XAMS",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Grocery Stores",
       "index_memberships": [
         "amsterdam_aex",
         "amsterdam_all",
@@ -90,12 +90,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -104,21 +104,21 @@
       "exchange_mic": "XAMS",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Basic Materials",
+      "industry": "Specialty Chemicals",
       "index_memberships": [
         "amsterdam_aex",
         "amsterdam_all"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -127,9 +127,9 @@
       "exchange_mic": "XAMS",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Basic Materials",
+      "industry": "Steel",
       "index_memberships": [
         "amsterdam_aex",
         "amsterdam_all",
@@ -137,12 +137,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -151,9 +151,9 @@
       "exchange_mic": "XAMS",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Semiconductor Equipment & Materials",
       "index_memberships": [
         "amsterdam_aex",
         "amsterdam_all",
@@ -161,12 +161,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -175,9 +175,9 @@
       "exchange_mic": "XAMS",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Semiconductor Equipment & Materials",
       "index_memberships": [
         "amsterdam_aex",
         "amsterdam_all",
@@ -188,12 +188,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -202,9 +202,9 @@
       "exchange_mic": "XAMS",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Insurance - Diversified",
       "index_memberships": [
         "amsterdam_aex",
         "amsterdam_all",
@@ -212,12 +212,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -226,9 +226,9 @@
       "exchange_mic": "XAMS",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Semiconductor Equipment & Materials",
       "index_memberships": [
         "amsterdam_aex",
         "amsterdam_all",
@@ -236,12 +236,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -250,21 +250,21 @@
       "exchange_mic": "XAMS",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Asset Management",
       "index_memberships": [
         "amsterdam_aex",
         "amsterdam_all"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -273,21 +273,21 @@
       "exchange_mic": "XAMS",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Basic Materials",
+      "industry": "Specialty Chemicals",
       "index_memberships": [
         "amsterdam_aex",
         "amsterdam_all"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -296,21 +296,21 @@
       "exchange_mic": "XAMS",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Farm & Heavy Construction Machinery",
       "index_memberships": [
         "amsterdam_aex",
         "amsterdam_all"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -319,9 +319,9 @@
       "exchange_mic": "XAMS",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Beverages - Brewers",
       "index_memberships": [
         "amsterdam_aex",
         "amsterdam_all",
@@ -330,12 +330,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -344,21 +344,21 @@
       "exchange_mic": "XAMS",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Basic Materials",
+      "industry": "Specialty Chemicals",
       "index_memberships": [
         "amsterdam_aex",
         "amsterdam_all"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -367,9 +367,9 @@
       "exchange_mic": "XAMS",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Diversified",
       "index_memberships": [
         "amsterdam_aex",
         "amsterdam_all",
@@ -378,12 +378,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -392,21 +392,21 @@
       "exchange_mic": "XAMS",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Industrials",
+      "industry": "Integrated Freight & Logistics",
       "index_memberships": [
         "amsterdam_aex",
         "amsterdam_all"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -415,21 +415,21 @@
       "exchange_mic": "XAMS",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Packaged Foods",
       "index_memberships": [
         "amsterdam_aex",
         "amsterdam_all"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -447,12 +447,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -461,9 +461,9 @@
       "exchange_mic": "XAMS",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Communication Services",
+      "industry": "Telecom Services",
       "index_memberships": [
         "amsterdam_aex",
         "amsterdam_all",
@@ -472,12 +472,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -486,9 +486,9 @@
       "exchange_mic": "XAMS",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Insurance - Diversified",
       "index_memberships": [
         "amsterdam_aex",
         "amsterdam_all",
@@ -496,12 +496,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -510,21 +510,21 @@
       "exchange_mic": "XAMS",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Medical Devices",
       "index_memberships": [
         "amsterdam_aex",
         "amsterdam_all"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -533,9 +533,9 @@
       "exchange_mic": "XAMS",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Internet Retail",
       "index_memberships": [
         "amsterdam_aex",
         "amsterdam_all",
@@ -543,12 +543,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -557,21 +557,21 @@
       "exchange_mic": "XAMS",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Specialty Business Services",
       "index_memberships": [
         "amsterdam_aex",
         "amsterdam_all"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -580,9 +580,9 @@
       "exchange_mic": "XAMS",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Energy",
+      "industry": "Oil & Gas Integrated",
       "index_memberships": [
         "amsterdam_aex",
         "amsterdam_all",
@@ -590,12 +590,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -604,21 +604,21 @@
       "exchange_mic": "XAMS",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Communication Services",
+      "industry": "Entertainment",
       "index_memberships": [
         "amsterdam_aex",
         "amsterdam_all"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -627,9 +627,9 @@
       "exchange_mic": "XAMS",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Household & Personal Products",
       "index_memberships": [
         "amsterdam_aex",
         "amsterdam_all",
@@ -638,12 +638,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -661,12 +661,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -675,9 +675,9 @@
       "exchange_mic": "XAMS",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Specialty Business Services",
       "index_memberships": [
         "amsterdam_aex",
         "amsterdam_all",
@@ -685,12 +685,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -699,21 +699,21 @@
       "exchange_mic": "XAMS",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Energy",
+      "industry": "Oil & Gas Equipment & Services",
       "index_memberships": [
         "amsterdam_aex",
         "amsterdam_all"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -722,21 +722,21 @@
       "exchange_mic": "XAMS",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Industrials",
+      "industry": "Specialty Industrial Machinery",
       "index_memberships": [
         "amsterdam_all",
         "amsterdam_amx"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -745,21 +745,21 @@
       "exchange_mic": "XPAR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Industrials",
+      "industry": "Airlines",
       "index_memberships": [
         "amsterdam_all",
         "amsterdam_amx"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -768,21 +768,21 @@
       "exchange_mic": "XAMS",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Financial Services",
+      "industry": "Asset Management",
       "index_memberships": [
         "amsterdam_all",
         "amsterdam_amx"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -791,21 +791,21 @@
       "exchange_mic": "XAMS",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "small",
+      "sector": "Basic Materials",
+      "industry": "Other Industrial Metals & Mining",
       "index_memberships": [
         "amsterdam_all",
         "amsterdam_amx"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -814,21 +814,21 @@
       "exchange_mic": "XAMS",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Basic Materials",
+      "industry": "Steel",
       "index_memberships": [
         "amsterdam_all",
         "amsterdam_amx"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -837,21 +837,21 @@
       "exchange_mic": "XAMS",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Industrials",
+      "industry": "Engineering & Construction",
       "index_memberships": [
         "amsterdam_all",
         "amsterdam_amx"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -860,21 +860,21 @@
       "exchange_mic": "XAMS",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Industrials",
+      "industry": "Engineering & Construction",
       "index_memberships": [
         "amsterdam_all",
         "amsterdam_amx"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -883,21 +883,21 @@
       "exchange_mic": "XAMS",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Consumer Cyclical",
+      "industry": "Leisure",
       "index_memberships": [
         "amsterdam_all",
         "amsterdam_amx"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -906,21 +906,21 @@
       "exchange_mic": "XAMS",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "small",
+      "sector": "Basic Materials",
+      "industry": "Specialty Chemicals",
       "index_memberships": [
         "amsterdam_all",
         "amsterdam_amx"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -929,21 +929,21 @@
       "exchange_mic": "XAMS",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Real Estate",
+      "industry": "Real Estate - Development",
       "index_memberships": [
         "amsterdam_all",
         "amsterdam_amx"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -952,21 +952,21 @@
       "exchange_mic": "XAMS",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "small",
+      "sector": "Real Estate",
+      "industry": "REIT - Retail",
       "index_memberships": [
         "amsterdam_all",
         "amsterdam_amx"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -984,12 +984,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -998,21 +998,21 @@
       "exchange_mic": "XAMS",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "small",
+      "sector": "Financial Services",
+      "industry": "Capital Markets",
       "index_memberships": [
         "amsterdam_all",
         "amsterdam_amx"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -1021,21 +1021,21 @@
       "exchange_mic": "XAMS",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "small",
+      "sector": "Energy",
+      "industry": "Oil & Gas Equipment & Services",
       "index_memberships": [
         "amsterdam_all",
         "amsterdam_amx"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -1044,9 +1044,9 @@
       "exchange_mic": "XAMS",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "small",
+      "sector": "Healthcare",
+      "industry": "Biotechnology",
       "index_memberships": [
         "amsterdam_all",
         "amsterdam_amx",
@@ -1054,12 +1054,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -1068,21 +1068,21 @@
       "exchange_mic": "XAMS",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Asset Management",
       "index_memberships": [
         "amsterdam_all",
         "amsterdam_amx"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -1091,21 +1091,21 @@
       "exchange_mic": "XAMS",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "small",
+      "sector": "Communication Services",
+      "industry": "Advertising Agencies",
       "index_memberships": [
         "amsterdam_all",
         "amsterdam_amx"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -1114,21 +1114,21 @@
       "exchange_mic": "XAMS",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Industrials",
+      "industry": "Engineering & Construction",
       "index_memberships": [
         "amsterdam_all",
         "amsterdam_amx"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -1137,9 +1137,9 @@
       "exchange_mic": "XAMS",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "small",
+      "sector": "Healthcare",
+      "industry": "Biotechnology",
       "index_memberships": [
         "amsterdam_all",
         "amsterdam_amx",
@@ -1147,12 +1147,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -1161,21 +1161,21 @@
       "exchange_mic": "XAMS",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "small",
+      "sector": "Industrials",
+      "industry": "Electrical Equipment & Parts",
       "index_memberships": [
         "amsterdam_all",
         "amsterdam_amx"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -1184,21 +1184,21 @@
       "exchange_mic": "XAMS",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "small",
+      "sector": "Technology",
+      "industry": "Communication Equipment",
       "index_memberships": [
         "amsterdam_all",
         "amsterdam_amx"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -1207,21 +1207,21 @@
       "exchange_mic": "XAMS",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Financial Services",
+      "industry": "Banks - Regional",
       "index_memberships": [
         "amsterdam_all",
         "amsterdam_amx"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -1230,21 +1230,21 @@
       "exchange_mic": "XAMS",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Energy",
+      "industry": "Oil & Gas Midstream",
       "index_memberships": [
         "amsterdam_all",
         "amsterdam_amx"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -1253,9 +1253,9 @@
       "exchange_mic": "XAMS",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Industrials",
+      "industry": "Staffing & Employment Services",
       "index_memberships": [
         "amsterdam_all",
         "amsterdam_amx",
@@ -1264,12 +1264,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -1278,9 +1278,9 @@
       "exchange_mic": "XAMS",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Industrials",
+      "industry": "Aerospace & Defense",
       "index_memberships": [
         "amsterdam_all",
         "amsterdam_amx",
@@ -1288,12 +1288,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -1310,12 +1310,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "etf",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "etf_equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -1332,12 +1332,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "etf",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "etf_equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -1354,12 +1354,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "etf",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "etf_equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -1376,12 +1376,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "etf",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "etf_equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -1398,12 +1398,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "etf",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "etf_equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -1420,12 +1420,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "etf",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "etf_equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -1442,12 +1442,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "etf",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "etf_equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -1464,12 +1464,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "etf",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "etf_equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -1486,12 +1486,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "etf",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "etf_equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -1508,12 +1508,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "etf",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "etf_equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -1530,12 +1530,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "etf",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "etf_equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -1552,12 +1552,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "etf",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "etf_equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -1575,12 +1575,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "etf",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "etf_equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -1597,12 +1597,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "etf",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "etf_equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -1619,12 +1619,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "etf",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "etf_equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -1641,12 +1641,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "etf",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "etf_equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -1663,12 +1663,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "etf",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "etf_equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -1685,12 +1685,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "etf",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "etf_equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -1707,12 +1707,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "etf",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "etf_equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -1729,12 +1729,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "etf",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "etf_equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -1743,9 +1743,9 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Consumer Electronics",
       "index_memberships": [
         "broad_market_stocks",
         "us_dow30",
@@ -1754,12 +1754,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -1768,9 +1768,9 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Software - Infrastructure",
       "index_memberships": [
         "broad_market_stocks",
         "us_dow30",
@@ -1779,12 +1779,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -1793,9 +1793,9 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Semiconductors",
       "index_memberships": [
         "broad_market_stocks",
         "semiconductor_stocks",
@@ -1805,12 +1805,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -1819,9 +1819,9 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Internet Retail",
       "index_memberships": [
         "broad_market_stocks",
         "us_dow30",
@@ -1830,12 +1830,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -1844,9 +1844,9 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Communication Services",
+      "industry": "Internet Content & Information",
       "index_memberships": [
         "broad_market_stocks",
         "us_nasdaq100",
@@ -1854,12 +1854,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -1868,9 +1868,9 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Communication Services",
+      "industry": "Internet Content & Information",
       "index_memberships": [
         "broad_market_stocks",
         "us_nasdaq100",
@@ -1878,12 +1878,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -1892,9 +1892,9 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Communication Services",
+      "industry": "Internet Content & Information",
       "index_memberships": [
         "broad_market_stocks",
         "us_nasdaq100",
@@ -1902,12 +1902,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -1916,9 +1916,9 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Auto Manufacturers",
       "index_memberships": [
         "broad_market_stocks",
         "us_nasdaq100",
@@ -1926,12 +1926,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -1940,9 +1940,9 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Insurance - Diversified",
       "index_memberships": [
         "broad_market_stocks",
         "financial_stocks",
@@ -1950,12 +1950,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -1964,9 +1964,9 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Diversified",
       "index_memberships": [
         "broad_market_stocks",
         "financial_stocks",
@@ -1975,12 +1975,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -1989,9 +1989,9 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Diversified",
       "index_memberships": [
         "broad_market_stocks",
         "financial_stocks",
@@ -1999,12 +1999,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -2013,9 +2013,9 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Diversified",
       "index_memberships": [
         "broad_market_stocks",
         "financial_stocks",
@@ -2023,12 +2023,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -2037,9 +2037,9 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Capital Markets",
       "index_memberships": [
         "broad_market_stocks",
         "financial_stocks",
@@ -2048,12 +2048,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -2062,9 +2062,9 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Capital Markets",
       "index_memberships": [
         "broad_market_stocks",
         "financial_stocks",
@@ -2072,12 +2072,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -2086,9 +2086,9 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Credit Services",
       "index_memberships": [
         "broad_market_stocks",
         "financial_stocks",
@@ -2097,12 +2097,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -2111,9 +2111,9 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Credit Services",
       "index_memberships": [
         "broad_market_stocks",
         "financial_stocks",
@@ -2121,12 +2121,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -2135,9 +2135,9 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Credit Services",
       "index_memberships": [
         "broad_market_stocks",
         "financial_stocks",
@@ -2146,12 +2146,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -2160,9 +2160,9 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Healthcare Plans",
       "index_memberships": [
         "broad_market_stocks",
         "healthcare_stocks",
@@ -2171,12 +2171,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -2185,9 +2185,9 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Drug Manufacturers - General",
       "index_memberships": [
         "broad_market_stocks",
         "healthcare_stocks",
@@ -2195,12 +2195,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -2209,9 +2209,9 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Drug Manufacturers - General",
       "index_memberships": [
         "broad_market_stocks",
         "healthcare_stocks",
@@ -2220,12 +2220,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -2234,9 +2234,9 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Drug Manufacturers - General",
       "index_memberships": [
         "broad_market_stocks",
         "healthcare_stocks",
@@ -2245,12 +2245,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -2259,9 +2259,9 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Drug Manufacturers - General",
       "index_memberships": [
         "broad_market_stocks",
         "healthcare_stocks",
@@ -2269,12 +2269,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -2283,9 +2283,9 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Drug Manufacturers - General",
       "index_memberships": [
         "broad_market_stocks",
         "healthcare_stocks",
@@ -2295,12 +2295,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -2309,9 +2309,9 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Drug Manufacturers - General",
       "index_memberships": [
         "broad_market_stocks",
         "healthcare_stocks",
@@ -2319,12 +2319,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -2333,9 +2333,9 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Diagnostics & Research",
       "index_memberships": [
         "broad_market_stocks",
         "healthcare_stocks",
@@ -2343,12 +2343,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -2357,9 +2357,9 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Diagnostics & Research",
       "index_memberships": [
         "broad_market_stocks",
         "healthcare_stocks",
@@ -2367,12 +2367,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -2381,9 +2381,9 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Medical Instruments & Supplies",
       "index_memberships": [
         "broad_market_stocks",
         "healthcare_stocks",
@@ -2392,12 +2392,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -2406,9 +2406,9 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Energy",
+      "industry": "Oil & Gas Integrated",
       "index_memberships": [
         "broad_market_stocks",
         "energy_stocks",
@@ -2416,12 +2416,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -2430,9 +2430,9 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Energy",
+      "industry": "Oil & Gas Integrated",
       "index_memberships": [
         "broad_market_stocks",
         "energy_stocks",
@@ -2441,12 +2441,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -2455,9 +2455,9 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Energy",
+      "industry": "Oil & Gas E&P",
       "index_memberships": [
         "broad_market_stocks",
         "energy_stocks",
@@ -2465,12 +2465,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -2479,9 +2479,9 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Energy",
+      "industry": "Oil & Gas Equipment & Services",
       "index_memberships": [
         "broad_market_stocks",
         "energy_stocks",
@@ -2489,12 +2489,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -2503,9 +2503,9 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Household & Personal Products",
       "index_memberships": [
         "broad_market_stocks",
         "us_dow30",
@@ -2513,12 +2513,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -2527,9 +2527,9 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Beverages - Non-Alcoholic",
       "index_memberships": [
         "broad_market_stocks",
         "us_dow30",
@@ -2537,12 +2537,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -2551,9 +2551,9 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Beverages - Non-Alcoholic",
       "index_memberships": [
         "broad_market_stocks",
         "us_nasdaq100",
@@ -2561,12 +2561,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -2575,9 +2575,9 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Discount Stores",
       "index_memberships": [
         "broad_market_stocks",
         "us_nasdaq100",
@@ -2585,12 +2585,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -2599,9 +2599,9 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Discount Stores",
       "index_memberships": [
         "broad_market_stocks",
         "us_dow30",
@@ -2610,12 +2610,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -2624,9 +2624,9 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Home Improvement Retail",
       "index_memberships": [
         "broad_market_stocks",
         "us_dow30",
@@ -2634,12 +2634,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -2648,21 +2648,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Home Improvement Retail",
       "index_memberships": [
         "broad_market_stocks",
         "us_sp500"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -2671,9 +2671,9 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Restaurants",
       "index_memberships": [
         "broad_market_stocks",
         "us_dow30",
@@ -2681,12 +2681,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -2695,9 +2695,9 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Footwear & Accessories",
       "index_memberships": [
         "broad_market_stocks",
         "us_dow30",
@@ -2705,12 +2705,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -2719,9 +2719,9 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Restaurants",
       "index_memberships": [
         "broad_market_stocks",
         "us_nasdaq100",
@@ -2729,12 +2729,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -2743,9 +2743,9 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Semiconductors",
       "index_memberships": [
         "broad_market_stocks",
         "semiconductor_stocks",
@@ -2754,12 +2754,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -2768,9 +2768,9 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Semiconductors",
       "index_memberships": [
         "broad_market_stocks",
         "semiconductor_stocks",
@@ -2779,12 +2779,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -2793,9 +2793,9 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Semiconductors",
       "index_memberships": [
         "broad_market_stocks",
         "semiconductor_stocks",
@@ -2804,12 +2804,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -2818,9 +2818,9 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Semiconductors",
       "index_memberships": [
         "broad_market_stocks",
         "semiconductor_stocks",
@@ -2829,12 +2829,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -2843,9 +2843,9 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Semiconductors",
       "index_memberships": [
         "broad_market_stocks",
         "semiconductor_stocks",
@@ -2854,12 +2854,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -2868,9 +2868,9 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Semiconductor Equipment & Materials",
       "index_memberships": [
         "broad_market_stocks",
         "semiconductor_stocks",
@@ -2879,12 +2879,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -2893,9 +2893,9 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Semiconductor Equipment & Materials",
       "index_memberships": [
         "broad_market_stocks",
         "semiconductor_stocks",
@@ -2904,12 +2904,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -2918,9 +2918,9 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Semiconductors",
       "index_memberships": [
         "broad_market_stocks",
         "semiconductor_stocks",
@@ -2929,12 +2929,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -2943,9 +2943,9 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Communication Equipment",
       "index_memberships": [
         "broad_market_stocks",
         "us_dow30",
@@ -2954,12 +2954,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -2968,21 +2968,21 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Software - Infrastructure",
       "index_memberships": [
         "broad_market_stocks",
         "us_sp500"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -2991,9 +2991,9 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Information Technology Services",
       "index_memberships": [
         "broad_market_stocks",
         "us_dow30",
@@ -3001,12 +3001,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -3015,9 +3015,9 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Software - Application",
       "index_memberships": [
         "broad_market_stocks",
         "us_nasdaq100",
@@ -3025,12 +3025,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -3039,9 +3039,9 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Software - Application",
       "index_memberships": [
         "broad_market_stocks",
         "us_dow30",
@@ -3049,12 +3049,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -3063,21 +3063,21 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Software - Application",
       "index_memberships": [
         "broad_market_stocks",
         "us_sp500"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -3086,9 +3086,9 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Software - Application",
       "index_memberships": [
         "broad_market_stocks",
         "us_nasdaq100",
@@ -3096,12 +3096,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -3110,9 +3110,9 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Communication Services",
+      "industry": "Telecom Services",
       "index_memberships": [
         "broad_market_stocks",
         "us_nasdaq100",
@@ -3120,12 +3120,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -3134,9 +3134,9 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Communication Services",
+      "industry": "Entertainment",
       "index_memberships": [
         "broad_market_stocks",
         "us_dow30",
@@ -3144,12 +3144,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -3158,9 +3158,9 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Communication Services",
+      "industry": "Entertainment",
       "index_memberships": [
         "broad_market_stocks",
         "us_nasdaq100",
@@ -3168,12 +3168,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -3182,9 +3182,9 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Communication Services",
+      "industry": "Telecom Services",
       "index_memberships": [
         "broad_market_stocks",
         "us_nasdaq100",
@@ -3192,12 +3192,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -3206,21 +3206,21 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Communication Services",
+      "industry": "Telecom Services",
       "index_memberships": [
         "broad_market_stocks",
         "us_sp500"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -3229,9 +3229,9 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Communication Services",
+      "industry": "Telecom Services",
       "index_memberships": [
         "broad_market_stocks",
         "us_dow30",
@@ -3239,12 +3239,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -3253,21 +3253,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Railroads",
       "index_memberships": [
         "broad_market_stocks",
         "us_sp500"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -3276,21 +3276,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Integrated Freight & Logistics",
       "index_memberships": [
         "broad_market_stocks",
         "us_sp500"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -3299,9 +3299,9 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Aerospace & Defense",
       "index_memberships": [
         "broad_market_stocks",
         "defense_stocks",
@@ -3309,12 +3309,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -3323,9 +3323,9 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Conglomerates",
       "index_memberships": [
         "broad_market_stocks",
         "defense_stocks",
@@ -3335,12 +3335,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -3349,9 +3349,9 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Farm & Heavy Construction Machinery",
       "index_memberships": [
         "broad_market_stocks",
         "us_dow30",
@@ -3359,12 +3359,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -3373,9 +3373,9 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Aerospace & Defense",
       "index_memberships": [
         "broad_market_stocks",
         "defense_stocks",
@@ -3383,12 +3383,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -3397,9 +3397,9 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Aerospace & Defense",
       "index_memberships": [
         "broad_market_stocks",
         "defense_stocks",
@@ -3408,12 +3408,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -3422,21 +3422,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Financial Data & Stock Exchanges",
       "index_memberships": [
         "broad_market_stocks",
         "us_sp500"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -3445,21 +3445,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Asset Management",
       "index_memberships": [
         "broad_market_stocks",
         "us_sp500"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -3468,9 +3468,9 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Travel Services",
       "index_memberships": [
         "broad_market_stocks",
         "us_nasdaq100",
@@ -3478,12 +3478,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -3492,21 +3492,21 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Software - Application",
       "index_memberships": [
         "broad_market_stocks",
         "us_sp500"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -3515,9 +3515,9 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Travel Services",
       "index_memberships": [
         "broad_market_stocks",
         "us_nasdaq100",
@@ -3525,12 +3525,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -3539,9 +3539,9 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Software - Infrastructure",
       "index_memberships": [
         "broad_market_stocks",
         "defense_stocks",
@@ -3550,12 +3550,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -3564,9 +3564,9 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Software - Infrastructure",
       "index_memberships": [
         "broad_market_stocks",
         "us_nasdaq100",
@@ -3574,12 +3574,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -3588,9 +3588,9 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Software - Infrastructure",
       "index_memberships": [
         "broad_market_stocks",
         "us_nasdaq100",
@@ -3598,12 +3598,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -3612,20 +3612,20 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Software - Application",
       "index_memberships": [
         "broad_market_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -3634,20 +3634,20 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Software - Infrastructure",
       "index_memberships": [
         "broad_market_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -3656,20 +3656,20 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Basic Materials",
+      "industry": "Other Industrial Metals & Mining",
       "index_memberships": [
         "broad_market_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -3678,21 +3678,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Software - Application",
       "index_memberships": [
         "broad_market_stocks",
         "us_nasdaq100"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -3701,20 +3701,20 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Diversified",
       "index_memberships": [
         "broad_market_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -3723,20 +3723,20 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Diversified",
       "index_memberships": [
         "broad_market_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -3745,20 +3745,20 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Diversified",
       "index_memberships": [
         "broad_market_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -3767,20 +3767,20 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Diversified",
       "index_memberships": [
         "broad_market_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -3789,20 +3789,20 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Diversified",
       "index_memberships": [
         "broad_market_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -3811,20 +3811,20 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Energy",
+      "industry": "Oil & Gas Midstream",
       "index_memberships": [
         "broad_market_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -3833,20 +3833,20 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Energy",
+      "industry": "Oil & Gas Midstream",
       "index_memberships": [
         "broad_market_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -3855,20 +3855,20 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Energy",
+      "industry": "Oil & Gas Integrated",
       "index_memberships": [
         "broad_market_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -3877,20 +3877,20 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Energy",
+      "industry": "Oil & Gas E&P",
       "index_memberships": [
         "broad_market_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -3899,20 +3899,20 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Railroads",
       "index_memberships": [
         "broad_market_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -3921,20 +3921,20 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Railroads",
       "index_memberships": [
         "broad_market_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -3943,20 +3943,20 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Communication Services",
+      "industry": "Telecom Services",
       "index_memberships": [
         "broad_market_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -3965,20 +3965,20 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Regional",
       "index_memberships": [
         "broad_market_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -3987,21 +3987,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Internet Retail",
       "index_memberships": [
         "broad_market_stocks",
         "us_nasdaq100"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -4010,20 +4010,20 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Internet Retail",
       "index_memberships": [
         "broad_market_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -4032,9 +4032,9 @@
       "exchange_mic": "XETR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Software - Application",
       "index_memberships": [
         "broad_market_stocks",
         "europe_eurostoxx50",
@@ -4043,12 +4043,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -4057,9 +4057,9 @@
       "exchange_mic": "XETR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Specialty Industrial Machinery",
       "index_memberships": [
         "broad_market_stocks",
         "europe_eurostoxx50",
@@ -4068,12 +4068,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -4082,9 +4082,9 @@
       "exchange_mic": "XETR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Communication Services",
+      "industry": "Telecom Services",
       "index_memberships": [
         "broad_market_stocks",
         "europe_eurostoxx50",
@@ -4093,12 +4093,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -4107,9 +4107,9 @@
       "exchange_mic": "XETR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Insurance - Diversified",
       "index_memberships": [
         "broad_market_stocks",
         "europe_eurostoxx50",
@@ -4119,12 +4119,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -4133,9 +4133,9 @@
       "exchange_mic": "XETR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Auto Manufacturers",
       "index_memberships": [
         "broad_market_stocks",
         "europe_eurostoxx50",
@@ -4144,12 +4144,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -4158,9 +4158,9 @@
       "exchange_mic": "XETR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Auto Manufacturers",
       "index_memberships": [
         "broad_market_stocks",
         "europe_eurostoxx50",
@@ -4169,12 +4169,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -4183,9 +4183,9 @@
       "exchange_mic": "XETR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Auto Manufacturers",
       "index_memberships": [
         "broad_market_stocks",
         "europe_large_caps",
@@ -4193,12 +4193,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -4207,9 +4207,9 @@
       "exchange_mic": "XETR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Basic Materials",
+      "industry": "Chemicals",
       "index_memberships": [
         "broad_market_stocks",
         "europe_eurostoxx50",
@@ -4218,12 +4218,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -4232,9 +4232,9 @@
       "exchange_mic": "XETR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Drug Manufacturers - General",
       "index_memberships": [
         "broad_market_stocks",
         "europe_eurostoxx50",
@@ -4244,12 +4244,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -4258,9 +4258,9 @@
       "exchange_mic": "XETR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Semiconductors",
       "index_memberships": [
         "broad_market_stocks",
         "europe_eurostoxx50",
@@ -4270,12 +4270,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -4284,9 +4284,9 @@
       "exchange_mic": "XETR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Insurance - Reinsurance",
       "index_memberships": [
         "broad_market_stocks",
         "europe_eurostoxx50",
@@ -4296,12 +4296,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -4310,9 +4310,9 @@
       "exchange_mic": "XETR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Utilities",
+      "industry": "Utilities - Diversified",
       "index_memberships": [
         "broad_market_stocks",
         "europe_large_caps",
@@ -4320,12 +4320,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -4334,9 +4334,9 @@
       "exchange_mic": "XETR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Real Estate",
+      "industry": "Real Estate Services",
       "index_memberships": [
         "broad_market_stocks",
         "europe_large_caps",
@@ -4344,12 +4344,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -4358,21 +4358,21 @@
       "exchange_mic": "XETR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Consumer Cyclical",
+      "industry": "Footwear & Accessories",
       "index_memberships": [
         "broad_market_stocks",
         "europe_large_caps"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -4381,9 +4381,9 @@
       "exchange_mic": "XETR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Medical Care Facilities",
       "index_memberships": [
         "broad_market_stocks",
         "europe_large_caps",
@@ -4392,12 +4392,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -4406,9 +4406,9 @@
       "exchange_mic": "XETR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Medical Care Facilities",
       "index_memberships": [
         "broad_market_stocks",
         "europe_large_caps",
@@ -4417,12 +4417,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -4431,9 +4431,9 @@
       "exchange_mic": "XETR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Insurance - Reinsurance",
       "index_memberships": [
         "broad_market_stocks",
         "europe_large_caps",
@@ -4441,12 +4441,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -4455,9 +4455,9 @@
       "exchange_mic": "XPAR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Luxury Goods",
       "index_memberships": [
         "broad_market_stocks",
         "europe_eurostoxx50",
@@ -4466,12 +4466,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -4480,9 +4480,9 @@
       "exchange_mic": "XPAR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Household & Personal Products",
       "index_memberships": [
         "broad_market_stocks",
         "europe_eurostoxx50",
@@ -4491,12 +4491,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -4505,9 +4505,9 @@
       "exchange_mic": "XPAR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Aerospace & Defense",
       "index_memberships": [
         "broad_market_stocks",
         "defense_stocks",
@@ -4518,12 +4518,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -4532,9 +4532,9 @@
       "exchange_mic": "XPAR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Drug Manufacturers - General",
       "index_memberships": [
         "broad_market_stocks",
         "europe_eurostoxx50",
@@ -4544,12 +4544,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -4558,9 +4558,9 @@
       "exchange_mic": "XPAR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Regional",
       "index_memberships": [
         "broad_market_stocks",
         "europe_eurostoxx50",
@@ -4570,12 +4570,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -4584,9 +4584,9 @@
       "exchange_mic": "XPAR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Regional",
       "index_memberships": [
         "broad_market_stocks",
         "europe_large_caps",
@@ -4595,12 +4595,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -4609,9 +4609,9 @@
       "exchange_mic": "XPAR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Regional",
       "index_memberships": [
         "broad_market_stocks",
         "europe_large_caps",
@@ -4620,12 +4620,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -4634,9 +4634,9 @@
       "exchange_mic": "XPAR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Specialty Industrial Machinery",
       "index_memberships": [
         "broad_market_stocks",
         "europe_eurostoxx50",
@@ -4645,12 +4645,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -4659,9 +4659,9 @@
       "exchange_mic": "XPAR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Engineering & Construction",
       "index_memberships": [
         "broad_market_stocks",
         "europe_eurostoxx50",
@@ -4670,12 +4670,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -4684,9 +4684,9 @@
       "exchange_mic": "XPAR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Aerospace & Defense",
       "index_memberships": [
         "broad_market_stocks",
         "defense_stocks",
@@ -4695,12 +4695,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -4709,9 +4709,9 @@
       "exchange_mic": "XPAR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Luxury Goods",
       "index_memberships": [
         "broad_market_stocks",
         "europe_large_caps",
@@ -4719,12 +4719,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -4733,9 +4733,9 @@
       "exchange_mic": "XPAR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Beverages - Wineries & Distilleries",
       "index_memberships": [
         "broad_market_stocks",
         "europe_large_caps",
@@ -4743,12 +4743,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -4757,9 +4757,9 @@
       "exchange_mic": "XPAR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Energy",
+      "industry": "Oil & Gas Integrated",
       "index_memberships": [
         "broad_market_stocks",
         "energy_stocks",
@@ -4769,12 +4769,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -4783,9 +4783,9 @@
       "exchange_mic": "XPAR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Utilities",
+      "industry": "Utilities - Diversified",
       "index_memberships": [
         "broad_market_stocks",
         "europe_large_caps",
@@ -4793,12 +4793,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -4807,9 +4807,9 @@
       "exchange_mic": "XPAR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Building Products & Equipment",
       "index_memberships": [
         "broad_market_stocks",
         "europe_eurostoxx50",
@@ -4818,12 +4818,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -4832,9 +4832,9 @@
       "exchange_mic": "XPAR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Information Technology Services",
       "index_memberships": [
         "broad_market_stocks",
         "europe_large_caps",
@@ -4842,12 +4842,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -4856,9 +4856,9 @@
       "exchange_mic": "XMAD",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Apparel Retail",
       "index_memberships": [
         "broad_market_stocks",
         "europe_eurostoxx50",
@@ -4867,12 +4867,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -4881,9 +4881,9 @@
       "exchange_mic": "XMAD",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Utilities",
+      "industry": "Utilities - Diversified",
       "index_memberships": [
         "broad_market_stocks",
         "europe_eurostoxx50",
@@ -4892,12 +4892,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -4906,9 +4906,9 @@
       "exchange_mic": "XMAD",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Diversified",
       "index_memberships": [
         "broad_market_stocks",
         "europe_eurostoxx50",
@@ -4918,12 +4918,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -4932,9 +4932,9 @@
       "exchange_mic": "XMAD",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Diversified",
       "index_memberships": [
         "broad_market_stocks",
         "europe_eurostoxx50",
@@ -4944,12 +4944,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -4958,9 +4958,9 @@
       "exchange_mic": "XMAD",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Communication Services",
+      "industry": "Telecom Services",
       "index_memberships": [
         "broad_market_stocks",
         "europe_large_caps",
@@ -4968,12 +4968,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -4982,9 +4982,9 @@
       "exchange_mic": "XMAD",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Energy",
+      "industry": "Oil & Gas Integrated",
       "index_memberships": [
         "broad_market_stocks",
         "energy_stocks",
@@ -4993,12 +4993,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -5007,9 +5007,9 @@
       "exchange_mic": "XMIL",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Utilities",
+      "industry": "Utilities - Diversified",
       "index_memberships": [
         "broad_market_stocks",
         "europe_eurostoxx50",
@@ -5018,12 +5018,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -5032,9 +5032,9 @@
       "exchange_mic": "XMIL",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Energy",
+      "industry": "Oil & Gas Integrated",
       "index_memberships": [
         "broad_market_stocks",
         "energy_stocks",
@@ -5044,12 +5044,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -5058,9 +5058,9 @@
       "exchange_mic": "XMIL",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Regional",
       "index_memberships": [
         "broad_market_stocks",
         "europe_eurostoxx50",
@@ -5070,12 +5070,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -5084,9 +5084,9 @@
       "exchange_mic": "XMIL",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Regional",
       "index_memberships": [
         "broad_market_stocks",
         "europe_eurostoxx50",
@@ -5096,12 +5096,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -5110,20 +5110,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Beverages - Wineries & Distilleries",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -5132,20 +5132,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Insurance - Life",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -5154,20 +5154,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Electrical Equipment & Parts",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -5176,20 +5176,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Regional",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -5198,20 +5198,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Furnishings, Fixtures & Appliances",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -5220,20 +5220,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Beverages - Wineries & Distilleries",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -5242,20 +5242,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Utilities",
+      "industry": "Utilities - Renewable",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -5264,20 +5264,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Regional",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -5286,20 +5286,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Basic Materials",
+      "industry": "Gold",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -5308,20 +5308,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Capital Markets",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -5330,20 +5330,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Drug Manufacturers - Specialty & Generic",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -5352,20 +5352,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Diversified",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -5374,20 +5374,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Packaged Foods",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -5396,20 +5396,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Capital Markets",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -5418,20 +5418,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Furnishings, Fixtures & Appliances",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -5440,20 +5440,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Medical Devices",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -5462,20 +5462,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Auto Manufacturers",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -5484,20 +5484,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Diversified",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -5506,20 +5506,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Basic Materials",
+      "industry": "Specialty Chemicals",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -5528,20 +5528,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Electronic Components",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -5550,20 +5550,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Regional",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -5572,20 +5572,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Electronic Components",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -5594,20 +5594,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Electrical Equipment & Parts",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -5616,20 +5616,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Diversified",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -5638,20 +5638,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Computer Hardware",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -5660,20 +5660,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Beverages - Wineries & Distilleries",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -5682,20 +5682,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Semiconductor Equipment & Materials",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -5704,20 +5704,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Energy",
+      "industry": "Thermal Coal",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -5726,20 +5726,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Railroads",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -5748,20 +5748,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Energy",
+      "industry": "Oil & Gas Integrated",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -5770,20 +5770,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Beverages - Wineries & Distilleries",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -5792,20 +5792,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Engineering & Construction",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -5814,20 +5814,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Diagnostics & Research",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -5836,20 +5836,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Farm Products",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -5858,20 +5858,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Regional",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -5880,20 +5880,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Farm Products",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -5902,20 +5902,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Regional",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -5924,20 +5924,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Energy",
+      "industry": "Oil & Gas Integrated",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -5946,20 +5946,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Energy",
+      "industry": "Thermal Coal",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -5968,20 +5968,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Communication Equipment",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -5990,20 +5990,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Semiconductors",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -6012,20 +6012,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Communication Equipment",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -6034,20 +6034,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Diversified",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -6056,20 +6056,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Integrated Freight & Logistics",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -6078,20 +6078,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Specialty Industrial Machinery",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -6100,20 +6100,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Communication Services",
+      "industry": "Telecom Services",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -6122,20 +6122,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Auto Manufacturers",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -6144,20 +6144,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Communication Services",
+      "industry": "Telecom Services",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -6166,20 +6166,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Software - Application",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -6188,20 +6188,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Furnishings, Fixtures & Appliances",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -6210,20 +6210,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Communication Services",
+      "industry": "Telecom Services",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -6232,20 +6232,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Electrical Equipment & Parts",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -6254,20 +6254,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Regional",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -6276,20 +6276,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Basic Materials",
+      "industry": "Agricultural Inputs",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -6298,20 +6298,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Insurance - Life",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -6320,20 +6320,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Semiconductor Equipment & Materials",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -6342,20 +6342,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Specialty Retail",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -6364,20 +6364,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Regional",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -6386,20 +6386,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Farm & Heavy Construction Machinery",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -6408,20 +6408,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Utilities",
+      "industry": "Utilities - Regulated Electric",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -6430,20 +6430,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Aerospace & Defense",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -6452,20 +6452,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Computer Hardware",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -6474,20 +6474,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Railroads",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -6496,20 +6496,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Regional",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -6518,20 +6518,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Semiconductor Equipment & Materials",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -6540,20 +6540,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Electrical Equipment & Parts",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -6562,20 +6562,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Capital Markets",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -6584,20 +6584,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Communication Equipment",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -6606,20 +6606,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Auto Manufacturers",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -6628,20 +6628,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Solar",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -6650,20 +6650,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Real Estate",
+      "industry": "Real Estate - Development",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -6672,20 +6672,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Semiconductors",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -6694,20 +6694,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Auto Manufacturers",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -6716,20 +6716,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Auto Parts",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -6738,20 +6738,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Real Estate",
+      "industry": "Real Estate - Development",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -6760,20 +6760,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Medical Care Facilities",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -6782,20 +6782,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Capital Markets",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -6804,20 +6804,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Packaged Foods",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -6826,20 +6826,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Drug Manufacturers - General",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -6848,20 +6848,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Marine Shipping",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -6870,20 +6870,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Utilities",
+      "industry": "Utilities - Renewable",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -6892,20 +6892,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Engineering & Construction",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -6914,20 +6914,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Regional",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -6936,20 +6936,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Biotechnology",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -6958,20 +6958,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Communication Services",
+      "industry": "Advertising Agencies",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -6980,20 +6980,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Semiconductor Equipment & Materials",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -7002,20 +7002,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Software - Application",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -7024,20 +7024,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Railroads",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -7046,20 +7046,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Beverages - Wineries & Distilleries",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -7068,20 +7068,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Regional",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -7090,20 +7090,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Basic Materials",
+      "industry": "Steel",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -7112,20 +7112,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Medical Devices",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -7134,20 +7134,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Computer Hardware",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -7156,20 +7156,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Basic Materials",
+      "industry": "Building Materials",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -7178,20 +7178,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Specialty Industrial Machinery",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -7200,20 +7200,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Basic Materials",
+      "industry": "Specialty Chemicals",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -7222,20 +7222,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Regional",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -7244,20 +7244,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Energy",
+      "industry": "Oil & Gas E&P",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -7266,20 +7266,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Capital Markets",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -7288,20 +7288,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Consumer Electronics",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -7310,20 +7310,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Electronics & Computer Distribution",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -7332,20 +7332,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Insurance - Life",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -7354,20 +7354,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Semiconductors",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -7376,20 +7376,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Semiconductors",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -7398,20 +7398,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Basic Materials",
+      "industry": "Aluminum",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -7420,20 +7420,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Basic Materials",
+      "industry": "Other Industrial Metals & Mining",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -7442,20 +7442,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Semiconductors",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -7464,20 +7464,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Electrical Equipment & Parts",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -7486,20 +7486,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Diversified",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -7508,20 +7508,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Capital Markets",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -7530,20 +7530,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Aerospace & Defense",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -7552,20 +7552,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Basic Materials",
+      "industry": "Chemicals",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -7574,20 +7574,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Regional",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -7596,20 +7596,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Drug Manufacturers - Specialty & Generic",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -7618,20 +7618,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Engineering & Construction",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -7640,20 +7640,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Airports & Air Services",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -7662,20 +7662,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Semiconductor Equipment & Materials",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -7684,20 +7684,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Basic Materials",
+      "industry": "Other Industrial Metals & Mining",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -7706,20 +7706,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Utilities",
+      "industry": "Utilities - Renewable",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -7728,20 +7728,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Aerospace & Defense",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -7750,20 +7750,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Farm & Heavy Construction Machinery",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -7772,20 +7772,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Capital Markets",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -7794,20 +7794,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Regional",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -7816,20 +7816,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Utilities",
+      "industry": "Utilities - Renewable",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -7838,20 +7838,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Drug Manufacturers - Specialty & Generic",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -7860,20 +7860,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Capital Markets",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -7882,20 +7882,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Basic Materials",
+      "industry": "Chemicals",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -7904,20 +7904,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Regional",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -7926,20 +7926,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Semiconductors",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -7948,20 +7948,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Capital Markets",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -7970,20 +7970,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Engineering & Construction",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -7992,20 +7992,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Farm & Heavy Construction Machinery",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -8014,20 +8014,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Consumer Electronics",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -8036,20 +8036,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Regional",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -8058,20 +8058,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Basic Materials",
+      "industry": "Gold",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -8080,20 +8080,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Utilities",
+      "industry": "Utilities - Independent Power Producers",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -8102,20 +8102,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Computer Hardware",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -8124,20 +8124,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Biotechnology",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -8146,20 +8146,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Utilities",
+      "industry": "Utilities - Independent Power Producers",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -8168,20 +8168,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Basic Materials",
+      "industry": "Other Industrial Metals & Mining",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -8190,20 +8190,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Semiconductors",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -8212,20 +8212,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Software - Application",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -8234,20 +8234,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Security & Protection Services",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -8256,20 +8256,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Electronic Components",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -8278,20 +8278,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Beverages - Wineries & Distilleries",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -8300,20 +8300,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Packaged Foods",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -8322,20 +8322,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Energy",
+      "industry": "Thermal Coal",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -8344,20 +8344,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Medical Instruments & Supplies",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -8366,20 +8366,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Semiconductors",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -8388,20 +8388,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Basic Materials",
+      "industry": "Steel",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -8410,20 +8410,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Basic Materials",
+      "industry": "Specialty Chemicals",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -8432,20 +8432,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Airlines",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -8454,20 +8454,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Real Estate",
+      "industry": "Real Estate - Development",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -8476,20 +8476,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Electronic Components",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -8498,20 +8498,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Software - Application",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -8520,20 +8520,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Beverages - Wineries & Distilleries",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -8542,20 +8542,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Basic Materials",
+      "industry": "Chemicals",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -8564,20 +8564,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Communication Equipment",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -8586,20 +8586,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Capital Markets",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -8608,20 +8608,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Airlines",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -8630,20 +8630,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Airlines",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -8652,20 +8652,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Basic Materials",
+      "industry": "Specialty Chemicals",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -8674,20 +8674,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Software - Infrastructure",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -8696,20 +8696,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Capital Markets",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -8718,20 +8718,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Basic Materials",
+      "industry": "Chemicals",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -8740,20 +8740,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Drug Manufacturers - Specialty & Generic",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -8762,20 +8762,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Solar",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -8784,20 +8784,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Energy",
+      "industry": "Thermal Coal",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -8806,20 +8806,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Capital Markets",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -8828,20 +8828,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Drug Manufacturers - Specialty & Generic",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -8850,20 +8850,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Specialty Industrial Machinery",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -8872,20 +8872,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Engineering & Construction",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -8894,20 +8894,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Packaged Foods",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -8916,20 +8916,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Communication Services",
+      "industry": "Electronic Gaming & Multimedia",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -8938,20 +8938,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Utilities",
+      "industry": "Utilities - Independent Power Producers",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -8960,20 +8960,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Basic Materials",
+      "industry": "Gold",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -8982,20 +8982,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Capital Markets",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -9004,20 +9004,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Drug Manufacturers - Specialty & Generic",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -9026,20 +9026,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Drug Manufacturers - Specialty & Generic",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -9048,20 +9048,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Financial Data & Stock Exchanges",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -9070,20 +9070,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Aerospace & Defense",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -9092,20 +9092,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Auto Manufacturers",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -9114,20 +9114,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Building Products & Equipment",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -9136,20 +9136,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Auto Parts",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -9158,20 +9158,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Beverages - Brewers",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -9180,20 +9180,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Engineering & Construction",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -9202,20 +9202,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Basic Materials",
+      "industry": "Specialty Chemicals",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -9224,20 +9224,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Airlines",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -9246,20 +9246,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Biotechnology",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -9268,20 +9268,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Basic Materials",
+      "industry": "Chemicals",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -9290,20 +9290,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Drug Manufacturers - Specialty & Generic",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -9312,20 +9312,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Auto Parts",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -9334,20 +9334,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Insurance - Life",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -9356,20 +9356,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Auto Parts",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -9378,20 +9378,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Solar",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -9400,20 +9400,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Packaging & Containers",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -9422,20 +9422,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Basic Materials",
+      "industry": "Chemicals",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -9444,20 +9444,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Energy",
+      "industry": "Thermal Coal",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -9466,20 +9466,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Financial Conglomerates",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -9488,20 +9488,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Software - Application",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -9510,20 +9510,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Real Estate",
+      "industry": "Real Estate - Diversified",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -9532,20 +9532,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Engineering & Construction",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -9554,20 +9554,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Regional",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -9576,20 +9576,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Semiconductor Equipment & Materials",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -9598,20 +9598,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Specialty Industrial Machinery",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -9620,20 +9620,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Financial Conglomerates",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -9642,20 +9642,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Biotechnology",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -9664,20 +9664,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Semiconductor Equipment & Materials",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -9686,20 +9686,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Electronic Components",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -9708,20 +9708,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Basic Materials",
+      "industry": "Building Materials",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -9730,20 +9730,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Basic Materials",
+      "industry": "Specialty Chemicals",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -9752,20 +9752,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Diagnostics & Research",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -9774,20 +9774,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Engineering & Construction",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -9796,20 +9796,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Energy",
+      "industry": "Oil & Gas Midstream",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -9818,20 +9818,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Basic Materials",
+      "industry": "Chemicals",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -9840,20 +9840,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Computer Hardware",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -9862,20 +9862,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Semiconductors",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -9884,20 +9884,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Aerospace & Defense",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -9906,20 +9906,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Energy",
+      "industry": "Thermal Coal",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -9928,20 +9928,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Semiconductors",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -9950,20 +9950,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Software - Application",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -9972,20 +9972,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Electronic Components",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -9994,20 +9994,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Electrical Equipment & Parts",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -10016,20 +10016,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Integrated Freight & Logistics",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -10038,20 +10038,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Drug Manufacturers - Specialty & Generic",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -10060,20 +10060,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Basic Materials",
+      "industry": "Aluminum",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -10082,20 +10082,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Biotechnology",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -10104,20 +10104,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Utilities",
+      "industry": "Utilities - Independent Power Producers",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -10126,20 +10126,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Electrical Equipment & Parts",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -10148,20 +10148,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Specialty Industrial Machinery",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -10170,20 +10170,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Biotechnology",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -10192,20 +10192,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Medical Distribution",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -10214,20 +10214,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Semiconductor Equipment & Materials",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -10236,20 +10236,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Basic Materials",
+      "industry": "Copper",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -10258,20 +10258,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Farm Products",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -10280,20 +10280,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Electronic Components",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -10302,20 +10302,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Medical Distribution",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -10324,20 +10324,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Auto Parts",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -10346,20 +10346,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Software - Application",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -10368,20 +10368,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Auto Manufacturers",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -10390,20 +10390,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Capital Markets",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -10412,20 +10412,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Regional",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -10434,20 +10434,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Capital Markets",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -10456,20 +10456,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Packaged Foods",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -10478,20 +10478,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Semiconductors",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -10500,20 +10500,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Basic Materials",
+      "industry": "Chemicals",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -10522,20 +10522,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Basic Materials",
+      "industry": "Specialty Chemicals",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -10544,20 +10544,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Internet Retail",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -10566,20 +10566,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Specialty Industrial Machinery",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -10588,20 +10588,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Software - Application",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -10610,20 +10610,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Specialty Industrial Machinery",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -10632,20 +10632,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Drug Manufacturers - Specialty & Generic",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -10654,20 +10654,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Capital Markets",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -10676,20 +10676,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Solar",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -10698,20 +10698,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Semiconductors",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -10720,20 +10720,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Utilities",
+      "industry": "Utilities - Regulated Gas",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -10742,20 +10742,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Semiconductor Equipment & Materials",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -10764,20 +10764,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Utilities",
+      "industry": "Utilities - Renewable",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -10786,20 +10786,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Insurance - Property & Casualty",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -10808,20 +10808,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Electronic Components",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -10830,20 +10830,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Solar",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -10852,20 +10852,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Basic Materials",
+      "industry": "Specialty Chemicals",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -10874,20 +10874,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Software - Infrastructure",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -10896,20 +10896,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Basic Materials",
+      "industry": "Specialty Chemicals",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -10918,20 +10918,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Beverages - Brewers",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -10940,20 +10940,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Financial Conglomerates",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -10962,20 +10962,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Electrical Equipment & Parts",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -10984,20 +10984,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Lodging",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -11006,20 +11006,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Marine Shipping",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -11028,20 +11028,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Basic Materials",
+      "industry": "Steel",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -11050,20 +11050,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Communication Equipment",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -11072,20 +11072,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Electronic Components",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -11094,20 +11094,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Electronic Components",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -11116,20 +11116,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Electrical Equipment & Parts",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -11138,20 +11138,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Engineering & Construction",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -11160,20 +11160,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Beverages - Non-Alcoholic",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -11182,20 +11182,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Electrical Equipment & Parts",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -11204,20 +11204,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Lodging",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -11226,20 +11226,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Business Equipment & Supplies",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -11248,20 +11248,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Semiconductor Equipment & Materials",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -11270,20 +11270,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Furnishings, Fixtures & Appliances",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -11292,20 +11292,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Solar",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -11314,20 +11314,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Basic Materials",
+      "industry": "Specialty Chemicals",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -11336,20 +11336,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Basic Materials",
+      "industry": "Building Materials",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -11358,20 +11358,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Basic Materials",
+      "industry": "Chemicals",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -11380,20 +11380,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Household & Personal Products",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -11402,20 +11402,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Capital Markets",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -11424,20 +11424,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Communication Services",
+      "industry": "Telecom Services",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -11446,20 +11446,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Railroads",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -11468,20 +11468,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Software - Infrastructure",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -11490,20 +11490,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Real Estate",
+      "industry": "Real Estate - Development",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -11512,20 +11512,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Real Estate",
+      "industry": "Real Estate Services",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -11534,20 +11534,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Footwear & Accessories",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -11556,20 +11556,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Energy",
+      "industry": "Oil & Gas Equipment & Services",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -11578,20 +11578,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Furnishings, Fixtures & Appliances",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -11600,20 +11600,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Farm & Heavy Construction Machinery",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -11622,20 +11622,20 @@
       "exchange_mic": "XSHG",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Capital Markets",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -11644,20 +11644,20 @@
       "exchange_mic": "XSHE",
       "currency": "CNY",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Utilities",
+      "industry": "Utilities - Renewable",
       "index_memberships": [
         "china_csi300"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -11674,12 +11674,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "etf",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "etf_equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -11696,12 +11696,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "etf",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "etf_equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -11718,12 +11718,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "etf",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "etf_equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -11740,12 +11740,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "etf",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "etf_equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -11762,12 +11762,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "etf",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "etf_equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -11784,12 +11784,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "etf",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "etf_equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -11798,21 +11798,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Aerospace & Defense",
       "index_memberships": [
         "defense_stocks",
         "us_sp500"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -11821,21 +11821,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Aerospace & Defense",
       "index_memberships": [
         "defense_stocks",
         "us_sp500"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -11844,21 +11844,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Aerospace & Defense",
       "index_memberships": [
         "defense_stocks",
         "us_sp500"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -11867,21 +11867,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Aerospace & Defense",
       "index_memberships": [
         "defense_stocks",
         "us_sp500"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -11890,21 +11890,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Aerospace & Defense",
       "index_memberships": [
         "defense_stocks",
         "us_sp500"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -11913,21 +11913,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Aerospace & Defense",
       "index_memberships": [
         "defense_stocks",
         "us_sp500"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -11936,9 +11936,9 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Aerospace & Defense",
       "index_memberships": [
         "defense_stocks",
         "us_nasdaq100",
@@ -11946,12 +11946,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -11960,21 +11960,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Aerospace & Defense",
       "index_memberships": [
         "defense_stocks",
         "us_sp500"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -11983,20 +11983,20 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Technology",
+      "industry": "Information Technology Services",
       "index_memberships": [
         "defense_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -12005,20 +12005,20 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Information Technology Services",
       "index_memberships": [
         "defense_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -12027,21 +12027,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Information Technology Services",
       "index_memberships": [
         "defense_stocks",
         "us_sp500"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -12050,20 +12050,20 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Industrials",
+      "industry": "Aerospace & Defense",
       "index_memberships": [
         "defense_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -12072,20 +12072,20 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Industrials",
+      "industry": "Aerospace & Defense",
       "index_memberships": [
         "defense_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -12094,21 +12094,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Aerospace & Defense",
       "index_memberships": [
         "defense_stocks",
         "us_sp500"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -12117,20 +12117,20 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Aerospace & Defense",
       "index_memberships": [
         "defense_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -12139,20 +12139,20 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Aerospace & Defense",
       "index_memberships": [
         "defense_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -12161,20 +12161,20 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Industrials",
+      "industry": "Aerospace & Defense",
       "index_memberships": [
         "defense_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -12183,20 +12183,20 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Aerospace & Defense",
       "index_memberships": [
         "defense_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -12205,20 +12205,20 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Aerospace & Defense",
       "index_memberships": [
         "defense_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -12227,20 +12227,20 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Aerospace & Defense",
       "index_memberships": [
         "defense_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -12249,20 +12249,20 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Industrials",
+      "industry": "Aerospace & Defense",
       "index_memberships": [
         "defense_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -12271,21 +12271,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Scientific & Technical Instruments",
       "index_memberships": [
         "defense_stocks",
         "us_sp500"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -12294,20 +12294,20 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Industrials",
+      "industry": "Consulting Services",
       "index_memberships": [
         "defense_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -12316,20 +12316,20 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Technology",
+      "industry": "Electronic Components",
       "index_memberships": [
         "defense_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -12338,20 +12338,20 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Industrials",
+      "industry": "Engineering & Construction",
       "index_memberships": [
         "defense_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -12360,20 +12360,20 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Industrials",
+      "industry": "Engineering & Construction",
       "index_memberships": [
         "defense_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -12382,20 +12382,20 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "small",
+      "sector": "Industrials",
+      "industry": "Aerospace & Defense",
       "index_memberships": [
         "defense_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -12404,20 +12404,20 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Industrials",
+      "industry": "Aerospace & Defense",
       "index_memberships": [
         "defense_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -12426,20 +12426,20 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Aerospace & Defense",
       "index_memberships": [
         "defense_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -12448,21 +12448,21 @@
       "exchange_mic": "XETR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Footwear & Accessories",
       "index_memberships": [
         "europe_eurostoxx50",
         "germany_dax"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -12471,21 +12471,21 @@
       "exchange_mic": "XPAR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Basic Materials",
+      "industry": "Specialty Chemicals",
       "index_memberships": [
         "europe_eurostoxx50",
         "france_cac40"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -12494,20 +12494,20 @@
       "exchange_mic": "XBRU",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Beverages - Brewers",
       "index_memberships": [
         "europe_eurostoxx50"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -12516,20 +12516,20 @@
       "exchange_mic": "XBRU",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Biotechnology",
       "index_memberships": [
         "europe_eurostoxx50"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -12538,21 +12538,21 @@
       "exchange_mic": "XPAR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Insurance - Diversified",
       "index_memberships": [
         "europe_eurostoxx50",
         "france_cac40"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -12561,21 +12561,21 @@
       "exchange_mic": "XPAR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Packaged Foods",
       "index_memberships": [
         "europe_eurostoxx50",
         "france_cac40"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -12584,21 +12584,21 @@
       "exchange_mic": "XETR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Regional",
       "index_memberships": [
         "europe_eurostoxx50",
         "germany_dax"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -12607,21 +12607,21 @@
       "exchange_mic": "XETR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Financial Data & Stock Exchanges",
       "index_memberships": [
         "europe_eurostoxx50",
         "germany_dax"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -12630,21 +12630,21 @@
       "exchange_mic": "XETR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Integrated Freight & Logistics",
       "index_memberships": [
         "europe_eurostoxx50",
         "germany_dax"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -12653,21 +12653,21 @@
       "exchange_mic": "XPAR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Medical Instruments & Supplies",
       "index_memberships": [
         "europe_eurostoxx50",
         "france_cac40"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -12676,21 +12676,21 @@
       "exchange_mic": "XMIL",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Auto Manufacturers",
       "index_memberships": [
         "europe_eurostoxx50",
         "italy_ftse_mib"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -12699,21 +12699,21 @@
       "exchange_mic": "XPAR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Luxury Goods",
       "index_memberships": [
         "europe_eurostoxx50",
         "france_cac40"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -12722,20 +12722,20 @@
       "exchange_mic": "XHEL",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Regional",
       "index_memberships": [
         "europe_eurostoxx50"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -12744,21 +12744,21 @@
       "exchange_mic": "XETR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Aerospace & Defense",
       "index_memberships": [
         "europe_eurostoxx50",
         "germany_dax"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -12767,21 +12767,21 @@
       "exchange_mic": "XPAR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Aerospace & Defense",
       "index_memberships": [
         "europe_eurostoxx50",
         "france_cac40"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -12790,21 +12790,21 @@
       "exchange_mic": "XETR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Specialty Industrial Machinery",
       "index_memberships": [
         "europe_eurostoxx50",
         "germany_dax"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -12813,20 +12813,20 @@
       "exchange_mic": "XETR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Auto Manufacturers",
       "index_memberships": [
         "europe_eurostoxx50"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -12835,20 +12835,20 @@
       "exchange_mic": "XPAR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Lodging",
       "index_memberships": [
         "france_cac40"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -12857,20 +12857,20 @@
       "exchange_mic": "XPAR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Engineering & Construction",
       "index_memberships": [
         "france_cac40"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -12879,20 +12879,20 @@
       "exchange_mic": "XPAR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Consulting Services",
       "index_memberships": [
         "france_cac40"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -12901,20 +12901,20 @@
       "exchange_mic": "XPAR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Grocery Stores",
       "index_memberships": [
         "france_cac40"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -12923,20 +12923,20 @@
       "exchange_mic": "XPAR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Software - Application",
       "index_memberships": [
         "france_cac40"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -12945,20 +12945,20 @@
       "exchange_mic": "XPAR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Financial Services",
+      "industry": "Credit Services",
       "index_memberships": [
         "france_cac40"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -12967,20 +12967,20 @@
       "exchange_mic": "XPAR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Diagnostics & Research",
       "index_memberships": [
         "france_cac40"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -12989,20 +12989,20 @@
       "exchange_mic": "XPAR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Electrical Equipment & Parts",
       "index_memberships": [
         "france_cac40"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -13011,7 +13011,7 @@
       "exchange_mic": "XPAR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
+      "market_cap_tier": "micro",
       "sector": null,
       "industry": null,
       "index_memberships": [
@@ -13019,12 +13019,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -13033,20 +13033,20 @@
       "exchange_mic": "XPAR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Communication Services",
+      "industry": "Telecom Services",
       "index_memberships": [
         "france_cac40"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -13055,20 +13055,20 @@
       "exchange_mic": "XPAR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Communication Services",
+      "industry": "Advertising Agencies",
       "index_memberships": [
         "france_cac40"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -13077,20 +13077,20 @@
       "exchange_mic": "XPAR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Consumer Cyclical",
+      "industry": "Auto Manufacturers",
       "index_memberships": [
         "france_cac40"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -13099,20 +13099,20 @@
       "exchange_mic": "XPAR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Auto Manufacturers",
       "index_memberships": [
         "france_cac40"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -13121,20 +13121,20 @@
       "exchange_mic": "XPAR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Semiconductors",
       "index_memberships": [
         "france_cac40"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -13143,20 +13143,20 @@
       "exchange_mic": "XPAR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Industrials",
+      "industry": "Specialty Business Services",
       "index_memberships": [
         "france_cac40"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -13165,20 +13165,20 @@
       "exchange_mic": "XPAR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Real Estate",
+      "industry": "REIT - Retail",
       "index_memberships": [
         "france_cac40"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -13187,20 +13187,20 @@
       "exchange_mic": "XPAR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Waste Management",
       "index_memberships": [
         "france_cac40"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -13209,20 +13209,20 @@
       "exchange_mic": "XETR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Household & Personal Products",
       "index_memberships": [
         "germany_dax"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -13231,20 +13231,20 @@
       "exchange_mic": "XETR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Basic Materials",
+      "industry": "Specialty Chemicals",
       "index_memberships": [
         "germany_dax"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -13253,20 +13253,20 @@
       "exchange_mic": "XETR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Regional",
       "index_memberships": [
         "germany_dax"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -13275,20 +13275,20 @@
       "exchange_mic": "XETR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Auto Parts",
       "index_memberships": [
         "germany_dax"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -13297,20 +13297,20 @@
       "exchange_mic": "XETR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Farm & Heavy Construction Machinery",
       "index_memberships": [
         "germany_dax"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -13319,20 +13319,20 @@
       "exchange_mic": "XETR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Utilities",
+      "industry": "Utilities - Diversified",
       "index_memberships": [
         "germany_dax"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -13341,20 +13341,20 @@
       "exchange_mic": "XETR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Industrials",
+      "industry": "Specialty Industrial Machinery",
       "index_memberships": [
         "germany_dax"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -13363,20 +13363,20 @@
       "exchange_mic": "XETR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Basic Materials",
+      "industry": "Building Materials",
       "index_memberships": [
         "germany_dax"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -13385,20 +13385,20 @@
       "exchange_mic": "XETR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Household & Personal Products",
       "index_memberships": [
         "germany_dax"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -13407,20 +13407,20 @@
       "exchange_mic": "XETR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Drug Manufacturers - Specialty & Generic",
       "index_memberships": [
         "germany_dax"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -13429,20 +13429,20 @@
       "exchange_mic": "XETR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Aerospace & Defense",
       "index_memberships": [
         "germany_dax"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -13451,20 +13451,20 @@
       "exchange_mic": "XETR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Consumer Cyclical",
+      "industry": "Auto Manufacturers",
       "index_memberships": [
         "germany_dax"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -13473,20 +13473,20 @@
       "exchange_mic": "XETR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Healthcare",
+      "industry": "Diagnostics & Research",
       "index_memberships": [
         "germany_dax"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -13495,20 +13495,20 @@
       "exchange_mic": "XETR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Communication Services",
+      "industry": "Internet Content & Information",
       "index_memberships": [
         "germany_dax"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -13517,20 +13517,20 @@
       "exchange_mic": "XETR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Medical Devices",
       "index_memberships": [
         "germany_dax"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -13539,20 +13539,20 @@
       "exchange_mic": "XETR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Basic Materials",
+      "industry": "Specialty Chemicals",
       "index_memberships": [
         "germany_dax"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -13561,20 +13561,20 @@
       "exchange_mic": "XETR",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Consumer Cyclical",
+      "industry": "Internet Retail",
       "index_memberships": [
         "germany_dax"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -13583,21 +13583,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Semiconductor Equipment & Materials",
       "index_memberships": [
         "global_proxy_stocks",
         "us_nasdaq100"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -13606,20 +13606,20 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Software - Application",
       "index_memberships": [
         "global_proxy_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -13628,21 +13628,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Drug Manufacturers - General",
       "index_memberships": [
         "global_proxy_stocks",
         "healthcare_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -13651,21 +13651,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Drug Manufacturers - General",
       "index_memberships": [
         "global_proxy_stocks",
         "healthcare_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -13674,21 +13674,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Drug Manufacturers - General",
       "index_memberships": [
         "global_proxy_stocks",
         "healthcare_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -13697,20 +13697,20 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Household & Personal Products",
       "index_memberships": [
         "global_proxy_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -13719,20 +13719,20 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Beverages - Wineries & Distilleries",
       "index_memberships": [
         "global_proxy_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -13741,21 +13741,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Drug Manufacturers - General",
       "index_memberships": [
         "global_proxy_stocks",
         "healthcare_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -13764,21 +13764,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Drug Manufacturers - General",
       "index_memberships": [
         "global_proxy_stocks",
         "healthcare_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -13787,20 +13787,20 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Energy",
+      "industry": "Oil & Gas Integrated",
       "index_memberships": [
         "global_proxy_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -13809,20 +13809,20 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Energy",
+      "industry": "Oil & Gas Integrated",
       "index_memberships": [
         "global_proxy_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -13831,20 +13831,20 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Diversified",
       "index_memberships": [
         "global_proxy_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -13853,20 +13853,20 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Basic Materials",
+      "industry": "Other Industrial Metals & Mining",
       "index_memberships": [
         "global_proxy_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -13875,20 +13875,20 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Tobacco",
       "index_memberships": [
         "global_proxy_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -13897,20 +13897,20 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Specialty Business Services",
       "index_memberships": [
         "global_proxy_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -13919,20 +13919,20 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Diversified",
       "index_memberships": [
         "global_proxy_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -13941,20 +13941,20 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Diversified",
       "index_memberships": [
         "global_proxy_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -13963,20 +13963,20 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Regional",
       "index_memberships": [
         "global_proxy_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -13985,20 +13985,20 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Diversified",
       "index_memberships": [
         "global_proxy_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -14007,20 +14007,20 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Diversified",
       "index_memberships": [
         "global_proxy_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -14037,12 +14037,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -14051,20 +14051,20 @@
       "exchange_mic": "XOTC",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Aerospace & Defense",
       "index_memberships": [
         "global_proxy_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -14073,20 +14073,20 @@
       "exchange_mic": "XOTC",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Aerospace & Defense",
       "index_memberships": [
         "global_proxy_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -14095,20 +14095,20 @@
       "exchange_mic": "XOTC",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Aerospace & Defense",
       "index_memberships": [
         "global_proxy_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -14117,20 +14117,20 @@
       "exchange_mic": "XOTC",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Aerospace & Defense",
       "index_memberships": [
         "global_proxy_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -14139,20 +14139,20 @@
       "exchange_mic": "XOTC",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Luxury Goods",
       "index_memberships": [
         "global_proxy_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -14161,20 +14161,20 @@
       "exchange_mic": "XOTC",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Drug Manufacturers - General",
       "index_memberships": [
         "global_proxy_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -14183,20 +14183,20 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Energy",
+      "industry": "Oil & Gas Integrated",
       "index_memberships": [
         "global_proxy_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -14205,20 +14205,20 @@
       "exchange_mic": "XOTC",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Drug Manufacturers - Specialty & Generic",
       "index_memberships": [
         "global_proxy_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -14227,20 +14227,20 @@
       "exchange_mic": "XOTC",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Drug Manufacturers - General",
       "index_memberships": [
         "global_proxy_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -14249,20 +14249,20 @@
       "exchange_mic": "XOTC",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Biotechnology",
       "index_memberships": [
         "global_proxy_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -14271,20 +14271,20 @@
       "exchange_mic": "XOTC",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Aerospace & Defense",
       "index_memberships": [
         "global_proxy_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -14293,20 +14293,20 @@
       "exchange_mic": "XOTC",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Aerospace & Defense",
       "index_memberships": [
         "global_proxy_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -14315,20 +14315,20 @@
       "exchange_mic": "XOTC",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Aerospace & Defense",
       "index_memberships": [
         "global_proxy_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -14337,20 +14337,20 @@
       "exchange_mic": "XOTC",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Aerospace & Defense",
       "index_memberships": [
         "global_proxy_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -14359,20 +14359,20 @@
       "exchange_mic": "XOTC",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Industrials",
+      "industry": "Aerospace & Defense",
       "index_memberships": [
         "global_proxy_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -14381,20 +14381,20 @@
       "exchange_mic": "XOTC",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Basic Materials",
+      "industry": "Specialty Chemicals",
       "index_memberships": [
         "global_proxy_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -14411,12 +14411,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "etf",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "etf_equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -14433,12 +14433,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "etf",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "etf_equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -14455,12 +14455,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "etf",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "etf_equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -14477,12 +14477,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "etf",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "etf_equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -14499,12 +14499,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "etf",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "etf_equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -14521,12 +14521,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "etf",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "etf_equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -14543,12 +14543,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "etf",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "etf_equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -14557,21 +14557,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Drug Manufacturers - General",
       "index_memberships": [
         "healthcare_stocks",
         "us_sp500"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -14580,9 +14580,9 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Drug Manufacturers - General",
       "index_memberships": [
         "healthcare_stocks",
         "us_nasdaq100",
@@ -14590,12 +14590,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -14604,9 +14604,9 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Biotechnology",
       "index_memberships": [
         "healthcare_stocks",
         "us_nasdaq100",
@@ -14614,12 +14614,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -14628,9 +14628,9 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Biotechnology",
       "index_memberships": [
         "healthcare_stocks",
         "us_nasdaq100",
@@ -14638,12 +14638,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -14652,21 +14652,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Drug Manufacturers - General",
       "index_memberships": [
         "healthcare_stocks",
         "us_sp500"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -14675,21 +14675,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Biotechnology",
       "index_memberships": [
         "healthcare_stocks",
         "us_nasdaq100"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -14698,21 +14698,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Biotechnology",
       "index_memberships": [
         "healthcare_stocks",
         "us_sp500"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -14721,20 +14721,20 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Biotechnology",
       "index_memberships": [
         "healthcare_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -14743,20 +14743,20 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Drug Manufacturers - Specialty & Generic",
       "index_memberships": [
         "healthcare_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -14765,21 +14765,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Medical Devices",
       "index_memberships": [
         "healthcare_stocks",
         "us_sp500"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -14788,21 +14788,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Medical Devices",
       "index_memberships": [
         "healthcare_stocks",
         "us_sp500"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -14811,21 +14811,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Medical Devices",
       "index_memberships": [
         "healthcare_stocks",
         "us_sp500"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -14834,21 +14834,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Medical Devices",
       "index_memberships": [
         "healthcare_stocks",
         "us_sp500"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -14857,21 +14857,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Medical Devices",
       "index_memberships": [
         "healthcare_stocks",
         "us_sp500"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -14880,21 +14880,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Medical Devices",
       "index_memberships": [
         "healthcare_stocks",
         "us_sp500"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -14911,12 +14911,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -14925,9 +14925,9 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Medical Devices",
       "index_memberships": [
         "healthcare_stocks",
         "us_nasdaq100",
@@ -14935,12 +14935,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -14949,21 +14949,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Medical Instruments & Supplies",
       "index_memberships": [
         "healthcare_stocks",
         "us_sp500"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -14972,21 +14972,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Medical Instruments & Supplies",
       "index_memberships": [
         "healthcare_stocks",
         "us_sp500"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -14995,21 +14995,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Medical Instruments & Supplies",
       "index_memberships": [
         "healthcare_stocks",
         "us_sp500"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -15018,21 +15018,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Medical Devices",
       "index_memberships": [
         "healthcare_stocks",
         "us_sp500"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -15041,20 +15041,20 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Medical Devices",
       "index_memberships": [
         "healthcare_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -15063,9 +15063,9 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Diagnostics & Research",
       "index_memberships": [
         "healthcare_stocks",
         "us_nasdaq100",
@@ -15073,12 +15073,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -15087,21 +15087,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Drug Manufacturers - Specialty & Generic",
       "index_memberships": [
         "healthcare_stocks",
         "us_sp500"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -15110,21 +15110,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Diagnostics & Research",
       "index_memberships": [
         "healthcare_stocks",
         "us_sp500"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -15133,21 +15133,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Diagnostics & Research",
       "index_memberships": [
         "healthcare_stocks",
         "us_sp500"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -15156,21 +15156,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Diagnostics & Research",
       "index_memberships": [
         "healthcare_stocks",
         "us_sp500"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -15179,21 +15179,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Diagnostics & Research",
       "index_memberships": [
         "healthcare_stocks",
         "us_sp500"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -15202,21 +15202,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Diagnostics & Research",
       "index_memberships": [
         "healthcare_stocks",
         "us_sp500"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -15225,20 +15225,20 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Diagnostics & Research",
       "index_memberships": [
         "healthcare_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -15255,12 +15255,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -15269,20 +15269,20 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Diagnostics & Research",
       "index_memberships": [
         "healthcare_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -15291,20 +15291,20 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Healthcare",
+      "industry": "Drug Manufacturers - Specialty & Generic",
       "index_memberships": [
         "healthcare_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -15313,20 +15313,20 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Healthcare",
+      "industry": "Biotechnology",
       "index_memberships": [
         "healthcare_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -15335,20 +15335,20 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Biotechnology",
       "index_memberships": [
         "healthcare_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -15365,12 +15365,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -15379,20 +15379,20 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Biotechnology",
       "index_memberships": [
         "healthcare_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -15401,20 +15401,20 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Healthcare",
+      "industry": "Biotechnology",
       "index_memberships": [
         "healthcare_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -15423,20 +15423,20 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Healthcare",
+      "industry": "Biotechnology",
       "index_memberships": [
         "healthcare_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -15445,20 +15445,20 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Healthcare",
+      "industry": "Biotechnology",
       "index_memberships": [
         "healthcare_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -15467,21 +15467,21 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Biotechnology",
       "index_memberships": [
         "healthcare_stocks",
         "us_nasdaq100"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -15490,20 +15490,20 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Biotechnology",
       "index_memberships": [
         "healthcare_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -15512,20 +15512,20 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "small",
+      "sector": "Healthcare",
+      "industry": "Biotechnology",
       "index_memberships": [
         "healthcare_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -15534,20 +15534,20 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Healthcare",
+      "industry": "Biotechnology",
       "index_memberships": [
         "healthcare_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -15556,20 +15556,20 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Healthcare",
+      "industry": "Biotechnology",
       "index_memberships": [
         "healthcare_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -15578,20 +15578,20 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Healthcare",
+      "industry": "Biotechnology",
       "index_memberships": [
         "healthcare_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -15600,20 +15600,20 @@
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "small",
+      "sector": "Healthcare",
+      "industry": "Biotechnology",
       "index_memberships": [
         "healthcare_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -15622,21 +15622,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Healthcare Plans",
       "index_memberships": [
         "healthcare_stocks",
         "us_sp500"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -15645,21 +15645,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Healthcare Plans",
       "index_memberships": [
         "healthcare_stocks",
         "us_sp500"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -15668,21 +15668,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Healthcare Plans",
       "index_memberships": [
         "healthcare_stocks",
         "us_sp500"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -15691,21 +15691,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Healthcare Plans",
       "index_memberships": [
         "healthcare_stocks",
         "us_sp500"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -15714,21 +15714,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Medical Care Facilities",
       "index_memberships": [
         "healthcare_stocks",
         "us_sp500"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -15737,21 +15737,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Healthcare Plans",
       "index_memberships": [
         "healthcare_stocks",
         "us_sp500"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -15760,21 +15760,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Healthcare",
+      "industry": "Medical Care Facilities",
       "index_memberships": [
         "healthcare_stocks",
         "us_sp500"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -15783,20 +15783,20 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Medical Care Facilities",
       "index_memberships": [
         "healthcare_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -15805,21 +15805,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Medical Distribution",
       "index_memberships": [
         "healthcare_stocks",
         "us_sp500"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -15828,21 +15828,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Medical Distribution",
       "index_memberships": [
         "healthcare_stocks",
         "us_sp500"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -15851,21 +15851,21 @@
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Medical Distribution",
       "index_memberships": [
         "healthcare_stocks",
         "us_sp500"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -15874,20 +15874,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Diversified",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -15896,20 +15896,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Financial Data & Stock Exchanges",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -15918,20 +15918,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Diversified",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -15940,20 +15940,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Insurance - Life",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -15962,20 +15962,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Diversified",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -15984,20 +15984,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Insurance - Life",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -16006,20 +16006,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Regional",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -16028,20 +16028,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Insurance - Life",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -16050,20 +16050,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Regional",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -16072,20 +16072,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Diversified",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -16094,20 +16094,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Utilities",
+      "industry": "Utilities - Regulated Electric",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -16116,20 +16116,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Utilities",
+      "industry": "Utilities - Regulated Gas",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -16138,20 +16138,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Utilities",
+      "industry": "Utilities - Independent Power Producers",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -16160,20 +16160,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Utilities",
+      "industry": "Utilities - Independent Power Producers",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -16182,20 +16182,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Utilities",
+      "industry": "Utilities - Regulated Electric",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -16204,20 +16204,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Utilities",
+      "industry": "Utilities - Regulated Gas",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -16226,20 +16226,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Real Estate",
+      "industry": "Real Estate - Diversified",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -16248,20 +16248,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Real Estate",
+      "industry": "Real Estate - Development",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -16270,20 +16270,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Real Estate",
+      "industry": "Real Estate Services",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -16292,20 +16292,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Real Estate",
+      "industry": "Real Estate - Development",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -16314,20 +16314,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Real Estate",
+      "industry": "REIT - Retail",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -16336,20 +16336,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Real Estate",
+      "industry": "Real Estate - Development",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -16358,20 +16358,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Real Estate",
+      "industry": "Real Estate - Development",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -16380,20 +16380,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Real Estate",
+      "industry": "Real Estate - Development",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -16402,20 +16402,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Real Estate",
+      "industry": "Real Estate Services",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -16424,20 +16424,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Real Estate",
+      "industry": "Real Estate Services",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -16446,20 +16446,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Conglomerates",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -16468,20 +16468,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Resorts & Casinos",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -16490,20 +16490,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Railroads",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -16512,20 +16512,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Auto Manufacturers",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -16534,20 +16534,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Pharmaceutical Retailers",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -16556,20 +16556,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Conglomerates",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -16578,20 +16578,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Electronic Components",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -16600,20 +16600,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Packaged Foods",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -16622,20 +16622,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Beverages - Brewers",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -16644,20 +16644,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Furnishings, Fixtures & Appliances",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -16666,20 +16666,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Marine Shipping",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -16688,20 +16688,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Packaged Foods",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -16710,20 +16710,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Energy",
+      "industry": "Oil & Gas Integrated",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -16732,20 +16732,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Tools & Accessories",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -16754,20 +16754,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Communication Services",
+      "industry": "Internet Content & Information",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -16776,20 +16776,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Communication Services",
+      "industry": "Telecom Services",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -16798,20 +16798,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Energy",
+      "industry": "Oil & Gas Integrated",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -16820,20 +16820,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Basic Materials",
+      "industry": "Building Materials",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -16842,20 +16842,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Auto & Truck Dealerships",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -16864,20 +16864,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Energy",
+      "industry": "Oil & Gas E&P",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -16886,20 +16886,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Communication Services",
+      "industry": "Telecom Services",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -16908,20 +16908,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Solar",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -16930,20 +16930,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Semiconductors",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -16952,20 +16952,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Computer Hardware",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -16974,20 +16974,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Communication Services",
+      "industry": "Internet Content & Information",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -16996,20 +16996,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Household & Personal Products",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -17018,20 +17018,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Energy",
+      "industry": "Thermal Coal",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -17040,20 +17040,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Drug Manufacturers - General",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -17062,20 +17062,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Medical Distribution",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -17084,20 +17084,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Biotechnology",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -17106,20 +17106,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Auto Manufacturers",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -17128,20 +17128,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Basic Materials",
+      "industry": "Aluminum",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -17150,20 +17150,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Consumer Electronics",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -17172,20 +17172,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Beverages - Brewers",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -17194,20 +17194,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Resorts & Casinos",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -17216,20 +17216,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Luxury Goods",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -17238,20 +17238,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Auto Manufacturers",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -17260,20 +17260,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Leisure",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -17282,20 +17282,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Integrated Freight & Logistics",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -17304,20 +17304,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Biotechnology",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -17326,20 +17326,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Textile Manufacturing",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -17348,20 +17348,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Packaged Foods",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -17370,20 +17370,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Leisure",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -17392,20 +17392,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Diagnostics & Research",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -17414,20 +17414,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Technology",
+      "industry": "Electronic Components",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -17436,20 +17436,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Integrated Freight & Logistics",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -17458,20 +17458,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Basic Materials",
+      "industry": "Gold",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -17480,20 +17480,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Internet Retail",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -17502,20 +17502,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Drug Manufacturers - Specialty & Generic",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -17524,20 +17524,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Pharmaceutical Retailers",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -17546,20 +17546,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Furnishings, Fixtures & Appliances",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -17568,20 +17568,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Restaurants",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -17590,20 +17590,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Internet Retail",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -17612,20 +17612,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Beverages - Non-Alcoholic",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -17634,20 +17634,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Communication Services",
+      "industry": "Internet Content & Information",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -17656,20 +17656,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Travel Services",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -17678,20 +17678,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Internet Retail",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -17700,20 +17700,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Leisure",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -17722,20 +17722,20 @@
       "exchange_mic": "XHKG",
       "currency": "HKD",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Communication Services",
+      "industry": "Electronic Gaming & Multimedia",
       "index_memberships": [
         "hongkong_hsi"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -17744,20 +17744,20 @@
       "exchange_mic": "XMIL",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Utilities",
+      "industry": "Utilities - Diversified",
       "index_memberships": [
         "italy_ftse_mib"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -17766,20 +17766,20 @@
       "exchange_mic": "XMIL",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Healthcare",
+      "industry": "Medical Distribution",
       "index_memberships": [
         "italy_ftse_mib"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -17788,20 +17788,20 @@
       "exchange_mic": "XMIL",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Financial Services",
+      "industry": "Asset Management",
       "index_memberships": [
         "italy_ftse_mib"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -17810,20 +17810,20 @@
       "exchange_mic": "XMIL",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Regional",
       "index_memberships": [
         "italy_ftse_mib"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -17832,20 +17832,20 @@
       "exchange_mic": "XMIL",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Regional",
       "index_memberships": [
         "italy_ftse_mib"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -17854,20 +17854,20 @@
       "exchange_mic": "XMIL",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Regional",
       "index_memberships": [
         "italy_ftse_mib"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -17876,20 +17876,20 @@
       "exchange_mic": "XMIL",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Regional",
       "index_memberships": [
         "italy_ftse_mib"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -17906,12 +17906,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -17928,12 +17928,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -17942,20 +17942,20 @@
       "exchange_mic": "XMIL",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Consumer Defensive",
+      "industry": "Beverages - Wineries & Distilleries",
       "index_memberships": [
         "italy_ftse_mib"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -17964,20 +17964,20 @@
       "exchange_mic": "XMIL",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Healthcare",
+      "industry": "Diagnostics & Research",
       "index_memberships": [
         "italy_ftse_mib"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -17994,12 +17994,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -18008,20 +18008,20 @@
       "exchange_mic": "XMIL",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Utilities",
+      "industry": "Utilities - Renewable",
       "index_memberships": [
         "italy_ftse_mib"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -18030,20 +18030,20 @@
       "exchange_mic": "XMIL",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Regional",
       "index_memberships": [
         "italy_ftse_mib"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -18052,20 +18052,20 @@
       "exchange_mic": "XMIL",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Insurance - Diversified",
       "index_memberships": [
         "italy_ftse_mib"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -18074,20 +18074,20 @@
       "exchange_mic": "XMIL",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Utilities",
+      "industry": "Utilities - Diversified",
       "index_memberships": [
         "italy_ftse_mib"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -18096,20 +18096,20 @@
       "exchange_mic": "XMIL",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Utilities",
+      "industry": "Utilities - Regulated Gas",
       "index_memberships": [
         "italy_ftse_mib"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -18118,20 +18118,20 @@
       "exchange_mic": "XMIL",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Real Estate",
+      "industry": "Real Estate Services",
       "index_memberships": [
         "italy_ftse_mib"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -18140,20 +18140,20 @@
       "exchange_mic": "XMIL",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Industrials",
+      "industry": "Specialty Industrial Machinery",
       "index_memberships": [
         "italy_ftse_mib"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -18162,20 +18162,20 @@
       "exchange_mic": "XMIL",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Aerospace & Defense",
       "index_memberships": [
         "italy_ftse_mib"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -18184,20 +18184,20 @@
       "exchange_mic": "XMIL",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Regional",
       "index_memberships": [
         "italy_ftse_mib"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -18206,20 +18206,20 @@
       "exchange_mic": "XMIL",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Apparel Manufacturing",
       "index_memberships": [
         "italy_ftse_mib"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -18228,20 +18228,20 @@
       "exchange_mic": "XMIL",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Technology",
+      "industry": "Software - Infrastructure",
       "index_memberships": [
         "italy_ftse_mib"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -18250,20 +18250,20 @@
       "exchange_mic": "XMIL",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Consumer Cyclical",
+      "industry": "Auto Parts",
       "index_memberships": [
         "italy_ftse_mib"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -18272,20 +18272,20 @@
       "exchange_mic": "XMIL",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Electrical Equipment & Parts",
       "index_memberships": [
         "italy_ftse_mib"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -18294,20 +18294,20 @@
       "exchange_mic": "XMIL",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Conglomerates",
       "index_memberships": [
         "italy_ftse_mib"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -18316,20 +18316,20 @@
       "exchange_mic": "XMIL",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Drug Manufacturers - General",
       "index_memberships": [
         "italy_ftse_mib"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -18338,20 +18338,20 @@
       "exchange_mic": "XMIL",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "mid",
+      "sector": "Energy",
+      "industry": "Oil & Gas Equipment & Services",
       "index_memberships": [
         "italy_ftse_mib"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -18360,20 +18360,20 @@
       "exchange_mic": "XMIL",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Utilities",
+      "industry": "Utilities - Regulated Gas",
       "index_memberships": [
         "italy_ftse_mib"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -18382,20 +18382,20 @@
       "exchange_mic": "XMIL",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Auto Manufacturers",
       "index_memberships": [
         "italy_ftse_mib"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -18412,12 +18412,12 @@
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -18426,20 +18426,20 @@
       "exchange_mic": "XMIL",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Energy",
+      "industry": "Oil & Gas Equipment & Services",
       "index_memberships": [
         "italy_ftse_mib"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -18448,20 +18448,20 @@
       "exchange_mic": "XMIL",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Communication Services",
+      "industry": "Telecom Services",
       "index_memberships": [
         "italy_ftse_mib"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -18470,20 +18470,20 @@
       "exchange_mic": "XMIL",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Utilities",
+      "industry": "Utilities - Regulated Electric",
       "index_memberships": [
         "italy_ftse_mib"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -18492,20 +18492,20 @@
       "exchange_mic": "XMIL",
       "currency": "EUR",
       "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Insurance - Property & Casualty",
       "index_memberships": [
         "italy_ftse_mib"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -18514,20 +18514,20 @@
       "exchange_mic": "XKRX",
       "currency": "KRW",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Household & Personal Products",
       "index_memberships": [
         "korea_kospi200"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -18536,20 +18536,20 @@
       "exchange_mic": "XKRX",
       "currency": "KRW",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Household & Personal Products",
       "index_memberships": [
         "korea_kospi200"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -18558,20 +18558,20 @@
       "exchange_mic": "XKRX",
       "currency": "KRW",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Household & Personal Products",
       "index_memberships": [
         "korea_kospi200"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -18580,20 +18580,20 @@
       "exchange_mic": "XKRX",
       "currency": "KRW",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Basic Materials",
+      "industry": "Building Materials",
       "index_memberships": [
         "korea_kospi200"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -18602,20 +18602,20 @@
       "exchange_mic": "XKRX",
       "currency": "KRW",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Grocery Stores",
       "index_memberships": [
         "korea_kospi200"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -18624,20 +18624,20 @@
       "exchange_mic": "XKRX",
       "currency": "KRW",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Banks - Regional",
       "index_memberships": [
         "korea_kospi200"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -18646,20 +18646,20 @@
       "exchange_mic": "XKRX",
       "currency": "KRW",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Biotechnology",
       "index_memberships": [
         "korea_kospi200"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -18668,20 +18668,20 @@
       "exchange_mic": "XKRX",
       "currency": "KRW",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Communication Services",
+      "industry": "Advertising Agencies",
       "index_memberships": [
         "korea_kospi200"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -18690,20 +18690,20 @@
       "exchange_mic": "XKRX",
       "currency": "KRW",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Drug Manufacturers - Specialty & Generic",
       "index_memberships": [
         "korea_kospi200"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -18712,20 +18712,20 @@
       "exchange_mic": "XKRX",
       "currency": "KRW",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Conglomerates",
       "index_memberships": [
         "korea_kospi200"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -18734,20 +18734,20 @@
       "exchange_mic": "XKRX",
       "currency": "KRW",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Packaged Foods",
       "index_memberships": [
         "korea_kospi200"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -18756,20 +18756,20 @@
       "exchange_mic": "XKRX",
       "currency": "KRW",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Integrated Freight & Logistics",
       "index_memberships": [
         "korea_kospi200"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -18778,20 +18778,20 @@
       "exchange_mic": "XKRX",
       "currency": "KRW",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Household & Personal Products",
       "index_memberships": [
         "korea_kospi200"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -18800,20 +18800,20 @@
       "exchange_mic": "XKRX",
       "currency": "KRW",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Basic Materials",
+      "industry": "Specialty Chemicals",
       "index_memberships": [
         "korea_kospi200"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -18822,20 +18822,20 @@
       "exchange_mic": "XKRX",
       "currency": "KRW",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Furnishings, Fixtures & Appliances",
       "index_memberships": [
         "korea_kospi200"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -18844,20 +18844,20 @@
       "exchange_mic": "XKRX",
       "currency": "KRW",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Specialty Industrial Machinery",
       "index_memberships": [
         "korea_kospi200"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -18866,20 +18866,20 @@
       "exchange_mic": "XKRX",
       "currency": "KRW",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Packaged Foods",
       "index_memberships": [
         "korea_kospi200"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -18888,20 +18888,20 @@
       "exchange_mic": "XKRX",
       "currency": "KRW",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Engineering & Construction",
       "index_memberships": [
         "korea_kospi200"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -18910,20 +18910,20 @@
       "exchange_mic": "XKRX",
       "currency": "KRW",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Drug Manufacturers - Specialty & Generic",
       "index_memberships": [
         "korea_kospi200"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -18932,20 +18932,20 @@
       "exchange_mic": "XKRX",
       "currency": "KRW",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Drug Manufacturers - Specialty & Generic",
       "index_memberships": [
         "korea_kospi200"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -18954,20 +18954,20 @@
       "exchange_mic": "XKRX",
       "currency": "KRW",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Financial Services",
+      "industry": "Insurance - Property & Casualty",
       "index_memberships": [
         "korea_kospi200"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -18976,20 +18976,20 @@
       "exchange_mic": "XKRX",
       "currency": "KRW",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Basic Materials",
+      "industry": "Specialty Chemicals",
       "index_memberships": [
         "korea_kospi200"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -18998,20 +18998,20 @@
       "exchange_mic": "XKRX",
       "currency": "KRW",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Engineering & Construction",
       "index_memberships": [
         "korea_kospi200"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -19020,20 +19020,20 @@
       "exchange_mic": "XKRX",
       "currency": "KRW",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Auto Parts",
       "index_memberships": [
         "korea_kospi200"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -19042,20 +19042,20 @@
       "exchange_mic": "XKRX",
       "currency": "KRW",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Food Distribution",
       "index_memberships": [
         "korea_kospi200"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -19064,20 +19064,20 @@
       "exchange_mic": "XKRX",
       "currency": "KRW",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Packaged Foods",
       "index_memberships": [
         "korea_kospi200"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -19086,20 +19086,20 @@
       "exchange_mic": "XKRX",
       "currency": "KRW",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Packaging & Containers",
       "index_memberships": [
         "korea_kospi200"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -19108,20 +19108,20 @@
       "exchange_mic": "XKRX",
       "currency": "KRW",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Conglomerates",
       "index_memberships": [
         "korea_kospi200"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -19130,20 +19130,20 @@
       "exchange_mic": "XKRX",
       "currency": "KRW",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Farm & Heavy Construction Machinery",
       "index_memberships": [
         "korea_kospi200"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -19152,20 +19152,20 @@
       "exchange_mic": "XKRX",
       "currency": "KRW",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Specialty Industrial Machinery",
       "index_memberships": [
         "korea_kospi200"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -19174,20 +19174,20 @@
       "exchange_mic": "XKRX",
       "currency": "KRW",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Specialty Industrial Machinery",
       "index_memberships": [
         "korea_kospi200"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -19196,20 +19196,20 @@
       "exchange_mic": "XKRX",
       "currency": "KRW",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Communication Services",
+      "industry": "Electronic Gaming & Multimedia",
       "index_memberships": [
         "korea_kospi200"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -19218,20 +19218,20 @@
       "exchange_mic": "XKRX",
       "currency": "KRW",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Electrical Equipment & Parts",
       "index_memberships": [
         "korea_kospi200"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -19240,20 +19240,20 @@
       "exchange_mic": "XKRX",
       "currency": "KRW",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Defensive",
+      "industry": "Discount Stores",
       "index_memberships": [
         "korea_kospi200"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -19262,20 +19262,20 @@
       "exchange_mic": "XKRX",
       "currency": "KRW",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Apparel Manufacturing",
       "index_memberships": [
         "korea_kospi200"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -19284,20 +19284,20 @@
       "exchange_mic": "XKRX",
       "currency": "KRW",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Basic Materials",
+      "industry": "Specialty Chemicals",
       "index_memberships": [
         "korea_kospi200"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -19306,20 +19306,20 @@
       "exchange_mic": "XKRX",
       "currency": "KRW",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Consumer Cyclical",
+      "industry": "Resorts & Casinos",
       "index_memberships": [
         "korea_kospi200"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -19328,20 +19328,20 @@
       "exchange_mic": "XKRX",
       "currency": "KRW",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Drug Manufacturers - Specialty & Generic",
       "index_memberships": [
         "korea_kospi200"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -19350,20 +19350,20 @@
       "exchange_mic": "XKRX",
       "currency": "KRW",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Healthcare",
+      "industry": "Biotechnology",
       "index_memberships": [
         "korea_kospi200"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -19372,20 +19372,20 @@
       "exchange_mic": "XKRX",
       "currency": "KRW",
       "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
+      "market_cap_tier": "large",
+      "sector": "Industrials",
+      "industry": "Conglomerates",
       "index_memberships": [
         "korea_kospi200"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
-      "instrument_type_detail": null,
+      "instrument_type_detail": "equity",
       "available_providers": [
         "yfinance"
       ],
       "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
+      "taxonomy_refreshed_at": "2026-06-30",
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },

--- a/src/swing_screener/data/symbol_pool.py
+++ b/src/swing_screener/data/symbol_pool.py
@@ -399,8 +399,11 @@ def enrich_pool_taxonomy(
             continue
         s.sector = info.get("sector") or s.sector
         s.industry = info.get("industry") or s.industry
+        # Accept both raw yfinance `.info` (`marketCap`) and the provider's
+        # curated `get_ticker_info` dict (`market_cap`).
         s.market_cap_tier = derive_cap_tier(
-            _coerce_float(info.get("marketCap")), cap_thresholds
+            _coerce_float(info.get("marketCap") or info.get("market_cap")),
+            cap_thresholds,
         )
         avg_vol = _coerce_float(info.get("averageDailyVolume3Month")) or _coerce_float(
             info.get("averageVolume")

--- a/web-ui/src/components/domain/screener/QuickFilterBar.test.tsx
+++ b/web-ui/src/components/domain/screener/QuickFilterBar.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen, fireEvent } from '@testing-library/react';
+import { renderWithProviders } from '@/test/utils';
+import { messagesEn } from '@/i18n/messages.en';
+import QuickFilterBar from './QuickFilterBar';
+
+const tx = messagesEn.screener.taxonomy;
+
+describe('QuickFilterBar', () => {
+  it('toggles a region chip and clears the active preset', () => {
+    const onChange = vi.fn();
+    const onPresetChange = vi.fn();
+    renderWithProviders(
+      <QuickFilterBar
+        value={{}}
+        onChange={onChange}
+        presetId="us_large_cap_equities"
+        onPresetChange={onPresetChange}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: tx.region.us }));
+    expect(onChange).toHaveBeenCalledWith({ region: ['us'] });
+    expect(onPresetChange).toHaveBeenCalledWith(null);
+  });
+
+  it('removes a region value when its chip is toggled off', () => {
+    const onChange = vi.fn();
+    renderWithProviders(
+      <QuickFilterBar
+        value={{ region: ['us'] }}
+        onChange={onChange}
+        presetId={null}
+        onPresetChange={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: tx.region.us }));
+    expect(onChange).toHaveBeenCalledWith({});
+  });
+
+  it('maps the Type chip to instrumentTypeDetail buckets', () => {
+    const onChange = vi.fn();
+    renderWithProviders(
+      <QuickFilterBar
+        value={{}}
+        onChange={onChange}
+        presetId={null}
+        onPresetChange={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: tx.type.etf }));
+    expect(onChange).toHaveBeenCalledWith({
+      instrumentTypeDetail: ['etf_equity', 'etf_sector', 'etf_leveraged', 'etf_bond', 'etf_commodity'],
+    });
+  });
+});

--- a/web-ui/src/components/domain/screener/QuickFilterBar.tsx
+++ b/web-ui/src/components/domain/screener/QuickFilterBar.tsx
@@ -1,0 +1,239 @@
+import { t } from '@/i18n/t';
+import Button from '@/components/common/Button';
+import Select from '@/components/common/Select';
+import { cn } from '@/utils/cn';
+import { usePresets } from '@/features/pool/hooks';
+import { SECTORS, INDEX_OPTIONS } from '@/features/pool/sectors';
+import type { TaxonomyFilterValues } from '@/features/pool/types';
+
+interface QuickFilterBarProps {
+  value: TaxonomyFilterValues;
+  onChange: (next: TaxonomyFilterValues) => void;
+  presetId: string | null;
+  onPresetChange: (presetId: string | null) => void;
+  sectors?: readonly string[];
+  indexOptions?: { id: string; label: string }[];
+  disabled?: boolean;
+}
+
+const REGION_OPTIONS: { value: string; label: string }[] = [
+  { value: 'us', label: t('screener.taxonomy.region.us') },
+  { value: 'europe', label: t('screener.taxonomy.region.europe') },
+  { value: 'asia_pacific', label: t('screener.taxonomy.region.asiaPacific') },
+];
+
+const CAP_OPTIONS: { value: string; label: string }[] = [
+  { value: 'large', label: t('screener.taxonomy.capTier.large') },
+  { value: 'mid', label: t('screener.taxonomy.capTier.mid') },
+  { value: 'small', label: t('screener.taxonomy.capTier.small') },
+  { value: 'micro', label: t('screener.taxonomy.capTier.micro') },
+];
+
+const ETF_BUCKET = ['etf_equity', 'etf_sector', 'etf_leveraged', 'etf_bond', 'etf_commodity'];
+const EQUITY_BUCKET = ['equity'];
+
+function sameSet(a: string[] | undefined, b: string[]): boolean {
+  if (!a || a.length !== b.length) return false;
+  const sa = new Set(a);
+  return b.every((x) => sa.has(x));
+}
+
+function pruned(values: TaxonomyFilterValues): TaxonomyFilterValues {
+  const out: TaxonomyFilterValues = {};
+  (Object.keys(values) as (keyof TaxonomyFilterValues)[]).forEach((k) => {
+    const v = values[k];
+    if (v && v.length) out[k] = v;
+  });
+  return out;
+}
+
+export default function QuickFilterBar(props: QuickFilterBarProps) {
+  const { value, onChange, presetId, onPresetChange, disabled } = props;
+  const sectors = props.sectors ?? SECTORS;
+  const indexOptions = props.indexOptions ?? INDEX_OPTIONS;
+  const { data: presets = [] } = usePresets();
+
+  function patch(next: Partial<TaxonomyFilterValues>) {
+    onPresetChange(null);
+    onChange(pruned({ ...value, ...next }));
+  }
+
+  function toggleScalar(field: keyof TaxonomyFilterValues, item: string) {
+    const current = (value[field] as string[] | undefined) ?? [];
+    const next = current.includes(item)
+      ? current.filter((x) => x !== item)
+      : [...current, item];
+    patch({ [field]: next });
+  }
+
+  function handlePreset(id: string) {
+    if (!id) {
+      onPresetChange(null);
+      onChange({});
+      return;
+    }
+    const preset = presets.find((p) => p.id === id);
+    onPresetChange(id);
+    onChange(preset ? pruned(preset.filter) : {});
+  }
+
+  const typeEquityActive = sameSet(value.instrumentTypeDetail, EQUITY_BUCKET);
+  const typeEtfActive = sameSet(value.instrumentTypeDetail, ETF_BUCKET);
+
+  function toggleType(bucket: string[], active: boolean) {
+    patch({ instrumentTypeDetail: active ? [] : bucket });
+  }
+
+  const chip = (active: boolean) =>
+    cn('rounded-full px-3 text-sm', active ? '' : 'text-muted');
+
+  return (
+    <div className="flex flex-wrap items-center gap-3 border-b border-border pb-3">
+      <label className="flex items-center gap-2 text-sm text-muted">
+        {t('screener.taxonomy.preset')}
+        <Select
+          value={presetId ?? ''}
+          disabled={disabled}
+          onChange={(e) => handlePreset(e.target.value)}
+          aria-label={t('screener.taxonomy.preset')}
+        >
+          <option value="">{t('screener.taxonomy.presetPlaceholder')}</option>
+          {presets.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.label}
+            </option>
+          ))}
+        </Select>
+        {presetId === null ? (
+          <span className="text-xs text-muted">{t('screener.taxonomy.presetCustom')}</span>
+        ) : null}
+      </label>
+
+      <ChipGroup label={t('screener.taxonomy.region.label')}>
+        {REGION_OPTIONS.map((o) => {
+          const active = (value.region ?? []).includes(o.value);
+          return (
+            <Button
+              key={o.value}
+              type="button"
+              variant={active ? 'primary' : 'secondary'}
+              size="sm"
+              aria-pressed={active}
+              disabled={disabled}
+              className={chip(active)}
+              onClick={() => toggleScalar('region', o.value)}
+            >
+              {o.label}
+            </Button>
+          );
+        })}
+      </ChipGroup>
+
+      <ChipGroup label={t('screener.taxonomy.capTier.label')}>
+        {CAP_OPTIONS.map((o) => {
+          const active = (value.marketCapTier ?? []).includes(o.value);
+          return (
+            <Button
+              key={o.value}
+              type="button"
+              variant={active ? 'primary' : 'secondary'}
+              size="sm"
+              aria-pressed={active}
+              disabled={disabled}
+              className={chip(active)}
+              onClick={() => toggleScalar('marketCapTier', o.value)}
+            >
+              {o.label}
+            </Button>
+          );
+        })}
+      </ChipGroup>
+
+      <ChipGroup label={t('screener.taxonomy.type.label')}>
+        <Button
+          type="button"
+          variant={typeEquityActive ? 'primary' : 'secondary'}
+          size="sm"
+          aria-pressed={typeEquityActive}
+          disabled={disabled}
+          className={chip(typeEquityActive)}
+          onClick={() => toggleType(EQUITY_BUCKET, typeEquityActive)}
+        >
+          {t('screener.taxonomy.type.equity')}
+        </Button>
+        <Button
+          type="button"
+          variant={typeEtfActive ? 'primary' : 'secondary'}
+          size="sm"
+          aria-pressed={typeEtfActive}
+          disabled={disabled}
+          className={chip(typeEtfActive)}
+          onClick={() => toggleType(ETF_BUCKET, typeEtfActive)}
+        >
+          {t('screener.taxonomy.type.etf')}
+        </Button>
+      </ChipGroup>
+
+      <MultiSelectDropdown
+        label={t('screener.taxonomy.sector.label')}
+        placeholder={t('screener.taxonomy.sector.placeholder')}
+        options={sectors.map((s) => ({ id: s, label: s }))}
+        selected={value.sector ?? []}
+        disabled={disabled}
+        onToggle={(id) => toggleScalar('sector', id)}
+      />
+
+      <MultiSelectDropdown
+        label={t('screener.taxonomy.index.label')}
+        placeholder={t('screener.taxonomy.index.placeholder')}
+        options={indexOptions}
+        selected={value.indexMemberships ?? []}
+        disabled={disabled}
+        onToggle={(id) => toggleScalar('indexMemberships', id)}
+      />
+    </div>
+  );
+}
+
+function ChipGroup({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex items-center gap-1">
+      <span className="text-xs uppercase tracking-wide text-muted">{label}</span>
+      <div className="flex flex-wrap gap-1">{children}</div>
+    </div>
+  );
+}
+
+interface MultiSelectDropdownProps {
+  label: string;
+  placeholder: string;
+  options: { id: string; label: string }[];
+  selected: string[];
+  disabled?: boolean;
+  onToggle: (id: string) => void;
+}
+
+function MultiSelectDropdown(props: MultiSelectDropdownProps) {
+  const { label, placeholder, options, selected, disabled, onToggle } = props;
+  const summary = selected.length ? `${label} (${selected.length})` : placeholder;
+  return (
+    <details className="relative">
+      <summary className="cursor-pointer select-none rounded-md border border-border px-3 py-2 text-sm text-foreground">
+        {summary}
+      </summary>
+      <div className="absolute z-10 mt-1 max-h-64 w-56 overflow-y-auto rounded-md border border-border bg-surface p-2 shadow-lg">
+        {options.map((o) => (
+          <label key={o.id} className="flex items-center gap-2 px-1 py-1 text-sm">
+            <input
+              type="checkbox"
+              checked={selected.includes(o.id)}
+              disabled={disabled}
+              onChange={() => onToggle(o.id)}
+            />
+            {o.label}
+          </label>
+        ))}
+      </div>
+    </details>
+  );
+}

--- a/web-ui/src/components/domain/screener/ScreenerForm.test.tsx
+++ b/web-ui/src/components/domain/screener/ScreenerForm.test.tsx
@@ -4,31 +4,12 @@ import userEvent from '@testing-library/user-event';
 import { renderWithProviders } from '@/test/utils';
 import ScreenerForm from './ScreenerForm';
 import { t } from '@/i18n/t';
-import type { UniverseSummary } from '@/features/screener/types';
-
-const mockUniverse: UniverseSummary = {
-  id: 'broad_market_stocks',
-  description: 'Broad Market Stocks',
-  kind: 'equity',
-  benchmark: 'SPY',
-  member_count: 500,
-  source: 'manual',
-  source_asof: '2026-01-01',
-  last_reviewed_at: '2026-01-01',
-  stale_after_days: 30,
-  currencies: ['USD'],
-  exchange_mics: ['XNYS', 'XNAS'],
-  source_adapter: 'manual',
-  source_documents: [],
-  refreshable: false,
-  days_since_review: 0,
-  freshness_status: 'fresh',
-  is_stale: false,
-};
 
 const defaultProps = {
-  selectedUniverse: 'broad_market_stocks',
-  setSelectedUniverse: vi.fn(),
+  taxonomyFilter: {},
+  setTaxonomyFilter: vi.fn(),
+  presetId: null,
+  setPresetId: vi.fn(),
   topN: 20,
   setTopN: vi.fn(),
   minPrice: 5,
@@ -39,8 +20,6 @@ const defaultProps = {
   setCurrencyFilter: vi.fn(),
   exchangeFilter: 'all' as const,
   setExchangeFilter: vi.fn(),
-  instrumentFilter: 'all' as const,
-  setInstrumentFilter: vi.fn(),
   includeOtc: false,
   setIncludeOtc: vi.fn(),
   recommendedOnly: false,
@@ -49,7 +28,6 @@ const defaultProps = {
   setRequireWeeklyUptrend: vi.fn(),
   actionFilter: 'all' as const,
   setActionFilter: vi.fn(),
-  universes: [mockUniverse],
   isLoading: false,
   onRun: vi.fn(),
   isCollapsed: false,
@@ -63,15 +41,9 @@ describe('ScreenerForm - collapsed state', () => {
     vi.clearAllMocks();
   });
 
-  it('shows universe description and member count in collapsed view', () => {
-    renderWithProviders(<ScreenerForm {...defaultProps} isCollapsed={true} />);
-    expect(screen.getByText('Broad Market Stocks')).toBeInTheDocument();
-    expect(screen.getByText(t('screener.controls.memberCount', { count: '500' }))).toBeInTheDocument();
-  });
-
   it('shows the Run button in collapsed view', () => {
     renderWithProviders(<ScreenerForm {...defaultProps} isCollapsed={true} />);
-    expect(screen.getByText(t('screener.controls.run'))).toBeInTheDocument();
+    expect(screen.getAllByText(t('screener.controls.run')).length).toBeGreaterThan(0);
   });
 
   it('shows "Advanced filters" label in collapsed view', () => {
@@ -109,20 +81,6 @@ describe('ScreenerForm - collapsed state', () => {
     );
     expect(screen.getByText(t('screener.controls.noOtc'))).toBeInTheDocument();
   });
-
-  it('shows weeklyUptrend pill when requireWeeklyUptrend is true', () => {
-    renderWithProviders(
-      <ScreenerForm {...defaultProps} isCollapsed={true} requireWeeklyUptrend={true} />
-    );
-    expect(screen.getByText(t('screener.controls.weeklyUptrend'))).toBeInTheDocument();
-  });
-
-  it('shows recommendedOnly pill when recommendedOnly is true', () => {
-    renderWithProviders(
-      <ScreenerForm {...defaultProps} isCollapsed={true} recommendedOnly={true} />
-    );
-    expect(screen.getByText(t('screener.controls.recommendedOnlyShort'))).toBeInTheDocument();
-  });
 });
 
 describe('ScreenerForm - expanded state', () => {
@@ -135,20 +93,12 @@ describe('ScreenerForm - expanded state', () => {
     expect(screen.getByText(t('screener.controls.hideFilters'))).toBeInTheDocument();
   });
 
-  it('calls onToggleCollapsed when "Hide filters" is clicked', async () => {
-    const onToggleCollapsed = vi.fn();
-    const user = userEvent.setup();
-    renderWithProviders(
-      <ScreenerForm {...defaultProps} isCollapsed={false} onToggleCollapsed={onToggleCollapsed} />
-    );
-    const hideBtn = screen.getByRole('button', { name: t('screener.controls.hideFilters') });
-    await user.click(hideBtn);
-    expect(onToggleCollapsed).toHaveBeenCalledTimes(1);
-  });
-
-  it('shows universe selector in expanded view', () => {
+  it('renders the quick filter bar and no universe selector', () => {
     renderWithProviders(<ScreenerForm {...defaultProps} isCollapsed={false} />);
-    expect(screen.getByRole('combobox', { name: t('screener.controls.universe') })).toBeInTheDocument();
+    expect(screen.getByText(t('screener.taxonomy.region.label'))).toBeInTheDocument();
+    expect(
+      screen.queryByRole('combobox', { name: t('screener.controls.universe') })
+    ).not.toBeInTheDocument();
   });
 });
 
@@ -158,73 +108,13 @@ describe('ScreenerForm - forceRefresh', () => {
   });
 
   it('renders forceRefresh checkbox unchecked by default', () => {
-    const { getByLabelText } = renderWithProviders(
-      <ScreenerForm
-        selectedUniverse="broad_market_stocks"
-        setSelectedUniverse={vi.fn()}
-        topN={20}
-        setTopN={vi.fn()}
-        minPrice={5}
-        setMinPrice={vi.fn()}
-        maxPrice={500}
-        setMaxPrice={vi.fn()}
-        currencyFilter="all"
-        setCurrencyFilter={vi.fn()}
-        exchangeFilter="all"
-        setExchangeFilter={vi.fn()}
-        instrumentFilter="all"
-        setInstrumentFilter={vi.fn()}
-        includeOtc={false}
-        setIncludeOtc={vi.fn()}
-        recommendedOnly={false}
-        setRecommendedOnly={vi.fn()}
-        requireWeeklyUptrend={false}
-        setRequireWeeklyUptrend={vi.fn()}
-        actionFilter="all"
-        setActionFilter={vi.fn()}
-        universes={[]}
-        isLoading={false}
-        onRun={vi.fn()}
-        forceRefresh={false}
-        setForceRefresh={vi.fn()}
-      />
-    );
-    const cb = getByLabelText(t('screener.controls.forceRefresh')) as HTMLInputElement;
+    renderWithProviders(<ScreenerForm {...defaultProps} forceRefresh={false} />);
+    const cb = screen.getByLabelText(t('screener.controls.forceRefresh')) as HTMLInputElement;
     expect(cb.checked).toBe(false);
   });
 
   it('shows warning when forceRefresh is true', () => {
-    const { getByText } = renderWithProviders(
-      <ScreenerForm
-        selectedUniverse="broad_market_stocks"
-        setSelectedUniverse={vi.fn()}
-        topN={20}
-        setTopN={vi.fn()}
-        minPrice={5}
-        setMinPrice={vi.fn()}
-        maxPrice={500}
-        setMaxPrice={vi.fn()}
-        currencyFilter="all"
-        setCurrencyFilter={vi.fn()}
-        exchangeFilter="all"
-        setExchangeFilter={vi.fn()}
-        instrumentFilter="all"
-        setInstrumentFilter={vi.fn()}
-        includeOtc={false}
-        setIncludeOtc={vi.fn()}
-        recommendedOnly={false}
-        setRecommendedOnly={vi.fn()}
-        requireWeeklyUptrend={false}
-        setRequireWeeklyUptrend={vi.fn()}
-        actionFilter="all"
-        setActionFilter={vi.fn()}
-        universes={[]}
-        isLoading={false}
-        onRun={vi.fn()}
-        forceRefresh={true}
-        setForceRefresh={vi.fn()}
-      />
-    );
-    expect(getByText(t('screener.controls.forceRefreshWarning'))).toBeInTheDocument();
+    renderWithProviders(<ScreenerForm {...defaultProps} forceRefresh={true} />);
+    expect(screen.getByText(t('screener.controls.forceRefreshWarning'))).toBeInTheDocument();
   });
 });

--- a/web-ui/src/components/domain/screener/ScreenerForm.tsx
+++ b/web-ui/src/components/domain/screener/ScreenerForm.tsx
@@ -1,59 +1,31 @@
 import { PlayCircle, RefreshCw, ChevronUp, Settings2 } from 'lucide-react';
 import { useCallback, type ChangeEvent } from 'react';
 import Button from '@/components/common/Button';
-import Badge from '@/components/common/Badge';
 import Field from '@/components/common/Field';
 import Input from '@/components/common/Input';
 import Select from '@/components/common/Select';
+import QuickFilterBar from '@/components/domain/screener/QuickFilterBar';
 import type { DecisionActionFilter } from '@/features/screener/prioritization';
 import { formatDecisionAction } from '@/features/screener/decisionSummary';
-import type { UniverseSummary } from '@/features/screener/types';
+import type { TaxonomyFilterValues } from '@/features/pool/types';
 import { t } from '@/i18n/t';
 
 type CurrencyFilter = 'all' | 'usd' | 'eur';
 type ExchangeFilter = 'all' | 'us_primary' | 'europe_primary' | 'xams' | 'xetr' | 'xpar' | 'xmil' | 'xmad';
-type InstrumentFilter = 'all' | 'equity' | 'etf';
 
 const TOP_N_MAX = 200;
-
-const universeFreshnessVariant = (status: UniverseSummary['freshness_status']): 'default' | 'success' | 'warning' | 'error' => {
-  switch (status) {
-    case 'fresh':
-      return 'success';
-    case 'review_due':
-      return 'warning';
-    case 'stale':
-      return 'error';
-    default:
-      return 'default';
-  }
-};
-
-const universeFreshnessLabel = (status: UniverseSummary['freshness_status']): string => {
-  switch (status) {
-    case 'fresh':
-      return t('screener.universe.freshness.fresh');
-    case 'review_due':
-      return t('screener.universe.freshness.reviewDue');
-    case 'stale':
-      return t('screener.universe.freshness.stale');
-    default:
-      return t('screener.universe.freshness.unknown');
-  }
-};
-
-const universeSourceLabel = (source: string): string => {
-  if (source === 'euronext_review') return t('screener.universe.source.euronextReview');
-  if (source === 'manual') return t('screener.universe.source.manual');
-  return source;
-};
 
 const formatActionFilterLabel = (value: DecisionActionFilter): string =>
   value === 'all' ? t('screener.controls.allActions') : formatDecisionAction(value);
 
+const activeFilterCount = (filter: TaxonomyFilterValues): number =>
+  Object.values(filter).reduce((sum, v) => sum + (v?.length ?? 0), 0);
+
 interface ScreenerFormProps {
-  selectedUniverse: string;
-  setSelectedUniverse: (value: string) => void;
+  taxonomyFilter: TaxonomyFilterValues;
+  setTaxonomyFilter: (value: TaxonomyFilterValues) => void;
+  presetId: string | null;
+  setPresetId: (value: string | null) => void;
   topN: number;
   setTopN: (value: number) => void;
   minPrice: number;
@@ -64,8 +36,6 @@ interface ScreenerFormProps {
   setCurrencyFilter: (value: CurrencyFilter) => void;
   exchangeFilter: ExchangeFilter;
   setExchangeFilter: (value: ExchangeFilter) => void;
-  instrumentFilter: InstrumentFilter;
-  setInstrumentFilter: (value: InstrumentFilter) => void;
   includeOtc: boolean;
   setIncludeOtc: (value: boolean) => void;
   recommendedOnly: boolean;
@@ -74,7 +44,6 @@ interface ScreenerFormProps {
   setRequireWeeklyUptrend: (value: boolean) => void;
   actionFilter: DecisionActionFilter;
   setActionFilter: (value: DecisionActionFilter) => void;
-  universes: UniverseSummary[];
   isLoading: boolean;
   onRun: () => void;
   isCollapsed?: boolean;
@@ -84,8 +53,10 @@ interface ScreenerFormProps {
 }
 
 export default function ScreenerForm({
-  selectedUniverse,
-  setSelectedUniverse,
+  taxonomyFilter,
+  setTaxonomyFilter,
+  presetId,
+  setPresetId,
   topN,
   setTopN,
   minPrice,
@@ -96,8 +67,6 @@ export default function ScreenerForm({
   setCurrencyFilter,
   exchangeFilter,
   setExchangeFilter,
-  instrumentFilter,
-  setInstrumentFilter,
   includeOtc,
   setIncludeOtc,
   recommendedOnly,
@@ -106,7 +75,6 @@ export default function ScreenerForm({
   setRequireWeeklyUptrend,
   actionFilter,
   setActionFilter,
-  universes,
   isLoading,
   onRun,
   isCollapsed = false,
@@ -114,8 +82,6 @@ export default function ScreenerForm({
   forceRefresh,
   setForceRefresh,
 }: ScreenerFormProps) {
-  const selectedUniverseMeta = universes.find((universe) => universe.id === selectedUniverse);
-
   const handleTopNChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
     const parsed = parseInt(e.target.value) || 20;
     setTopN(Math.min(Math.max(parsed, 1), TOP_N_MAX));
@@ -129,20 +95,24 @@ export default function ScreenerForm({
     setMaxPrice(parseFloat(e.target.value) || 1000);
   }, [setMaxPrice]);
 
+  const filterCount = activeFilterCount(taxonomyFilter);
+
   if (isCollapsed) {
     return (
       <div className="rounded-lg border border-border bg-surface/60 p-3 space-y-2">
-        {/* Row 1: Universe name + Run CTA */}
+        {/* Row 1: filter summary + Run CTA */}
         <div className="flex items-center justify-between gap-3">
           <div>
             <span className="text-sm font-semibold text-foreground">
-              {selectedUniverseMeta?.description ?? selectedUniverse}
+              {presetId
+                ? t('screener.taxonomy.preset')
+                : filterCount > 0
+                  ? t('screener.taxonomy.preset')
+                  : t('screener.controls.run')}
             </span>
-            {selectedUniverseMeta && (
-              <span className="ml-2 text-xs text-muted">
-                {t('screener.controls.memberCount', { count: String(selectedUniverseMeta.member_count) })}
-              </span>
-            )}
+            <span className="ml-2 text-xs text-muted">
+              {presetId ?? (filterCount > 0 ? `${filterCount}` : t('screener.taxonomy.sector.placeholder'))}
+            </span>
           </div>
           <div className="flex items-center gap-2">
             <Button onClick={onRun} disabled={isLoading} size="sm">
@@ -183,11 +153,6 @@ export default function ScreenerForm({
               {exchangeFilter}
             </span>
           )}
-          {instrumentFilter !== 'all' && (
-            <span className="text-[11px] px-2 py-0.5 rounded-full bg-foreground/10 text-muted">
-              {instrumentFilter}
-            </span>
-          )}
           {!includeOtc && (
             <span className="text-[11px] px-2 py-0.5 rounded-full bg-foreground/10 text-muted">
               {t('screener.controls.noOtc')}
@@ -225,21 +190,15 @@ export default function ScreenerForm({
       )}
 
       <div className="space-y-3">
-        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-7 gap-3 items-end">
-          <Field label={t('screener.controls.universe')}>
-            <Select
-              value={selectedUniverse}
-              onChange={(e) => setSelectedUniverse(e.target.value)}
-              disabled={isLoading}
-            >
-              {universes.map((universe) => (
-                <option key={universe.id} value={universe.id}>
-                  {universe.description} ({universe.member_count})
-                </option>
-              ))}
-            </Select>
-          </Field>
+        <QuickFilterBar
+          value={taxonomyFilter}
+          onChange={setTaxonomyFilter}
+          presetId={presetId}
+          onPresetChange={setPresetId}
+          disabled={isLoading}
+        />
 
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-5 gap-3 items-end">
           <Field label={t('screener.controls.topN')}>
             <Input
               type="number"
@@ -301,19 +260,6 @@ export default function ScreenerForm({
               <option value="xmad">{t('screener.controls.venue.madrid')}</option>
             </Select>
           </Field>
-
-          <Field label={t('screener.controls.instrument.label')}>
-            <Select
-              value={instrumentFilter}
-              onChange={(e) => setInstrumentFilter(e.target.value as InstrumentFilter)}
-              disabled={isLoading}
-            >
-              <option value="all">{t('screener.controls.instrument.all')}</option>
-              <option value="equity">{t('screener.controls.instrument.stocks')}</option>
-              <option value="etf">{t('screener.controls.instrument.etfs')}</option>
-            </Select>
-          </Field>
-
         </div>
 
         <div className="flex justify-end">
@@ -335,28 +281,6 @@ export default function ScreenerForm({
             )}
           </Button>
         </div>
-
-        {selectedUniverseMeta ? (
-          <div className="rounded-lg border border-border bg-surface px-3 py-2">
-            <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-              <div className="text-xs text-muted">
-                {t('screener.controls.memberCount', { count: String(selectedUniverseMeta.member_count) })}
-                {' · '}
-                {universeSourceLabel(selectedUniverseMeta.source)}
-                {' · '}
-                source as of {selectedUniverseMeta.source_asof}
-              </div>
-              <div className="flex flex-wrap gap-2">
-                <Badge variant={universeFreshnessVariant(selectedUniverseMeta.freshness_status)}>
-                  {universeFreshnessLabel(selectedUniverseMeta.freshness_status)}
-                </Badge>
-                {selectedUniverseMeta.exchange_mics.map((mic) => (
-                  <Badge key={mic} variant="default">{mic}</Badge>
-                ))}
-              </div>
-            </div>
-          </div>
-        ) : null}
 
         <div className="flex flex-col gap-3 border-t border-border pt-3 md:flex-row md:items-end md:justify-between">
           <div className="flex flex-col gap-3 md:flex-row md:items-center">

--- a/web-ui/src/components/domain/workspace/ScreenerInboxPanel.tsx
+++ b/web-ui/src/components/domain/workspace/ScreenerInboxPanel.tsx
@@ -6,8 +6,9 @@ import ScreenerForm from '@/components/domain/screener/ScreenerForm';
 import ScreenerCandidatesTable from '@/components/domain/screener/ScreenerCandidatesTable';
 import { useConfigDefaultsQuery } from '@/features/config/hooks';
 import { useActiveStrategyQuery } from '@/features/strategy/hooks';
-import { useUniverses, useRunScreenerMutation } from '@/features/screener/hooks';
+import { useRunScreenerMutation } from '@/features/screener/hooks';
 import { filterCandidates, filterOutAddOns, prioritizeCandidates, type DecisionActionFilter } from '@/features/screener/prioritization';
+import type { TaxonomyFilterValues } from '@/features/pool/types';
 import OpenPositionIntelligencePanel from '@/components/domain/positions/OpenPositionIntelligencePanel';
 import { useScreenerStore } from '@/stores/screenerStore';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
@@ -15,16 +16,11 @@ import type { WorkspaceAnalysisTab } from '@/components/domain/workspace/types';
 import { t } from '@/i18n/t';
 import { useLocalStorage } from '@/hooks';
 import { formatDate } from '@/utils/formatters';
-import {
-  parseUniverseValue,
-  SCREENER_UNIVERSE_STORAGE_KEY,
-} from '@/features/screener/universeStorage';
 
 const TOP_N_MAX = 200;
 
 type CurrencyFilter = 'all' | 'usd' | 'eur';
 type ExchangeFilter = 'all' | 'us_primary' | 'europe_primary' | 'xams' | 'xetr' | 'xpar' | 'xmil' | 'xmad';
-type InstrumentFilter = 'all' | 'equity' | 'etf';
 const DECISION_ACTION_FILTERS: DecisionActionFilter[] = [
   'all',
   'BUY_NOW',
@@ -62,11 +58,6 @@ const exchangeFilterToRequest = (value: ExchangeFilter): string[] | undefined =>
     default:
       return undefined;
   }
-};
-
-const instrumentFilterToRequest = (value: InstrumentFilter): Array<'equity' | 'etf'> | undefined => {
-  if (value === 'all') return undefined;
-  return [value];
 };
 
 const RUNNING_STEPS = [
@@ -135,10 +126,15 @@ export default function ScreenerInboxPanel() {
 
   const riskConfig = activeStrategy?.risk ?? configDefaultsQuery.data?.risk;
 
-  const [selectedUniverse, setSelectedUniverse] = useLocalStorage(
-    SCREENER_UNIVERSE_STORAGE_KEY,
-    'broad_market_stocks',
-    (value: unknown) => parseUniverseValue(value) ?? 'broad_market_stocks'
+  const [taxonomyFilter, setTaxonomyFilter] = useLocalStorage<TaxonomyFilterValues>(
+    'screener.taxonomyFilter',
+    {},
+    (value: unknown) => (value && typeof value === 'object' ? (value as TaxonomyFilterValues) : {})
+  );
+  const [presetId, setPresetId] = useLocalStorage<string | null>(
+    'screener.presetId',
+    null,
+    (value: unknown) => (typeof value === 'string' ? value : null)
   );
   const [topN, setTopN] = useLocalStorage('screener.topN', 20, (val: unknown) => {
     const parsed = typeof val === 'number' ? val : parseInt(String(val), 10);
@@ -165,11 +161,6 @@ export default function ScreenerInboxPanel() {
       return 'all';
     }
   );
-  const [instrumentFilter, setInstrumentFilter] = useLocalStorage<InstrumentFilter>(
-    'screener.instrumentFilter',
-    'all',
-    (val: unknown) => (val === 'equity' || val === 'etf' || val === 'all' ? val : 'all')
-  );
   const [includeOtc, setIncludeOtc] = useLocalStorage('screener.includeOtc', false);
   const [recommendedOnly, setRecommendedOnly] = useLocalStorage('screener.recommendedOnly', false);
   const [requireWeeklyUptrend, setRequireWeeklyUptrend] = useLocalStorage('screener.requireWeeklyUptrend', false);
@@ -186,7 +177,6 @@ export default function ScreenerInboxPanel() {
   const [isFormCollapsed, setIsFormCollapsed] = useLocalStorage('screener-form-collapsed', true);
   const [forceRefresh, setForceRefresh] = useState(false);
 
-  const universesQuery = useUniverses();
   const screenerMutation = useRunScreenerMutation((data) => {
     setLastResult(data);
     if (data.candidates.length > 0) {
@@ -198,7 +188,8 @@ export default function ScreenerInboxPanel() {
 
   const handleRunScreener = useCallback(() => {
     screenerMutation.mutate({
-      universe: selectedUniverse,
+      taxonomyFilter,
+      preset: presetId ?? undefined,
       top: topN,
       minPrice,
       maxPrice,
@@ -206,7 +197,6 @@ export default function ScreenerInboxPanel() {
       exchangeMics: exchangeFilterToRequest(exchangeFilter),
       includeOtc,
       requireWeeklyUptrend: requireWeeklyUptrend || undefined,
-      instrumentTypes: instrumentFilterToRequest(instrumentFilter),
       breakoutLookback: strategySignals?.breakoutLookback ?? defaultIndicators?.breakoutLookback ?? 50,
       pullbackMa: strategySignals?.pullbackMa ?? defaultIndicators?.pullbackMa ?? 20,
       minHistory: strategySignals?.minHistory ?? defaultIndicators?.minHistory ?? 260,
@@ -217,13 +207,13 @@ export default function ScreenerInboxPanel() {
     defaultIndicators?.minHistory,
     defaultIndicators?.pullbackMa,
     screenerMutation.mutate,
-    selectedUniverse,
+    taxonomyFilter,
+    presetId,
     topN,
     minPrice,
     maxPrice,
     currencyFilter,
     exchangeFilter,
-    instrumentFilter,
     includeOtc,
     requireWeeklyUptrend,
     forceRefresh,
@@ -280,8 +270,10 @@ export default function ScreenerInboxPanel() {
   return (
     <Card variant="bordered" className="p-3 md:p-4 flex min-h-0 flex-col gap-3 xl:h-full xl:overflow-y-auto">
       <ScreenerForm
-        selectedUniverse={selectedUniverse}
-        setSelectedUniverse={setSelectedUniverse}
+        taxonomyFilter={taxonomyFilter}
+        setTaxonomyFilter={setTaxonomyFilter}
+        presetId={presetId}
+        setPresetId={setPresetId}
         topN={topN}
         setTopN={setTopN}
         minPrice={minPrice}
@@ -292,8 +284,6 @@ export default function ScreenerInboxPanel() {
         setCurrencyFilter={setCurrencyFilter}
         exchangeFilter={exchangeFilter}
         setExchangeFilter={setExchangeFilter}
-        instrumentFilter={instrumentFilter}
-        setInstrumentFilter={setInstrumentFilter}
         includeOtc={includeOtc}
         setIncludeOtc={setIncludeOtc}
         recommendedOnly={recommendedOnly}
@@ -302,7 +292,6 @@ export default function ScreenerInboxPanel() {
         setRequireWeeklyUptrend={setRequireWeeklyUptrend}
         actionFilter={actionFilter}
         setActionFilter={setActionFilter}
-        universes={universesQuery.data?.universes ?? []}
         isLoading={screenerMutation.isPending}
         onRun={handleRunScreener}
         isCollapsed={isFormCollapsed}

--- a/web-ui/src/features/pool/api.ts
+++ b/web-ui/src/features/pool/api.ts
@@ -1,0 +1,38 @@
+import { API_ENDPOINTS } from '@/lib/api';
+import { fetchJson } from '@/lib/fetchJson';
+import {
+  ReviewQueueEntry,
+  TaxonomyPreset,
+  transformPreset,
+  transformReviewEntry,
+} from './types';
+
+export async function fetchPresets(): Promise<TaxonomyPreset[]> {
+  const body = await fetchJson<{ presets?: unknown[] }>(API_ENDPOINTS.poolPresets, {
+    errorMessage: 'Failed to load taxonomy presets',
+  });
+  return (body.presets ?? []).map((p) => transformPreset(p as Parameters<typeof transformPreset>[0]));
+}
+
+export async function fetchReviewQueue(): Promise<ReviewQueueEntry[]> {
+  const body = await fetchJson<{ entries?: unknown[] }>(API_ENDPOINTS.poolReviewQueue, {
+    errorMessage: 'Failed to load review queue',
+  });
+  return (body.entries ?? []).map((e) => transformReviewEntry(e as Parameters<typeof transformReviewEntry>[0]));
+}
+
+export async function removeFromPool(symbol: string): Promise<boolean> {
+  const body = await fetchJson<{ removed: boolean }>(API_ENDPOINTS.poolReviewQueueRemove(symbol), {
+    method: 'POST',
+    errorMessage: 'Failed to remove symbol from pool',
+  });
+  return body.removed;
+}
+
+export async function restoreToPool(symbol: string): Promise<boolean> {
+  const body = await fetchJson<{ restored: boolean }>(API_ENDPOINTS.poolReviewQueueRestore(symbol), {
+    method: 'POST',
+    errorMessage: 'Failed to restore symbol to pool',
+  });
+  return body.restored;
+}

--- a/web-ui/src/features/pool/hooks.ts
+++ b/web-ui/src/features/pool/hooks.ts
@@ -1,0 +1,34 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { queryKeys } from '@/lib/queryKeys';
+import { fetchPresets, fetchReviewQueue, removeFromPool, restoreToPool } from './api';
+
+export function usePresets() {
+  return useQuery({
+    queryKey: queryKeys.taxonomyPresets(),
+    queryFn: fetchPresets,
+    staleTime: 60 * 60 * 1000,
+  });
+}
+
+export function useReviewQueue() {
+  return useQuery({
+    queryKey: queryKeys.reviewQueue(),
+    queryFn: fetchReviewQueue,
+  });
+}
+
+export function useRemoveFromPool() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: removeFromPool,
+    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.reviewQueue() }),
+  });
+}
+
+export function useRestoreToPool() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: restoreToPool,
+    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.reviewQueue() }),
+  });
+}

--- a/web-ui/src/features/pool/sectors.ts
+++ b/web-ui/src/features/pool/sectors.ts
@@ -1,0 +1,30 @@
+// Morningstar/yfinance sector vocabulary used to tag pool symbols. Static list
+// (the screener pre-filter matches these exact strings against PoolSymbol.sector).
+export const SECTORS = [
+  'Technology',
+  'Healthcare',
+  'Financial Services',
+  'Consumer Cyclical',
+  'Consumer Defensive',
+  'Energy',
+  'Industrials',
+  'Basic Materials',
+  'Utilities',
+  'Real Estate',
+  'Communication Services',
+] as const;
+
+// Known index-membership ids (old universe ids) surfaced in the Index filter.
+export const INDEX_OPTIONS: { id: string; label: string }[] = [
+  { id: 'us_sp500', label: 'S&P 500' },
+  { id: 'us_nasdaq100', label: 'NASDAQ 100' },
+  { id: 'us_dow30', label: 'Dow 30' },
+  { id: 'germany_dax', label: 'DAX' },
+  { id: 'france_cac40', label: 'CAC 40' },
+  { id: 'uk_ftse100', label: 'FTSE 100' },
+  { id: 'spain_ibex35', label: 'IBEX 35' },
+  { id: 'europe_eurostoxx50', label: 'Euro Stoxx 50' },
+  { id: 'amsterdam_aex', label: 'AEX' },
+  { id: 'italy_ftse_mib', label: 'FTSE MIB' },
+  { id: 'broad_market_stocks', label: 'Broad Market' },
+];

--- a/web-ui/src/features/pool/types.test.ts
+++ b/web-ui/src/features/pool/types.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { transformReviewEntry, transformPreset } from './types';
+
+describe('transformReviewEntry', () => {
+  it('maps snake_case API entry to camelCase', () => {
+    const out = transformReviewEntry({
+      symbol: 'AAPL',
+      exchange_mic: 'XNAS',
+      fetch_failure_count: 3,
+      first_failed_at: '2026-06-28',
+      last_failed_at: '2026-06-30',
+      reason: 'no data',
+    });
+    expect(out).toEqual({
+      symbol: 'AAPL',
+      exchangeMic: 'XNAS',
+      capTier: undefined,
+      sector: undefined,
+      provider: undefined,
+      failureCount: 3,
+      firstFailedAt: '2026-06-28',
+      lastFailedAt: '2026-06-30',
+      reason: 'no data',
+    });
+  });
+});
+
+describe('transformPreset', () => {
+  it('maps snake_case filter keys to camelCase', () => {
+    const out = transformPreset({
+      id: 'us_large_cap_equities',
+      label: 'US Large Cap Equities',
+      filter: { region: ['us'], market_cap_tier: ['large'], instrument_type_detail: ['equity'] },
+    });
+    expect(out.id).toBe('us_large_cap_equities');
+    expect(out.label).toBe('US Large Cap Equities');
+    expect(out.filter).toEqual({
+      region: ['us'],
+      marketCapTier: ['large'],
+      instrumentTypeDetail: ['equity'],
+      sector: undefined,
+      indexMemberships: undefined,
+      provider: undefined,
+      currency: undefined,
+      exchangeMics: undefined,
+      liquidityTier: undefined,
+    });
+  });
+});

--- a/web-ui/src/features/pool/types.ts
+++ b/web-ui/src/features/pool/types.ts
@@ -1,0 +1,80 @@
+export interface TaxonomyFilterValues {
+  region?: string[];
+  marketCapTier?: string[];
+  sector?: string[];
+  indexMemberships?: string[];
+  instrumentTypeDetail?: string[];
+  provider?: string[];
+  currency?: string[];
+  exchangeMics?: string[];
+  liquidityTier?: string[];
+}
+
+export interface TaxonomyPreset {
+  id: string;
+  label: string;
+  filter: TaxonomyFilterValues;
+}
+
+export interface ReviewQueueEntry {
+  symbol: string;
+  exchangeMic?: string;
+  capTier?: string;
+  sector?: string;
+  provider?: string;
+  failureCount: number;
+  firstFailedAt: string;
+  lastFailedAt: string;
+  reason: string;
+}
+
+interface ReviewQueueEntryAPI {
+  symbol: string;
+  exchange_mic?: string;
+  cap_tier?: string;
+  sector?: string;
+  provider?: string;
+  fetch_failure_count: number;
+  first_failed_at: string;
+  last_failed_at: string;
+  reason: string;
+}
+
+export function transformReviewEntry(api: ReviewQueueEntryAPI): ReviewQueueEntry {
+  return {
+    symbol: api.symbol,
+    exchangeMic: api.exchange_mic,
+    capTier: api.cap_tier,
+    sector: api.sector,
+    provider: api.provider,
+    failureCount: api.fetch_failure_count,
+    firstFailedAt: api.first_failed_at,
+    lastFailedAt: api.last_failed_at,
+    reason: api.reason,
+  };
+}
+
+interface TaxonomyPresetAPI {
+  id: string;
+  label: string;
+  filter: Record<string, string[] | undefined>;
+}
+
+export function transformPreset(api: TaxonomyPresetAPI): TaxonomyPreset {
+  const f = api.filter ?? {};
+  return {
+    id: api.id,
+    label: api.label,
+    filter: {
+      region: f.region,
+      marketCapTier: f.market_cap_tier,
+      sector: f.sector,
+      indexMemberships: f.index_memberships,
+      instrumentTypeDetail: f.instrument_type_detail,
+      provider: f.provider,
+      currency: f.currency,
+      exchangeMics: f.exchange_mics,
+      liquidityTier: f.liquidity_tier,
+    },
+  };
+}

--- a/web-ui/src/features/screener/api.ts
+++ b/web-ui/src/features/screener/api.ts
@@ -16,8 +16,9 @@ export async function fetchUniverses(): Promise<UniversesResponse> {
   });
 }
 
-export async function runScreener(request: ScreenerRequest): Promise<ScreenerResponse> {
-  const apiRequest = {
+export function toScreenerRequestPayload(request: ScreenerRequest): Record<string, unknown> {
+  const tf = request.taxonomyFilter;
+  return {
     universe: request.universe,
     tickers: request.tickers,
     top: request.top,
@@ -34,7 +35,23 @@ export async function runScreener(request: ScreenerRequest): Promise<ScreenerRes
     min_history: request.minHistory,
     require_weekly_uptrend: request.requireWeeklyUptrend,
     force_refresh: request.forceRefresh,
+    preset: request.preset,
+    taxonomy_filter: tf && {
+      region: tf.region,
+      market_cap_tier: tf.marketCapTier,
+      sector: tf.sector,
+      index_memberships: tf.indexMemberships,
+      instrument_type_detail: tf.instrumentTypeDetail,
+      provider: tf.provider,
+      currency: tf.currency,
+      exchange_mics: tf.exchangeMics,
+      liquidity_tier: tf.liquidityTier,
+    },
   };
+}
+
+export async function runScreener(request: ScreenerRequest): Promise<ScreenerResponse> {
+  const apiRequest = toScreenerRequestPayload(request);
 
   const res = await fetch(apiUrl(API_ENDPOINTS.screenerRun), {
     method: 'POST',

--- a/web-ui/src/features/screener/payload.test.ts
+++ b/web-ui/src/features/screener/payload.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { toScreenerRequestPayload } from './api';
+
+describe('toScreenerRequestPayload', () => {
+  it('serializes taxonomyFilter to snake_case and keeps preset', () => {
+    const payload = toScreenerRequestPayload({
+      top: 20,
+      taxonomyFilter: {
+        region: ['us'],
+        marketCapTier: ['large'],
+        indexMemberships: ['us_sp500'],
+        instrumentTypeDetail: ['equity'],
+      },
+      preset: 'us_large_cap_equities',
+    });
+    expect(payload.taxonomy_filter).toEqual({
+      region: ['us'],
+      market_cap_tier: ['large'],
+      sector: undefined,
+      index_memberships: ['us_sp500'],
+      instrument_type_detail: ['equity'],
+      provider: undefined,
+      currency: undefined,
+      exchange_mics: undefined,
+      liquidity_tier: undefined,
+    });
+    expect(payload.preset).toBe('us_large_cap_equities');
+  });
+
+  it('omits taxonomy_filter when not provided', () => {
+    const payload = toScreenerRequestPayload({ top: 10, forceRefresh: true });
+    expect(payload.taxonomy_filter).toBeUndefined();
+    expect(payload.force_refresh).toBe(true);
+    expect(payload.top).toBe(10);
+  });
+});

--- a/web-ui/src/features/screener/types.ts
+++ b/web-ui/src/features/screener/types.ts
@@ -1,6 +1,7 @@
 // Screener types
 
 import { Recommendation, RecommendationAPI, transformRecommendation } from '@/types/recommendation';
+import type { TaxonomyFilterValues } from '@/features/pool/types';
 
 export type SameSymbolMode = 'NEW_ENTRY' | 'ADD_ON' | 'MANAGE_ONLY' | 'RE_ENTRY' | 'SCALE_BACK';
 
@@ -331,6 +332,7 @@ export interface ScreenerCandidateAPI {
 }
 
 export interface ScreenerRequest {
+  /** @deprecated use taxonomyFilter; resolves to index-membership filter. */
   universe?: string;
   tickers?: string[];
   top?: number;
@@ -347,6 +349,8 @@ export interface ScreenerRequest {
   minHistory?: number;
   requireWeeklyUptrend?: boolean;
   forceRefresh?: boolean;
+  taxonomyFilter?: TaxonomyFilterValues;
+  preset?: string;
 }
 
 export interface ScreenerResponse {

--- a/web-ui/src/i18n/messages.en.ts
+++ b/web-ui/src/i18n/messages.en.ts
@@ -1187,6 +1187,37 @@ export const messagesEn = {
         etfs: 'ETFs',
       },
     },
+    taxonomy: {
+      preset: 'Preset',
+      presetPlaceholder: 'Choose a preset',
+      presetCustom: 'Custom',
+      region: {
+        label: 'Region',
+        us: 'US',
+        europe: 'Europe',
+        asiaPacific: 'Asia-Pac',
+      },
+      capTier: {
+        label: 'Cap',
+        large: 'Large',
+        mid: 'Mid',
+        small: 'Small',
+        micro: 'Micro',
+      },
+      type: {
+        label: 'Type',
+        equity: 'Equity',
+        etf: 'ETF',
+      },
+      sector: {
+        label: 'Sector',
+        placeholder: 'All sectors',
+      },
+      index: {
+        label: 'Index',
+        placeholder: 'Any index',
+      },
+    },
     universe: {
       freshness: {
         fresh: 'Fresh',

--- a/web-ui/src/lib/api.ts
+++ b/web-ui/src/lib/api.ts
@@ -17,6 +17,12 @@ export const API_ENDPOINTS = {
   screenerRun: '/api/screener/run',
   screenerRunStatus: (jobId: string) => `/api/screener/run/${jobId}`,
 
+  // Symbol pool
+  poolPresets: '/api/pool/presets',
+  poolReviewQueue: '/api/pool/review-queue',
+  poolReviewQueueRemove: (s: string) => `/api/pool/review-queue/${encodeURIComponent(s)}/remove`,
+  poolReviewQueueRestore: (s: string) => `/api/pool/review-queue/${encodeURIComponent(s)}/restore`,
+
   // Backtest
   backtestEventStudy: '/api/backtest/event-study',
   backtestEventStudyStatus: (jobId: string) => `/api/backtest/event-study/${jobId}`,

--- a/web-ui/src/lib/queryKeys.ts
+++ b/web-ui/src/lib/queryKeys.ts
@@ -9,6 +9,8 @@ export const queryKeys = {
     payloadHash == null ? (['strategy-validation'] as const) : (['strategy-validation', payloadHash] as const),
   universes: () => ['universes'] as const,
   universeDetail: (id?: string | null) => ['universe-detail', id ?? null] as const,
+  taxonomyPresets: () => ['taxonomy-presets'] as const,
+  reviewQueue: () => ['review-queue'] as const,
   dailyReview: (topN: number, universe?: string | null) => ['dailyReview', topN, universe ?? null] as const,
   orders: (status?: OrderFilterStatus) =>
     status == null ? (['orders'] as const) : (['orders', status] as const),

--- a/web-ui/src/test/mocks/handlers.ts
+++ b/web-ui/src/test/mocks/handlers.ts
@@ -518,6 +518,31 @@ export function resetMockApiState(): void {
 
 // MSW request handlers
 export const handlers = [
+  // Symbol pool endpoints
+  http.get(`${API_BASE_URL}/api/pool/presets`, () => {
+    return HttpResponse.json({
+      presets: [
+        {
+          id: 'us_large_cap_equities',
+          label: 'US Large Cap Equities',
+          filter: { region: ['us'], market_cap_tier: ['large'], instrument_type_detail: ['equity'] },
+        },
+      ],
+    })
+  }),
+
+  http.get(`${API_BASE_URL}/api/pool/review-queue`, () => {
+    return HttpResponse.json({ entries: [] })
+  }),
+
+  http.post(`${API_BASE_URL}/api/pool/review-queue/:symbol/remove`, () => {
+    return HttpResponse.json({ removed: true })
+  }),
+
+  http.post(`${API_BASE_URL}/api/pool/review-queue/:symbol/restore`, () => {
+    return HttpResponse.json({ restored: true })
+  }),
+
   // Config endpoints
   http.get(`${API_BASE_URL}/api/config`, () => {
     return HttpResponse.json(mockConfig)


### PR DESCRIPTION
The screener no longer picks one universe at a time. `QuickFilterBar` sits above the candidates table with a preset selector and region / cap / type chip groups plus sector / index multi-selects, driving a `taxonomyFilter` + `preset` on the screener request. `ScreenerForm` drops the universe `<Select>` and the instrument selector; currency, venue, OTC and price stay in the collapsible panel. `ScreenerInboxPanel` owns `taxonomyFilter`/`presetId` (localStorage) and sends `taxonomy_filter`/`preset` instead of `universe`.

New `web-ui/src/features/pool/` carries the pool types, api client, React Query hooks (`usePresets`, `useReviewQueue`, `useRemoveFromPool`, `useRestoreToPool`) and the static sector/index option lists. Currency and venue keep their existing enum controls and ride the legacy top-level fields, which the backend maps onto the taxonomy spec.

This branch also ships the enriched `data/symbol_pool.json` (the #382 merge dropped the generated artifact) and fixes `enrich_pool_taxonomy` to read `get_ticker_info`'s `market_cap` key. Sector / market-cap tier / instrument-type detail are now populated for ~815/1538 symbols (US and Western Europe; Asian index members lack yfinance `.info`). `data/README.md` documents the build + enrich runbook.