### PR TITLE
chore: refresh symbol pool, instrument master, and universe snapshots

### DIFF
--- a/data/intelligence/instrument_master.json
+++ b/data/intelligence/instrument_master.json
@@ -936,6 +936,24 @@
     "instrument_type": "equity"
   },
   {
+    "symbol": "000990.KS",
+    "exchange_mic": "XKRX",
+    "country_code": "KR",
+    "currency": "KRW",
+    "timezone": "Asia/Seoul",
+    "provider_symbol_map": {
+      "yahoo_finance": "000990.KS"
+    },
+    "primary_listing": true,
+    "status": "active",
+    "status_reason": null,
+    "replacement_symbol": null,
+    "source": "wikipedia_yfinance",
+    "source_asof": "2026-06-30",
+    "last_reviewed_at": "2026-06-30",
+    "instrument_type": "equity"
+  },
+  {
     "symbol": "000999.SZ",
     "exchange_mic": "XSHE",
     "country_code": "CN",
@@ -5778,6 +5796,24 @@
     "instrument_type": "equity"
   },
   {
+    "symbol": "267270.KS",
+    "exchange_mic": "XKRX",
+    "country_code": "KR",
+    "currency": "KRW",
+    "timezone": "Asia/Seoul",
+    "provider_symbol_map": {
+      "yahoo_finance": "267270.KS"
+    },
+    "primary_listing": true,
+    "status": "active",
+    "status_reason": null,
+    "replacement_symbol": null,
+    "source": "wikipedia_yfinance",
+    "source_asof": "2026-06-30",
+    "last_reviewed_at": "2026-06-30",
+    "instrument_type": "equity"
+  },
+  {
     "symbol": "268280.KS",
     "exchange_mic": "XKRX",
     "country_code": "KR",
@@ -6966,6 +7002,24 @@
     "instrument_type": "equity"
   },
   {
+    "symbol": "456040.KS",
+    "exchange_mic": "XKRX",
+    "country_code": "KR",
+    "currency": "KRW",
+    "timezone": "Asia/Seoul",
+    "provider_symbol_map": {
+      "yahoo_finance": "456040.KS"
+    },
+    "primary_listing": true,
+    "status": "active",
+    "status_reason": null,
+    "replacement_symbol": null,
+    "source": "wikipedia_yfinance",
+    "source_asof": "2026-06-30",
+    "last_reviewed_at": "2026-06-30",
+    "instrument_type": "equity"
+  },
+  {
     "symbol": "457190.KS",
     "exchange_mic": "XKRX",
     "country_code": "KR",
@@ -6981,6 +7035,24 @@
     "source": "wikipedia_yfinance",
     "source_asof": "2026-06-18",
     "last_reviewed_at": "2026-06-18",
+    "instrument_type": "equity"
+  },
+  {
+    "symbol": "483650.KS",
+    "exchange_mic": "XKRX",
+    "country_code": "KR",
+    "currency": "KRW",
+    "timezone": "Asia/Seoul",
+    "provider_symbol_map": {
+      "yahoo_finance": "483650.KS"
+    },
+    "primary_listing": true,
+    "status": "active",
+    "status_reason": null,
+    "replacement_symbol": null,
+    "source": "wikipedia_yfinance",
+    "source_asof": "2026-06-30",
+    "last_reviewed_at": "2026-06-30",
     "instrument_type": "equity"
   },
   {
@@ -10629,6 +10701,24 @@
     "instrument_type": "equity"
   },
   {
+    "symbol": "ABDN.L",
+    "exchange_mic": "XLON",
+    "country_code": "GB",
+    "currency": "GBP",
+    "timezone": "Europe/London",
+    "provider_symbol_map": {
+      "yahoo_finance": "ABDN.L"
+    },
+    "primary_listing": true,
+    "status": "active",
+    "status_reason": null,
+    "replacement_symbol": null,
+    "source": "wikipedia_yfinance",
+    "source_asof": "2026-06-30",
+    "last_reviewed_at": "2026-06-30",
+    "instrument_type": "equity"
+  },
+  {
     "symbol": "ABEV",
     "exchange_mic": "XOTC",
     "country_code": "US",
@@ -11278,6 +11368,24 @@
     "source": "manual",
     "source_asof": "2026-04-11",
     "last_reviewed_at": "2026-04-11",
+    "instrument_type": "equity"
+  },
+  {
+    "symbol": "ALAB",
+    "exchange_mic": "XNAS",
+    "country_code": "US",
+    "currency": "USD",
+    "timezone": "America/New_York",
+    "provider_symbol_map": {
+      "yahoo_finance": "ALAB"
+    },
+    "primary_listing": true,
+    "status": "active",
+    "status_reason": null,
+    "replacement_symbol": null,
+    "source": "wikipedia_yfinance",
+    "source_asof": "2026-06-30",
+    "last_reviewed_at": "2026-06-30",
     "instrument_type": "equity"
   },
   {
@@ -13890,6 +13998,24 @@
     "instrument_type": "equity"
   },
   {
+    "symbol": "CCC.L",
+    "exchange_mic": "XLON",
+    "country_code": "GB",
+    "currency": "GBP",
+    "timezone": "Europe/London",
+    "provider_symbol_map": {
+      "yahoo_finance": "CCC.L"
+    },
+    "primary_listing": true,
+    "status": "active",
+    "status_reason": null,
+    "replacement_symbol": null,
+    "source": "wikipedia_yfinance",
+    "source_asof": "2026-06-30",
+    "last_reviewed_at": "2026-06-30",
+    "instrument_type": "equity"
+  },
+  {
     "symbol": "CCEP",
     "exchange_mic": "XNAS",
     "country_code": "US",
@@ -14875,6 +15001,24 @@
     "source": "manual",
     "source_asof": "2026-04-11",
     "last_reviewed_at": "2026-04-11",
+    "instrument_type": "equity"
+  },
+  {
+    "symbol": "CRWV",
+    "exchange_mic": "XNAS",
+    "country_code": "US",
+    "currency": "USD",
+    "timezone": "America/New_York",
+    "provider_symbol_map": {
+      "yahoo_finance": "CRWV"
+    },
+    "primary_listing": true,
+    "status": "active",
+    "status_reason": null,
+    "replacement_symbol": null,
+    "source": "wikipedia_yfinance",
+    "source_asof": "2026-06-30",
+    "last_reviewed_at": "2026-06-30",
     "instrument_type": "equity"
   },
   {
@@ -16039,6 +16183,24 @@
     "source": "wikipedia_yfinance",
     "source_asof": "2026-06-13",
     "last_reviewed_at": "2026-06-13",
+    "instrument_type": "equity"
+  },
+  {
+    "symbol": "ECHO",
+    "exchange_mic": "XNAS",
+    "country_code": "US",
+    "currency": "USD",
+    "timezone": "America/New_York",
+    "provider_symbol_map": {
+      "yahoo_finance": "ECHO"
+    },
+    "primary_listing": true,
+    "status": "active",
+    "status_reason": null,
+    "replacement_symbol": null,
+    "source": "wikipedia_yfinance",
+    "source_asof": "2026-06-30",
+    "last_reviewed_at": "2026-06-30",
     "instrument_type": "equity"
   },
   {
@@ -17290,6 +17452,24 @@
     "source": "wikipedia_yfinance",
     "source_asof": "2026-06-13",
     "last_reviewed_at": "2026-06-13",
+    "instrument_type": "equity"
+  },
+  {
+    "symbol": "FLEX",
+    "exchange_mic": "XNAS",
+    "country_code": "US",
+    "currency": "USD",
+    "timezone": "America/New_York",
+    "provider_symbol_map": {
+      "yahoo_finance": "FLEX"
+    },
+    "primary_listing": true,
+    "status": "active",
+    "status_reason": null,
+    "replacement_symbol": null,
+    "source": "wikipedia_yfinance",
+    "source_asof": "2026-06-30",
+    "last_reviewed_at": "2026-06-30",
     "instrument_type": "equity"
   },
   {
@@ -18572,6 +18752,24 @@
     "instrument_type": "equity"
   },
   {
+    "symbol": "HONA",
+    "exchange_mic": "XNAS",
+    "country_code": "US",
+    "currency": "USD",
+    "timezone": "America/New_York",
+    "provider_symbol_map": {
+      "yahoo_finance": "HONA"
+    },
+    "primary_listing": true,
+    "status": "active",
+    "status_reason": null,
+    "replacement_symbol": null,
+    "source": "wikipedia_yfinance",
+    "source_asof": "2026-06-30",
+    "last_reviewed_at": "2026-06-30",
+    "instrument_type": "equity"
+  },
+  {
     "symbol": "HOOD",
     "exchange_mic": "XNAS",
     "country_code": "US",
@@ -19454,6 +19652,24 @@
     "source": "wikipedia_yfinance",
     "source_asof": "2026-06-13",
     "last_reviewed_at": "2026-06-13",
+    "instrument_type": "equity"
+  },
+  {
+    "symbol": "INVP.L",
+    "exchange_mic": "XLON",
+    "country_code": "GB",
+    "currency": "GBP",
+    "timezone": "Europe/London",
+    "provider_symbol_map": {
+      "yahoo_finance": "INVP.L"
+    },
+    "primary_listing": true,
+    "status": "active",
+    "status_reason": null,
+    "replacement_symbol": null,
+    "source": "wikipedia_yfinance",
+    "source_asof": "2026-06-30",
+    "last_reviewed_at": "2026-06-30",
     "instrument_type": "equity"
   },
   {
@@ -21938,6 +22154,24 @@
     "source": "manual",
     "source_asof": "2026-04-11",
     "last_reviewed_at": "2026-04-11",
+    "instrument_type": "equity"
+  },
+  {
+    "symbol": "NBIS",
+    "exchange_mic": "XNAS",
+    "country_code": "US",
+    "currency": "USD",
+    "timezone": "America/New_York",
+    "provider_symbol_map": {
+      "yahoo_finance": "NBIS"
+    },
+    "primary_listing": true,
+    "status": "active",
+    "status_reason": null,
+    "replacement_symbol": null,
+    "source": "wikipedia_yfinance",
+    "source_asof": "2026-06-30",
+    "last_reviewed_at": "2026-06-30",
     "instrument_type": "equity"
   },
   {

--- a/data/symbol_pool.json
+++ b/data/symbol_pool.json
@@ -1873,6 +1873,7 @@
       "industry": "Internet Content & Information",
       "index_memberships": [
         "broad_market_stocks",
+        "us_dow30",
         "us_nasdaq100",
         "us_sp500"
       ],
@@ -3234,7 +3235,6 @@
       "industry": "Telecom Services",
       "index_memberships": [
         "broad_market_stocks",
-        "us_dow30",
         "us_sp500"
       ],
       "liquidity_tier": null,
@@ -12430,7 +12430,8 @@
       "sector": "Industrials",
       "industry": "Aerospace & Defense",
       "index_memberships": [
-        "defense_stocks"
+        "defense_stocks",
+        "us_nasdaq100"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
@@ -15471,8 +15472,7 @@
       "sector": "Healthcare",
       "industry": "Biotechnology",
       "index_memberships": [
-        "healthcare_stocks",
-        "us_nasdaq100"
+        "healthcare_stocks"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
@@ -18862,6 +18862,28 @@
       "last_fetch_ok_at": null
     },
     {
+      "symbol": "483650.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
       "symbol": "001680.KS",
       "exchange_mic": "XKRX",
       "currency": "KRW",
@@ -18946,6 +18968,28 @@
       ],
       "primary_provider": "yfinance",
       "taxonomy_refreshed_at": "2026-06-30",
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "000990.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -19302,28 +19346,6 @@
       "last_fetch_ok_at": null
     },
     {
-      "symbol": "114090.KS",
-      "exchange_mic": "XKRX",
-      "currency": "KRW",
-      "region": "asia_pacific",
-      "market_cap_tier": "large",
-      "sector": "Consumer Cyclical",
-      "industry": "Resorts & Casinos",
-      "index_memberships": [
-        "korea_kospi200"
-      ],
-      "liquidity_tier": null,
-      "instrument_type": "equity",
-      "instrument_type_detail": "equity",
-      "available_providers": [
-        "yfinance"
-      ],
-      "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": "2026-06-30",
-      "fetch_failure_count": 0,
-      "last_fetch_ok_at": null
-    },
-    {
       "symbol": "006280.KS",
       "exchange_mic": "XKRX",
       "currency": "KRW",
@@ -19331,28 +19353,6 @@
       "market_cap_tier": "large",
       "sector": "Healthcare",
       "industry": "Drug Manufacturers - Specialty & Generic",
-      "index_memberships": [
-        "korea_kospi200"
-      ],
-      "liquidity_tier": null,
-      "instrument_type": "equity",
-      "instrument_type_detail": "equity",
-      "available_providers": [
-        "yfinance"
-      ],
-      "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": "2026-06-30",
-      "fetch_failure_count": 0,
-      "last_fetch_ok_at": null
-    },
-    {
-      "symbol": "005250.KS",
-      "exchange_mic": "XKRX",
-      "currency": "KRW",
-      "region": "asia_pacific",
-      "market_cap_tier": "large",
-      "sector": "Healthcare",
-      "industry": "Biotechnology",
       "index_memberships": [
         "korea_kospi200"
       ],
@@ -19386,28 +19386,6 @@
       ],
       "primary_provider": "yfinance",
       "taxonomy_refreshed_at": "2026-06-30",
-      "fetch_failure_count": 0,
-      "last_fetch_ok_at": null
-    },
-    {
-      "symbol": "006360.KS",
-      "exchange_mic": "XKRX",
-      "currency": "KRW",
-      "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
-      "index_memberships": [
-        "korea_kospi200"
-      ],
-      "liquidity_tier": null,
-      "instrument_type": "equity",
-      "instrument_type_detail": null,
-      "available_providers": [
-        "yfinance"
-      ],
-      "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
       "fetch_failure_count": 0,
       "last_fetch_ok_at": null
     },
@@ -19831,6 +19809,28 @@
     },
     {
       "symbol": "272210.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "267270.KS",
       "exchange_mic": "XKRX",
       "currency": "KRW",
       "region": "asia_pacific",
@@ -21722,6 +21722,28 @@
       "last_fetch_ok_at": null
     },
     {
+      "symbol": "456040.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "region": "asia_pacific",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "korea_kospi200"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
       "symbol": "010060.KS",
       "exchange_mic": "XKRX",
       "currency": "KRW",
@@ -22361,28 +22383,6 @@
     },
     {
       "symbol": "003030.KS",
-      "exchange_mic": "XKRX",
-      "currency": "KRW",
-      "region": "asia_pacific",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
-      "index_memberships": [
-        "korea_kospi200"
-      ],
-      "liquidity_tier": null,
-      "instrument_type": "equity",
-      "instrument_type_detail": null,
-      "available_providers": [
-        "yfinance"
-      ],
-      "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
-      "fetch_failure_count": 0,
-      "last_fetch_ok_at": null
-    },
-    {
-      "symbol": "004490.KS",
       "exchange_mic": "XKRX",
       "currency": "KRW",
       "region": "asia_pacific",
@@ -23570,6 +23570,28 @@
       "last_fetch_ok_at": null
     },
     {
+      "symbol": "ABDN.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
       "symbol": "ADM.L",
       "exchange_mic": "XLON",
       "currency": "GBP",
@@ -23878,28 +23900,6 @@
       "last_fetch_ok_at": null
     },
     {
-      "symbol": "BKG.L",
-      "exchange_mic": "XLON",
-      "currency": "GBP",
-      "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
-      "index_memberships": [
-        "uk_ftse100"
-      ],
-      "liquidity_tier": null,
-      "instrument_type": "equity",
-      "instrument_type_detail": null,
-      "available_providers": [
-        "yfinance"
-      ],
-      "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
-      "fetch_failure_count": 0,
-      "last_fetch_ok_at": null
-    },
-    {
       "symbol": "BP.L",
       "exchange_mic": "XLON",
       "currency": "GBP",
@@ -24101,6 +24101,28 @@
       "symbol": "CPG.L",
       "exchange_mic": "XLON",
       "currency": "USD",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CCC.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
       "region": "europe",
       "market_cap_tier": null,
       "sector": null,
@@ -24692,6 +24714,28 @@
       "last_fetch_ok_at": null
     },
     {
+      "symbol": "INVP.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "region": "europe",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "uk_ftse100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
       "symbol": "JD.L",
       "exchange_mic": "XLON",
       "currency": "GBP",
@@ -24956,28 +25000,6 @@
       "last_fetch_ok_at": null
     },
     {
-      "symbol": "MNDI.L",
-      "exchange_mic": "XLON",
-      "currency": "GBP",
-      "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
-      "index_memberships": [
-        "uk_ftse100"
-      ],
-      "liquidity_tier": null,
-      "instrument_type": "equity",
-      "instrument_type_detail": null,
-      "available_providers": [
-        "yfinance"
-      ],
-      "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
-      "fetch_failure_count": 0,
-      "last_fetch_ok_at": null
-    },
-    {
       "symbol": "NG.L",
       "exchange_mic": "XLON",
       "currency": "GBP",
@@ -25199,28 +25221,6 @@
     },
     {
       "symbol": "RTO.L",
-      "exchange_mic": "XLON",
-      "currency": "GBP",
-      "region": "europe",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
-      "index_memberships": [
-        "uk_ftse100"
-      ],
-      "liquidity_tier": null,
-      "instrument_type": "equity",
-      "instrument_type_detail": null,
-      "available_providers": [
-        "yfinance"
-      ],
-      "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
-      "fetch_failure_count": 0,
-      "last_fetch_ok_at": null
-    },
-    {
-      "symbol": "RMV.L",
       "exchange_mic": "XLON",
       "currency": "GBP",
       "region": "europe",
@@ -25908,6 +25908,28 @@
       "last_fetch_ok_at": null
     },
     {
+      "symbol": "ALAB",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
       "symbol": "ADSK",
       "exchange_mic": "XNAS",
       "currency": "USD",
@@ -26000,29 +26022,6 @@
       "last_fetch_ok_at": null
     },
     {
-      "symbol": "CHTR",
-      "exchange_mic": "XNAS",
-      "currency": "USD",
-      "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
-      "index_memberships": [
-        "us_nasdaq100",
-        "us_sp500"
-      ],
-      "liquidity_tier": null,
-      "instrument_type": "equity",
-      "instrument_type_detail": null,
-      "available_providers": [
-        "yfinance"
-      ],
-      "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
-      "fetch_failure_count": 0,
-      "last_fetch_ok_at": null
-    },
-    {
       "symbol": "CTAS",
       "exchange_mic": "XNAS",
       "currency": "USD",
@@ -26055,29 +26054,6 @@
       "industry": null,
       "index_memberships": [
         "us_nasdaq100"
-      ],
-      "liquidity_tier": null,
-      "instrument_type": "equity",
-      "instrument_type_detail": null,
-      "available_providers": [
-        "yfinance"
-      ],
-      "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
-      "fetch_failure_count": 0,
-      "last_fetch_ok_at": null
-    },
-    {
-      "symbol": "CTSH",
-      "exchange_mic": "XNAS",
-      "currency": "USD",
-      "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
-      "index_memberships": [
-        "us_nasdaq100",
-        "us_sp500"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
@@ -26124,6 +26100,28 @@
       "index_memberships": [
         "us_nasdaq100",
         "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "CRWV",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
@@ -26512,7 +26510,8 @@
       "sector": null,
       "industry": null,
       "index_memberships": [
-        "us_nasdaq100"
+        "us_nasdaq100",
+        "us_sp500"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
@@ -26627,6 +26626,28 @@
       "index_memberships": [
         "us_nasdaq100",
         "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "NBIS",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_nasdaq100"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
@@ -26938,7 +26959,7 @@
       "last_fetch_ok_at": null
     },
     {
-      "symbol": "TRI",
+      "symbol": "TER",
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
@@ -26946,7 +26967,8 @@
       "sector": null,
       "industry": null,
       "index_memberships": [
-        "us_nasdaq100"
+        "us_nasdaq100",
+        "us_sp500"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
@@ -26960,7 +26982,7 @@
       "last_fetch_ok_at": null
     },
     {
-      "symbol": "VRSK",
+      "symbol": "TRI",
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
@@ -26968,8 +26990,7 @@
       "sector": null,
       "industry": null,
       "index_memberships": [
-        "us_nasdaq100",
-        "us_sp500"
+        "us_nasdaq100"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
@@ -27062,28 +27083,6 @@
       "index_memberships": [
         "us_nasdaq100",
         "us_sp500"
-      ],
-      "liquidity_tier": null,
-      "instrument_type": "equity",
-      "instrument_type_detail": null,
-      "available_providers": [
-        "yfinance"
-      ],
-      "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
-      "fetch_failure_count": 0,
-      "last_fetch_ok_at": null
-    },
-    {
-      "symbol": "ZS",
-      "exchange_mic": "XNAS",
-      "currency": "USD",
-      "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
-      "index_memberships": [
-        "us_nasdaq100"
       ],
       "liquidity_tier": null,
       "instrument_type": "equity",
@@ -28197,28 +28196,6 @@
       "last_fetch_ok_at": null
     },
     {
-      "symbol": "CPB",
-      "exchange_mic": "XNAS",
-      "currency": "USD",
-      "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
-      "index_memberships": [
-        "us_sp500"
-      ],
-      "liquidity_tier": null,
-      "instrument_type": "equity",
-      "instrument_type_detail": null,
-      "available_providers": [
-        "yfinance"
-      ],
-      "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
-      "fetch_failure_count": 0,
-      "last_fetch_ok_at": null
-    },
-    {
       "symbol": "COF",
       "exchange_mic": "XNYS",
       "currency": "USD",
@@ -28483,6 +28460,28 @@
       "last_fetch_ok_at": null
     },
     {
+      "symbol": "CHTR",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
       "symbol": "CMG",
       "exchange_mic": "XNYS",
       "currency": "USD",
@@ -28703,6 +28702,28 @@
       "last_fetch_ok_at": null
     },
     {
+      "symbol": "CTSH",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
       "symbol": "COHR",
       "exchange_mic": "XNYS",
       "currency": "USD",
@@ -28770,28 +28791,6 @@
     },
     {
       "symbol": "FIX",
-      "exchange_mic": "XNYS",
-      "currency": "USD",
-      "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
-      "index_memberships": [
-        "us_sp500"
-      ],
-      "liquidity_tier": null,
-      "instrument_type": "equity",
-      "instrument_type_detail": null,
-      "available_providers": [
-        "yfinance"
-      ],
-      "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
-      "fetch_failure_count": 0,
-      "last_fetch_ok_at": null
-    },
-    {
-      "symbol": "CAG",
       "exchange_mic": "XNYS",
       "currency": "USD",
       "region": "us",
@@ -29473,7 +29472,7 @@
       "last_fetch_ok_at": null
     },
     {
-      "symbol": "SATS",
+      "symbol": "ECHO",
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
@@ -30177,6 +30176,28 @@
       "last_fetch_ok_at": null
     },
     {
+      "symbol": "FLEX",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
       "symbol": "F",
       "exchange_mic": "XNYS",
       "currency": "USD",
@@ -30707,6 +30728,28 @@
     {
       "symbol": "HLT",
       "exchange_mic": "XNYS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "HONA",
+      "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",
       "market_cap_tier": null,
@@ -32465,28 +32508,6 @@
       "last_fetch_ok_at": null
     },
     {
-      "symbol": "POOL",
-      "exchange_mic": "XNAS",
-      "currency": "USD",
-      "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
-      "index_memberships": [
-        "us_sp500"
-      ],
-      "liquidity_tier": null,
-      "instrument_type": "equity",
-      "instrument_type_detail": null,
-      "available_providers": [
-        "yfinance"
-      ],
-      "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
-      "fetch_failure_count": 0,
-      "last_fetch_ok_at": null
-    },
-    {
       "symbol": "PPG",
       "exchange_mic": "XNYS",
       "currency": "USD",
@@ -33455,28 +33476,6 @@
       "last_fetch_ok_at": null
     },
     {
-      "symbol": "TER",
-      "exchange_mic": "XNAS",
-      "currency": "USD",
-      "region": "us",
-      "market_cap_tier": null,
-      "sector": null,
-      "industry": null,
-      "index_memberships": [
-        "us_sp500"
-      ],
-      "liquidity_tier": null,
-      "instrument_type": "equity",
-      "instrument_type_detail": null,
-      "available_providers": [
-        "yfinance"
-      ],
-      "primary_provider": "yfinance",
-      "taxonomy_refreshed_at": null,
-      "fetch_failure_count": 0,
-      "last_fetch_ok_at": null
-    },
-    {
       "symbol": "TPL",
       "exchange_mic": "XNYS",
       "currency": "USD",
@@ -33896,6 +33895,28 @@
     },
     {
       "symbol": "VRSN",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "region": "us",
+      "market_cap_tier": null,
+      "sector": null,
+      "industry": null,
+      "index_memberships": [
+        "us_sp500"
+      ],
+      "liquidity_tier": null,
+      "instrument_type": "equity",
+      "instrument_type_detail": null,
+      "available_providers": [
+        "yfinance"
+      ],
+      "primary_provider": "yfinance",
+      "taxonomy_refreshed_at": null,
+      "fetch_failure_count": 0,
+      "last_fetch_ok_at": null
+    },
+    {
+      "symbol": "VRSK",
       "exchange_mic": "XNAS",
       "currency": "USD",
       "region": "us",

--- a/src/swing_screener/data/universes/registry/snapshots/korea_kospi200.json
+++ b/src/swing_screener/data/universes/registry/snapshots/korea_kospi200.json
@@ -5,8 +5,8 @@
   "benchmark": "^KS11",
   "source": "wikipedia",
   "source_adapter": "wikipedia_index_review",
-  "source_asof": "2026-06-18",
-  "last_reviewed_at": "2026-06-18",
+  "source_asof": "2026-06-30",
+  "last_reviewed_at": "2026-06-30",
   "stale_after_days": 100,
   "rules": {
     "exchange_mics": [
@@ -130,6 +130,13 @@
       "source_symbol": "112610"
     },
     {
+      "symbol": "483650.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "source_name": "d'Alba Global",
+      "source_symbol": "483650"
+    },
+    {
       "symbol": "001680.KS",
       "exchange_mic": "XKRX",
       "currency": "KRW",
@@ -156,6 +163,13 @@
       "currency": "KRW",
       "source_name": "Daewoong Pharmaceutical",
       "source_symbol": "069620"
+    },
+    {
+      "symbol": "000990.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "source_name": "DB HiTek",
+      "source_symbol": "000990"
     },
     {
       "symbol": "005830.KS",
@@ -270,13 +284,6 @@
       "source_symbol": "093370"
     },
     {
-      "symbol": "114090.KS",
-      "exchange_mic": "XKRX",
-      "currency": "KRW",
-      "source_name": "Grand Korea Leisure",
-      "source_symbol": "114090"
-    },
-    {
       "symbol": "006280.KS",
       "exchange_mic": "XKRX",
       "currency": "KRW",
@@ -284,25 +291,11 @@
       "source_symbol": "006280"
     },
     {
-      "symbol": "005250.KS",
-      "exchange_mic": "XKRX",
-      "currency": "KRW",
-      "source_name": "Green Cross Holdings",
-      "source_symbol": "005250"
-    },
-    {
       "symbol": "078930.KS",
       "exchange_mic": "XKRX",
       "currency": "KRW",
       "source_name": "GS",
       "source_symbol": "078930"
-    },
-    {
-      "symbol": "006360.KS",
-      "exchange_mic": "XKRX",
-      "currency": "KRW",
-      "source_name": "GS E&C",
-      "source_symbol": "006360"
     },
     {
       "symbol": "007070.KS",
@@ -443,6 +436,13 @@
       "currency": "KRW",
       "source_name": "Hanwha Systems",
       "source_symbol": "272210"
+    },
+    {
+      "symbol": "267270.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "source_name": "HD Construction Equipment",
+      "source_symbol": "267270"
     },
     {
       "symbol": "267250.KS",
@@ -1015,7 +1015,7 @@
       "symbol": "036570.KS",
       "exchange_mic": "XKRX",
       "currency": "KRW",
-      "source_name": "NCSoft",
+      "source_name": "NC",
       "source_symbol": "036570"
     },
     {
@@ -1038,6 +1038,13 @@
       "currency": "KRW",
       "source_name": "Nongshim",
       "source_symbol": "004370"
+    },
+    {
+      "symbol": "456040.KS",
+      "exchange_mic": "XKRX",
+      "currency": "KRW",
+      "source_name": "OCI",
+      "source_symbol": "456040"
     },
     {
       "symbol": "010060.KS",
@@ -1248,13 +1255,6 @@
       "currency": "KRW",
       "source_name": "Seah Steel Holdings",
       "source_symbol": "003030"
-    },
-    {
-      "symbol": "004490.KS",
-      "exchange_mic": "XKRX",
-      "currency": "KRW",
-      "source_name": "Sebang Global Battery",
-      "source_symbol": "004490"
     },
     {
       "symbol": "055550.KS",

--- a/src/swing_screener/data/universes/registry/snapshots/uk_ftse100.json
+++ b/src/swing_screener/data/universes/registry/snapshots/uk_ftse100.json
@@ -5,8 +5,8 @@
   "benchmark": "^FTSE",
   "source": "wikipedia",
   "source_adapter": "wikipedia_index_review",
-  "source_asof": "2026-06-13",
-  "last_reviewed_at": "2026-06-13",
+  "source_asof": "2026-06-30",
+  "last_reviewed_at": "2026-06-30",
   "stale_after_days": 100,
   "rules": {
     "exchange_mics": [
@@ -25,6 +25,13 @@
       "currency": "GBP",
       "source_name": "3i",
       "source_symbol": "III"
+    },
+    {
+      "symbol": "ABDN.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "source_name": "Aberdeen Group",
+      "source_symbol": "ABDN"
     },
     {
       "symbol": "ADM.L",
@@ -125,13 +132,6 @@
       "source_symbol": "BEZ"
     },
     {
-      "symbol": "BKG.L",
-      "exchange_mic": "XLON",
-      "currency": "GBP",
-      "source_name": "Berkeley Group Holdings",
-      "source_symbol": "BKG"
-    },
-    {
       "symbol": "BP.L",
       "exchange_mic": "XLON",
       "currency": "GBP",
@@ -200,6 +200,13 @@
       "currency": "USD",
       "source_name": "Compass Group",
       "source_symbol": "CPG"
+    },
+    {
+      "symbol": "CCC.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "source_name": "Computacenter",
+      "source_symbol": "CCC"
     },
     {
       "symbol": "CTEC.L",
@@ -384,6 +391,13 @@
       "source_symbol": "ITRK"
     },
     {
+      "symbol": "INVP.L",
+      "exchange_mic": "XLON",
+      "currency": "GBP",
+      "source_name": "Investec",
+      "source_symbol": "INVP"
+    },
+    {
       "symbol": "JD.L",
       "exchange_mic": "XLON",
       "currency": "GBP",
@@ -468,13 +482,6 @@
       "source_symbol": "MTLN"
     },
     {
-      "symbol": "MNDI.L",
-      "exchange_mic": "XLON",
-      "currency": "GBP",
-      "source_name": "Mondi",
-      "source_symbol": "MNDI"
-    },
-    {
       "symbol": "NG.L",
       "exchange_mic": "XLON",
       "currency": "GBP",
@@ -550,13 +557,6 @@
       "currency": "GBP",
       "source_name": "Rentokil Initial",
       "source_symbol": "RTO"
-    },
-    {
-      "symbol": "RMV.L",
-      "exchange_mic": "XLON",
-      "currency": "GBP",
-      "source_name": "Rightmove",
-      "source_symbol": "RMV"
     },
     {
       "symbol": "RIO.L",

--- a/src/swing_screener/data/universes/registry/snapshots/us_dow30.json
+++ b/src/swing_screener/data/universes/registry/snapshots/us_dow30.json
@@ -5,8 +5,8 @@
   "benchmark": "^DJI",
   "source": "wikipedia",
   "source_adapter": "wikipedia_index_review",
-  "source_asof": "2026-06-13",
-  "last_reviewed_at": "2026-06-13",
+  "source_asof": "2026-06-30",
+  "last_reviewed_at": "2026-06-30",
   "stale_after_days": 100,
   "rules": {
     "exchange_mics": [
@@ -24,6 +24,13 @@
       "currency": "USD",
       "source_name": "3M",
       "source_symbol": "MMM"
+    },
+    {
+      "symbol": "GOOGL",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "source_name": "Alphabet",
+      "source_symbol": "GOOGL"
     },
     {
       "symbol": "AXP",
@@ -206,13 +213,6 @@
       "currency": "USD",
       "source_name": "UnitedHealth Group",
       "source_symbol": "UNH"
-    },
-    {
-      "symbol": "VZ",
-      "exchange_mic": "XNAS",
-      "currency": "USD",
-      "source_name": "Verizon",
-      "source_symbol": "VZ"
     },
     {
       "symbol": "V",

--- a/src/swing_screener/data/universes/registry/snapshots/us_nasdaq100.json
+++ b/src/swing_screener/data/universes/registry/snapshots/us_nasdaq100.json
@@ -5,8 +5,8 @@
   "benchmark": "^NDX",
   "source": "wikipedia",
   "source_adapter": "wikipedia_index_review",
-  "source_asof": "2026-06-13",
-  "last_reviewed_at": "2026-06-13",
+  "source_asof": "2026-06-30",
+  "last_reviewed_at": "2026-06-30",
   "stale_after_days": 100,
   "rules": {
     "exchange_mics": [
@@ -125,6 +125,13 @@
       "source_symbol": "ASML"
     },
     {
+      "symbol": "ALAB",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "source_name": "Astera Labs",
+      "source_symbol": "ALAB"
+    },
+    {
       "symbol": "ADSK",
       "exchange_mic": "XNAS",
       "currency": "USD",
@@ -174,13 +181,6 @@
       "source_symbol": "CDNS"
     },
     {
-      "symbol": "CHTR",
-      "exchange_mic": "XNAS",
-      "currency": "USD",
-      "source_name": "Charter Communications",
-      "source_symbol": "CHTR"
-    },
-    {
       "symbol": "CTAS",
       "exchange_mic": "XNAS",
       "currency": "USD",
@@ -202,13 +202,6 @@
       "source_symbol": "CCEP"
     },
     {
-      "symbol": "CTSH",
-      "exchange_mic": "XNAS",
-      "currency": "USD",
-      "source_name": "Cognizant",
-      "source_symbol": "CTSH"
-    },
-    {
       "symbol": "CMCSA",
       "exchange_mic": "XNAS",
       "currency": "USD",
@@ -228,6 +221,13 @@
       "currency": "USD",
       "source_name": "Copart",
       "source_symbol": "CPRT"
+    },
+    {
+      "symbol": "CRWV",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "source_name": "CoreWeave",
+      "source_symbol": "CRWV"
     },
     {
       "symbol": "COST",
@@ -340,13 +340,6 @@
       "currency": "USD",
       "source_name": "Idexx Laboratories",
       "source_symbol": "IDXX"
-    },
-    {
-      "symbol": "INSM",
-      "exchange_mic": "XNAS",
-      "currency": "USD",
-      "source_name": "Insmed Incorporated",
-      "source_symbol": "INSM"
     },
     {
       "symbol": "INTC",
@@ -489,6 +482,13 @@
       "source_symbol": "MNST"
     },
     {
+      "symbol": "NBIS",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "source_name": "Nebius Group",
+      "source_symbol": "NBIS"
+    },
+    {
       "symbol": "NFLX",
       "exchange_mic": "XNAS",
       "currency": "USD",
@@ -587,6 +587,13 @@
       "source_symbol": "REGN"
     },
     {
+      "symbol": "RKLB",
+      "exchange_mic": "XNYS",
+      "currency": "USD",
+      "source_name": "Rocket Lab",
+      "source_symbol": "RKLB"
+    },
+    {
       "symbol": "ROP",
       "exchange_mic": "XNAS",
       "currency": "USD",
@@ -650,6 +657,13 @@
       "source_symbol": "TTWO"
     },
     {
+      "symbol": "TER",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "source_name": "Teradyne",
+      "source_symbol": "TER"
+    },
+    {
       "symbol": "TSLA",
       "exchange_mic": "XNAS",
       "currency": "USD",
@@ -669,13 +683,6 @@
       "currency": "USD",
       "source_name": "Thomson Reuters",
       "source_symbol": "TRI"
-    },
-    {
-      "symbol": "VRSK",
-      "exchange_mic": "XNAS",
-      "currency": "USD",
-      "source_name": "Verisk Analytics",
-      "source_symbol": "VRSK"
     },
     {
       "symbol": "VRTX",
@@ -718,13 +725,6 @@
       "currency": "USD",
       "source_name": "Xcel Energy",
       "source_symbol": "XEL"
-    },
-    {
-      "symbol": "ZS",
-      "exchange_mic": "XNAS",
-      "currency": "USD",
-      "source_name": "Zscaler",
-      "source_symbol": "ZS"
     }
   ],
   "source_documents": [

--- a/src/swing_screener/data/universes/registry/snapshots/us_sp500.json
+++ b/src/swing_screener/data/universes/registry/snapshots/us_sp500.json
@@ -5,8 +5,8 @@
   "benchmark": "^GSPC",
   "source": "wikipedia",
   "source_adapter": "wikipedia_index_review",
-  "source_asof": "2026-06-13",
-  "last_reviewed_at": "2026-06-13",
+  "source_asof": "2026-06-30",
+  "last_reviewed_at": "2026-06-30",
   "stale_after_days": 100,
   "rules": {
     "exchange_mics": [
@@ -601,13 +601,6 @@
       "source_symbol": "CPT"
     },
     {
-      "symbol": "CPB",
-      "exchange_mic": "XNAS",
-      "currency": "USD",
-      "source_name": "Campbell's Company (The)",
-      "source_symbol": "CPB"
-    },
-    {
       "symbol": "COF",
       "exchange_mic": "XNYS",
       "currency": "USD",
@@ -872,13 +865,6 @@
       "currency": "USD",
       "source_name": "Comfort Systems USA",
       "source_symbol": "FIX"
-    },
-    {
-      "symbol": "CAG",
-      "exchange_mic": "XNYS",
-      "currency": "USD",
-      "source_name": "Conagra Brands",
-      "source_symbol": "CAG"
     },
     {
       "symbol": "COP",
@@ -1175,11 +1161,11 @@
       "source_symbol": "EBAY"
     },
     {
-      "symbol": "SATS",
+      "symbol": "ECHO",
       "exchange_mic": "XNAS",
       "currency": "USD",
       "source_name": "EchoStar",
-      "source_symbol": "SATS"
+      "source_symbol": "ECHO"
     },
     {
       "symbol": "ECL",
@@ -1441,6 +1427,13 @@
       "source_symbol": "FISV"
     },
     {
+      "symbol": "FLEX",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "source_name": "Flex Ltd.",
+      "source_symbol": "FLEX"
+    },
+    {
       "symbol": "F",
       "exchange_mic": "XNYS",
       "currency": "USD",
@@ -1672,10 +1665,17 @@
       "source_symbol": "HD"
     },
     {
+      "symbol": "HONA",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "source_name": "Honeywell Aerospace",
+      "source_symbol": "HONA"
+    },
+    {
       "symbol": "HON",
       "exchange_mic": "XNYS",
       "currency": "USD",
-      "source_name": "Honeywell",
+      "source_name": "Honeywell Technologies",
       "source_symbol": "HON"
     },
     {
@@ -2132,6 +2132,13 @@
       "currency": "USD",
       "source_name": "Martin Marietta Materials",
       "source_symbol": "MLM"
+    },
+    {
+      "symbol": "MRVL",
+      "exchange_mic": "XNAS",
+      "currency": "USD",
+      "source_name": "Marvell Technology",
+      "source_symbol": "MRVL"
     },
     {
       "symbol": "MAS",
@@ -2608,13 +2615,6 @@
       "currency": "USD",
       "source_name": "PNC Financial Services",
       "source_symbol": "PNC"
-    },
-    {
-      "symbol": "POOL",
-      "exchange_mic": "XNAS",
-      "currency": "USD",
-      "source_name": "Pool Corporation",
-      "source_symbol": "POOL"
     },
     {
       "symbol": "PPG",


### PR DESCRIPTION
Committed local refresh-all/rebuild/enrich output from the Pool tab (#390).