### PR TITLE
Remove dead universe-selection code

### DIFF
--- a/api/services/screener_service.py
+++ b/api/services/screener_service.py
@@ -91,49 +91,6 @@ from swing_screener.selection.screening_window import (
     resolve_fetch_start_date,
 )
 
-# Map of removed universe ids to their replacements (or None if dropped with no replacement).
-_REMOVED_UNIVERSE_IDS: dict[str, str | None] = {
-    "usd_all": "broad_market_stocks",
-    "mega": "broad_market_stocks",
-    "mega_all": "broad_market_stocks",
-    "eur_all": None,
-    "usd_mega_stocks": "broad_market_stocks",
-    "mega_stocks": "broad_market_stocks",
-    "usd_core_etfs": "broad_market_etfs",
-    "core_etfs": "broad_market_etfs",
-    "usd_defense_all": "defense_stocks",
-    "defense_all": "defense_stocks",
-    "mega_defense": "defense_stocks",
-    "usd_defense_stocks": "defense_stocks",
-    "defense_stocks": "defense_stocks",
-    "usd_defense_etfs": "defense_etfs",
-    "defense_etfs": "defense_etfs",
-    "usd_healthcare_all": "healthcare_stocks",
-    "healthcare_all": "healthcare_stocks",
-    "mega_healthcare_biotech": "healthcare_stocks",
-    "usd_healthcare_stocks": "healthcare_stocks",
-    "healthcare_stocks": "healthcare_stocks",
-    "usd_healthcare_etfs": "healthcare_etfs",
-    "healthcare_etfs": "healthcare_etfs",
-    "eur_europe_large": "europe_large_caps",
-    "europe_large": "europe_large_caps",
-    "mega_europe": "europe_large_caps",
-    "usd_europe_large": "global_proxy_stocks",
-    "eur_amsterdam_all": "amsterdam_all",
-    "eur_amsterdam_aex": "amsterdam_aex",
-    "eur_amsterdam_amx": "amsterdam_amx",
-    "us_all": "broad_market_stocks",
-    "us_mega_stocks": "broad_market_stocks",
-    "us_core_etfs": "broad_market_etfs",
-    "us_defense_all": "defense_stocks",
-    "us_defense_stocks": "defense_stocks",
-    "us_defense_etfs": "defense_etfs",
-    "us_healthcare_all": "healthcare_stocks",
-    "us_healthcare_stocks": "healthcare_stocks",
-    "us_healthcare_etfs": "healthcare_etfs",
-    "europe_large_eur": "europe_large_caps",
-    "europe_proxies_usd": "global_proxy_stocks",
-}
 from api.services.screener_run_manager import get_screener_run_manager
 
 logger = logging.getLogger(__name__)
@@ -342,7 +299,8 @@ class ScreenerService:
 
         Returns requested_top. Populates ctx.universe_cfg, benchmark, tickers,
         screening_tickers, active_currencies, asof_str, market_health, now_utc,
-        warnings. Raises UnprocessableError/NotFoundError exactly as before.
+        warnings. Raises UnprocessableError on a non-positive top and
+        NotFoundError when no tickers survive the taxonomy pre-filter.
         """
         request = ctx.request
         requested_top = request.top or 20

--- a/web-ui/src/components/domain/workspace/AnalysisCanvasPanel.test.tsx
+++ b/web-ui/src/components/domain/workspace/AnalysisCanvasPanel.test.tsx
@@ -30,7 +30,6 @@ vi.mock('@/features/intelligence/catalysts/hooks', () => ({
 }));
 
 vi.mock('@/features/screener/hooks', () => ({
-  useUniverses: vi.fn(),
   useRunScreenerMutation: vi.fn(),
 }));
 

--- a/web-ui/src/features/screener/api.ts
+++ b/web-ui/src/features/screener/api.ts
@@ -7,15 +7,8 @@ import {
   ScreenerRunStatusResponseAPI,
   ScreenerResponse,
   ScreenerResponseAPI,
-  UniversesResponse,
   transformScreenerResponse,
 } from './types';
-
-export async function fetchUniverses(): Promise<UniversesResponse> {
-  return fetchJson<UniversesResponse>(API_ENDPOINTS.universes, {
-    errorMessage: 'Failed to fetch universes',
-  });
-}
 
 export function toScreenerRequestPayload(request: ScreenerRequest): Record<string, unknown> {
   const tf = request.taxonomyFilter;

--- a/web-ui/src/features/screener/hooks.ts
+++ b/web-ui/src/features/screener/hooks.ts
@@ -1,16 +1,9 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
-import { fetchUniverses, runScreener } from './api';
+import { runScreener } from './api';
 import { ScreenerRequest, ScreenerResponse, PriceHistoryPoint, CandlePattern, transformCandlePattern } from './types';
 import { queryKeys } from '@/lib/queryKeys';
 import { API_ENDPOINTS } from '@/lib/api';
 import { fetchJson } from '@/lib/fetchJson';
-
-export function useUniverses() {
-  return useQuery({
-    queryKey: queryKeys.universes(),
-    queryFn: fetchUniverses,
-  });
-}
 
 export function useRunScreenerMutation(
   onSuccess?: (data: ScreenerResponse) => void,


### PR DESCRIPTION
Dead-code cleanup left over from the taxonomy symbol-pool migration. No behavior change.

- Drop the orphaned `useUniverses` hook (`features/screener/hooks.ts`) and `fetchUniverses` client (`features/screener/api.ts`). The Universes management page uses `useUniverseCatalog`/`fetchUniverseCatalog`, so these had no live callers; the `UniversesResponse` type stays (still used by `features/universes/api.ts`).
- Remove the `_REMOVED_UNIVERSE_IDS` map in `screener_service.py` (defined, never read after the universe-validation path was deleted). This also clears the long-standing `E402` on the `screener_run_manager` import that followed it.
- Drop the stale `useUniverses` entry from the `AnalysisCanvasPanel` test mock.
- Fix the `_resolve_universe_and_window` docstring that still claimed it raised the old `UnprocessableError` universe-validation error.

Deliberately untouched: `load_universe_from_package`/`load_universe_from_file` (public `swing_screener.data` API, ~12 tests, docs), the universe registry/snapshots + instrument master (the symbol pool is built from them), `get_universe_benchmark`/`filter_tickers_by_metadata`/`get_instrument_record`, `queryKeys.universes()`, `migrateRemovedUniverseIds` (still runs in `App.tsx`), and the Universes management page + its `/api/universes` endpoints.
