### PR TITLE
fix: use a real-time quote for open-position pricing instead of the d…

### DIFF
--- a/api/services/portfolio/pricing.py
+++ b/api/services/portfolio/pricing.py
@@ -78,6 +78,24 @@ class PositionPricingService:
         prices, _ = _last_close_map(ohlcv)
         return prices
 
+    def _fetch_live_quote(self, ticker: str) -> Optional[float]:
+        """Best-effort real-time quote; None if the provider can't produce one.
+
+        Unlike `_fetch_last_prices`, this bypasses the daily-bar cache (whose
+        TTL is tuned for the post-close screener, not intraday position
+        tracking) so open positions reflect the actual current price rather
+        than a stale pre-market-fetched close.
+        """
+        try:
+            price = self._provider.fetch_latest_price(ticker)
+            price = float(price)
+        except Exception as exc:
+            logger.info("Live quote unavailable for %s, falling back to last close: %s", ticker, exc)
+            return None
+        if price != price:  # NaN
+            return None
+        return price
+
     @staticmethod
     def _fallback_price(position: dict) -> float:
         exit_price = position.get("exit_price")
@@ -88,30 +106,38 @@ class PositionPricingService:
             return float(current_price)
         return float(position.get("entry_price", 0.0))
 
-    def _attach_live_prices(self, positions: list[dict]) -> dict[str, float]:
-        """Attach latest price to open positions and return fetched price map."""
+    def _attach_live_prices(self, positions: list[dict]) -> tuple[dict[str, float], set[str]]:
+        """Attach latest price to open positions.
+
+        Returns (price map, tickers priced from a genuine real-time quote —
+        the rest, if any, fell back to the last daily-bar close).
+        """
         last_prices: dict[str, float] = {}
+        live_tickers: set[str] = set()
         open_positions = [p for p in positions if p.get("status") == "open"]
         if open_positions:
-            try:
-                tickers = list({str(p.get("ticker", "")).upper() for p in open_positions if p.get("ticker")})
-                last_prices = self._fetch_last_prices(tickers)
-                for pos in positions:
-                    if pos.get("status") == "open":
-                        ticker = str(pos.get("ticker", "")).upper()
-                        pos["current_price"] = last_prices.get(ticker)
-            except (KeyError, ValueError, TypeError) as exc:
-                logger.warning("Failed to fetch current prices (data error): %s", exc)
-                for pos in positions:
-                    if pos.get("status") == "open":
-                        pos["current_price"] = None
-            except Exception:
-                logger.exception("Unexpected error fetching current prices")
-                for pos in positions:
-                    if pos.get("status") == "open":
-                        pos["current_price"] = None
+            tickers = list({str(p.get("ticker", "")).upper() for p in open_positions if p.get("ticker")})
+            for ticker in tickers:
+                quote = self._fetch_live_quote(ticker)
+                if quote is not None:
+                    last_prices[ticker] = quote
+                    live_tickers.add(ticker)
 
-        return last_prices
+            remaining = [t for t in tickers if t not in last_prices]
+            if remaining:
+                try:
+                    last_prices.update(self._fetch_last_prices(remaining))
+                except (KeyError, ValueError, TypeError) as exc:
+                    logger.warning("Failed to fetch current prices (data error): %s", exc)
+                except Exception:
+                    logger.exception("Unexpected error fetching current prices")
+
+            for pos in positions:
+                if pos.get("status") == "open":
+                    ticker = str(pos.get("ticker", "")).upper()
+                    pos["current_price"] = last_prices.get(ticker)
+
+        return last_prices, live_tickers
 
     def _eurusd_rate(self) -> float:
         """Fetch EURUSD rate with simple caching."""

--- a/api/services/portfolio/read.py
+++ b/api/services/portfolio/read.py
@@ -97,6 +97,7 @@ class PortfolioReadService:
         eurusd_rate: float,
         account_currency: str = "EUR",
         *,
+        live_tickers: frozenset[str] = frozenset(),
         time_stop_days: int | None = None,
         time_stop_min_r: float | None = None,
     ) -> PositionWithMetrics:
@@ -115,9 +116,9 @@ class PortfolioReadService:
         if state_position.status == "open" and live_price is not None:
             payload["current_price"] = live_price
 
-        if live_price is not None:
+        if live_price is not None and ticker in live_tickers:
             price_source = "live"
-        elif position.get("current_price") is not None:
+        elif live_price is not None or position.get("current_price") is not None:
             price_source = "cached"
         else:
             price_source = "entry"
@@ -191,7 +192,7 @@ class PortfolioReadService:
         time_stop_min_r: float | None = None,
     ) -> PositionsWithMetricsResponse:
         positions, asof = self._positions_repo.list_positions(status=status)
-        current_prices = self._pricing._attach_live_prices(positions)
+        current_prices, live_tickers = self._pricing._attach_live_prices(positions)
         has_usd_positions = any(
             detect_currency(str(position.get("ticker", "")).upper()) == "USD"
             for position in positions
@@ -205,6 +206,7 @@ class PortfolioReadService:
                 current_prices,
                 eurusd_rate,
                 account_currency,
+                live_tickers=live_tickers,
                 time_stop_days=time_stop_days,
                 time_stop_min_r=time_stop_min_r,
             )
@@ -225,12 +227,23 @@ class PortfolioReadService:
 
         ticker = str(position.get("ticker", "")).upper()
         current_price = self._pricing._fallback_price(position)
+        # Non-open positions (closed) have a fixed, recorded price - label unchanged from prior behavior.
+        price_source = "live"
 
         if position.get("status") == "open" and ticker:
-            try:
-                current_price = self._pricing._fetch_last_prices([ticker]).get(ticker, current_price)
-            except Exception as exc:
-                logger.warning("Failed to fetch current price for %s metrics: %s", ticker, exc)
+            live_quote = self._pricing._fetch_live_quote(ticker)
+            if live_quote is not None:
+                current_price = live_quote
+                price_source = "live"
+            else:
+                try:
+                    last_close = self._pricing._fetch_last_prices([ticker]).get(ticker)
+                except Exception as exc:
+                    logger.warning("Failed to fetch current price for %s metrics: %s", ticker, exc)
+                    last_close = None
+                if last_close is not None:
+                    current_price = last_close
+                    price_source = "cached"
 
         state_position = to_state_position(position)
         entry_fee_eur = float(position.get("entry_fee_eur") or 0.0)
@@ -297,7 +310,7 @@ class PortfolioReadService:
             partial_closes=partial_close_events,
             blended_r=blended_r,
             r_fx_adjusted=r_fx_adjusted,
-            price_source="live",
+            price_source=price_source,
             r_uses_initial_risk=r_uses_initial_risk_metrics,
         )
 

--- a/tests/api/test_fx_adjusted_r.py
+++ b/tests/api/test_fx_adjusted_r.py
@@ -115,6 +115,7 @@ class TestFxAdjustedREndpoint:
         portfolio_service._eurusd_cache.clear()
 
         mock_provider = MagicMock(spec=MarketDataProvider)
+        mock_provider.fetch_latest_price.side_effect = ConnectionError("no live quote in test")
 
         def mock_fetch(tickers, **kwargs):
             closes = {}
@@ -142,6 +143,7 @@ class TestFxAdjustedREndpoint:
         portfolio_service._eurusd_cache.clear()
 
         mock_provider = MagicMock(spec=MarketDataProvider)
+        mock_provider.fetch_latest_price.side_effect = ConnectionError("no live quote in test")
         mock_provider.fetch_ohlcv.return_value = _ohlcv_with_closes({"ASML.AS": [750.0, 750.0]})
         mock_provider.get_provider_name.return_value = "mock"
         monkeypatch.setattr(portfolio_service, "get_default_provider", lambda **kwargs: mock_provider)
@@ -158,6 +160,7 @@ class TestFxAdjustedREndpoint:
         portfolio_service._eurusd_cache.clear()
 
         mock_provider = MagicMock(spec=MarketDataProvider)
+        mock_provider.fetch_latest_price.side_effect = ConnectionError("no live quote in test")
         mock_provider.fetch_ohlcv.return_value = _ohlcv_with_closes({"AAPL": [120.0, 120.0]})
         mock_provider.get_provider_name.return_value = "mock"
         monkeypatch.setattr(portfolio_service, "get_default_provider", lambda **kwargs: mock_provider)
@@ -173,6 +176,7 @@ class TestFxAdjustedREndpoint:
         portfolio_service._eurusd_cache.clear()
 
         mock_provider = MagicMock(spec=MarketDataProvider)
+        mock_provider.fetch_latest_price.side_effect = ConnectionError("no live quote in test")
 
         def mock_fetch(tickers, **kwargs):
             closes = {}

--- a/tests/api/test_portfolio_metrics_endpoints.py
+++ b/tests/api/test_portfolio_metrics_endpoints.py
@@ -60,6 +60,7 @@ def test_position_metrics_endpoint(monkeypatch: pytest.MonkeyPatch, tmp_path) ->
     monkeypatch.setattr(api.dependencies, "POSITIONS_FILE", positions_file)
 
     mock_provider = MagicMock(spec=MarketDataProvider)
+    mock_provider.fetch_latest_price.side_effect = ConnectionError("no live quote in test")
     mock_provider.fetch_ohlcv.return_value = _ohlcv_with_closes({"VALE": [16.30, 16.65]})
     mock_provider.get_provider_name.return_value = "mock"
     monkeypatch.setattr(portfolio_service, "get_default_provider", lambda **kwargs: mock_provider)
@@ -106,6 +107,7 @@ def test_position_metrics_subtracts_recorded_fees(monkeypatch: pytest.MonkeyPatc
     monkeypatch.setattr(api.dependencies, "POSITIONS_FILE", positions_file)
 
     mock_provider = MagicMock(spec=MarketDataProvider)
+    mock_provider.fetch_latest_price.side_effect = ConnectionError("no live quote in test")
     mock_provider.fetch_ohlcv.return_value = _ohlcv_with_closes({"BAMNB.AS": [9.98, 10.0]})
     mock_provider.get_provider_name.return_value = "mock"
     monkeypatch.setattr(portfolio_service, "get_default_provider", lambda **kwargs: mock_provider)
@@ -153,6 +155,7 @@ def test_position_metrics_subtracts_recorded_fees_usd(
     monkeypatch.setattr(api.dependencies, "POSITIONS_FILE", positions_file)
 
     mock_provider = MagicMock(spec=MarketDataProvider)
+    mock_provider.fetch_latest_price.side_effect = ConnectionError("no live quote in test")
 
     def mock_fetch_ohlcv(tickers, **kwargs):
         if "EURUSD=X" in tickers:
@@ -216,6 +219,7 @@ def test_positions_endpoint_returns_precomputed_metrics(
     monkeypatch.setattr(api.dependencies, "POSITIONS_FILE", positions_file)
 
     mock_provider = MagicMock(spec=MarketDataProvider)
+    mock_provider.fetch_latest_price.side_effect = ConnectionError("no live quote in test")
     mock_provider.fetch_ohlcv.return_value = _ohlcv_with_closes({"VALE": [16.30, 16.65]})
     mock_provider.get_provider_name.return_value = "mock"
     monkeypatch.setattr(portfolio_service, "get_default_provider", lambda **kwargs: mock_provider)
@@ -298,6 +302,7 @@ def test_portfolio_summary_endpoint(monkeypatch: pytest.MonkeyPatch, tmp_path) -
     _set_account_size(monkeypatch, account_size=1000.0)
 
     mock_provider = MagicMock(spec=MarketDataProvider)
+    mock_provider.fetch_latest_price.side_effect = ConnectionError("no live quote in test")
     mock_provider.fetch_ohlcv.return_value = _ohlcv_with_closes(
         {
             "VALE": [16.30, 16.65],

--- a/tests/api/test_position_live_price.py
+++ b/tests/api/test_position_live_price.py
@@ -1,0 +1,125 @@
+"""Open-position pricing must prefer a genuine live quote over a cached daily close.
+
+Regression coverage for a bug where `same_day_cache_ttl_minutes` (tuned for the
+post-close screener) let a pre-market daily-bar fetch serve yesterday's close
+as "current price" for the rest of the trading session, mislabeled `price_source:
+"live"` even though no real-time quote was ever fetched.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pandas as pd
+from fastapi.testclient import TestClient
+
+import api.dependencies as deps
+from api.main import app
+from api.services import portfolio_service
+from swing_screener.data.providers import MarketDataProvider
+
+client = TestClient(app)
+
+OPEN_POSITION = {
+    "position_id": "POS-LIVE001",
+    "ticker": "LRCX",
+    "status": "open",
+    "entry_date": "2026-06-16",
+    "entry_price": 383.04,
+    "stop_price": 383.04,
+    "shares": 1,
+    "initial_risk": 36.74,
+}
+
+
+def _write_positions(tmp_path: Path, positions: list[dict]) -> Path:
+    p = tmp_path / "positions.json"
+    p.write_text(json.dumps({"positions": positions, "asof": "2026-06-30"}))
+    return p
+
+
+def _stale_ohlcv(ticker: str, close: float) -> pd.DataFrame:
+    idx = pd.date_range("2026-06-29", periods=2, freq="D")
+    data = {
+        ("Open", ticker): [close, close],
+        ("High", ticker): [close, close],
+        ("Low", ticker): [close, close],
+        ("Close", ticker): [close, close],
+        ("Volume", ticker): [1_000_000, 1_000_000],
+    }
+    df = pd.DataFrame(data, index=idx)
+    df.columns = pd.MultiIndex.from_tuples(df.columns)
+    return df
+
+
+class TestListPositionsLiveQuote:
+    def test_uses_live_quote_over_stale_cached_close(self, tmp_path, monkeypatch):
+        pos_file = _write_positions(tmp_path, [OPEN_POSITION])
+        monkeypatch.setattr(deps, "POSITIONS_FILE", pos_file)
+
+        mock_provider = MagicMock(spec=MarketDataProvider)
+        mock_provider.fetch_latest_price.return_value = 396.44  # real-time quote
+        mock_provider.fetch_ohlcv.return_value = _stale_ohlcv("LRCX", 433.33)  # stale daily bar
+        mock_provider.get_provider_name.return_value = "mock"
+        monkeypatch.setattr(portfolio_service, "get_default_provider", lambda **kwargs: mock_provider)
+
+        response = client.get("/api/portfolio/positions?status=open")
+
+        assert response.status_code == 200
+        positions = response.json()["positions"]
+        assert len(positions) == 1
+        assert positions[0]["current_price"] == 396.44
+        assert positions[0]["price_source"] == "live"
+
+    def test_falls_back_to_cached_close_when_live_quote_fails(self, tmp_path, monkeypatch):
+        pos_file = _write_positions(tmp_path, [OPEN_POSITION])
+        monkeypatch.setattr(deps, "POSITIONS_FILE", pos_file)
+
+        mock_provider = MagicMock(spec=MarketDataProvider)
+        mock_provider.fetch_latest_price.side_effect = ConnectionError("no live quote")
+        mock_provider.fetch_ohlcv.return_value = _stale_ohlcv("LRCX", 433.33)
+        mock_provider.get_provider_name.return_value = "mock"
+        monkeypatch.setattr(portfolio_service, "get_default_provider", lambda **kwargs: mock_provider)
+
+        response = client.get("/api/portfolio/positions?status=open")
+
+        assert response.status_code == 200
+        positions = response.json()["positions"]
+        assert positions[0]["current_price"] == 433.33
+        assert positions[0]["price_source"] == "cached"
+
+
+class TestPositionMetricsLiveQuote:
+    def test_uses_live_quote_over_stale_cached_close(self, tmp_path, monkeypatch):
+        pos_file = _write_positions(tmp_path, [OPEN_POSITION])
+        monkeypatch.setattr(deps, "POSITIONS_FILE", pos_file)
+
+        mock_provider = MagicMock(spec=MarketDataProvider)
+        mock_provider.fetch_latest_price.return_value = 396.44
+        mock_provider.fetch_ohlcv.return_value = _stale_ohlcv("LRCX", 433.33)
+        mock_provider.get_provider_name.return_value = "mock"
+        monkeypatch.setattr(portfolio_service, "get_default_provider", lambda **kwargs: mock_provider)
+
+        response = client.get("/api/portfolio/positions/POS-LIVE001/metrics")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["current_value"] == 396.44  # 1 share, so current_value == price used
+        assert data["price_source"] == "live"
+
+    def test_falls_back_to_cached_close_when_live_quote_fails(self, tmp_path, monkeypatch):
+        pos_file = _write_positions(tmp_path, [OPEN_POSITION])
+        monkeypatch.setattr(deps, "POSITIONS_FILE", pos_file)
+
+        mock_provider = MagicMock(spec=MarketDataProvider)
+        mock_provider.fetch_latest_price.side_effect = ConnectionError("no live quote")
+        mock_provider.fetch_ohlcv.return_value = _stale_ohlcv("LRCX", 433.33)
+        mock_provider.get_provider_name.return_value = "mock"
+        monkeypatch.setattr(portfolio_service, "get_default_provider", lambda **kwargs: mock_provider)
+
+        response = client.get("/api/portfolio/positions/POS-LIVE001/metrics")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["price_source"] == "cached"


### PR DESCRIPTION
…aily-bar cache

same_day_cache_ttl_minutes (480min/8h, tuned for the post-close screener's EU-ticker case) also gated _attach_live_prices/get_position_metrics, so any pre-market pricing call froze open positions at yesterday's close for the rest of the session while still labeling it price_source="live". Now these paths try provider.fetch_latest_price() first (same mechanism already used by the "Check live" stop preview) and only fall back to the daily-bar close when no live quote is available, labeling that fallback "cached" honestly.

Also hardens two pre-existing tests (test_fx_adjusted_r, test_portfolio_metrics_endpoints) whose unconfigured MagicMock(spec=MarketDataProvider) silently returned 1.0 from fetch_latest_price() (MagicMock's default __float__), which would have masked the real behavior under test.