### PR TITLE
fix: address intelligence engine v2 review findings

### DIFF
--- a/api/services/intelligence_chat_service.py
+++ b/api/services/intelligence_chat_service.py
@@ -99,7 +99,11 @@ def _default_answer_fn(
     if not configured_model:
         raise RuntimeError("Intelligence chat model is not configured")
     model = str(configured_model)
-    client = OpenAI()
+    client = OpenAI(
+        api_key=os.environ.get("OPENAI_API_KEY"),
+        timeout=float(cfg.get("request_timeout_seconds", 60.0)),
+        max_retries=int(cfg.get("max_retries", 2)),
+    )
     context = _format_context(
         ticker=ticker,
         intelligence=intelligence,
@@ -215,7 +219,8 @@ class IntelligenceChatService:
             return []
         try:
             raw = json.loads(path.read_text())
-            return [IntelligenceChatMessage.model_validate(item) for item in raw.get("messages", [])]
+            messages = raw.get("messages", []) if isinstance(raw, dict) else []
+            return [IntelligenceChatMessage.model_validate(item) for item in messages]
         except (OSError, ValueError, TypeError):
             return []
 

--- a/src/swing_screener/intelligence/graph/nodes.py
+++ b/src/swing_screener/intelligence/graph/nodes.py
@@ -13,14 +13,6 @@ if TYPE_CHECKING:
     from swing_screener.intelligence.symbol_analyzer import SymbolAnalyzer
 
 
-def _has_position(req) -> bool:
-    return (
-        req.entry_price is not None
-        and req.r_now is not None
-        and req.days_open is not None
-    )
-
-
 def resolve_context(analyzer: "SymbolAnalyzer", state: AnalyzerState) -> AnalyzerState:
     req, ticker = state["req"], state["ticker"]
     now = state.get("now") or datetime.now(timezone.utc)
@@ -31,7 +23,7 @@ def resolve_context(analyzer: "SymbolAnalyzer", state: AnalyzerState) -> Analyze
     state["prior_digest"] = mod.read_history(
         ticker, limit=analyzer._history_digest_size
     )
-    state["has_position"] = _has_position(req)
+    state["has_position"] = mod.is_position_request(req)
     return state
 
 
@@ -48,10 +40,8 @@ def assemble_inputs(analyzer: "SymbolAnalyzer", state: AnalyzerState) -> Analyze
         trade_plan["target"] = req.target
     if req.rr is not None:
         trade_plan["rr"] = req.rr
-    if req.target is not None and req.close is not None:
-        trade_plan["upside_pct"] = round(
-            (req.target - req.close) / req.close * 100, 1
-        )
+    if req.target is not None and req.close is not None and req.close != 0:
+        trade_plan["upside_pct"] = round((req.target - req.close) / req.close * 100, 1)
     if trade_plan:
         inputs_used["trade_plan"] = trade_plan
 

--- a/src/swing_screener/intelligence/history.py
+++ b/src/swing_screener/intelligence/history.py
@@ -87,7 +87,12 @@ def _matching_evidence(prediction: HistoryPrediction, played_out: list[str]) -> 
     if not prediction_tokens:
         return None
     for evidence in played_out:
-        if len(prediction_tokens & _tokens(evidence)) >= 2:
+        overlap = len(prediction_tokens & _tokens(evidence))
+        # Require the evidence to cover a substantial share of the prediction's
+        # meaningful tokens, not just two incidentally-shared generic words
+        # (e.g. "earnings", "growth") — those produce false confirmed/contradicted
+        # outcomes.
+        if overlap >= 2 and overlap >= 0.6 * len(prediction_tokens):
             return evidence
     return None
 

--- a/src/swing_screener/intelligence/symbol_analyzer.py
+++ b/src/swing_screener/intelligence/symbol_analyzer.py
@@ -280,6 +280,16 @@ def _fallback_position_fields(
     return position_signal, key_numbers
 
 
+def is_position_request(req: SymbolIntelligenceRequest) -> bool:
+    """True when the request carries open-position context (analysis runs in
+    MANAGE_ONLY mode). Single source of truth for the position/candidate split."""
+    return (
+        req.entry_price is not None
+        and req.r_now is not None
+        and req.days_open is not None
+    )
+
+
 def _build_user_prompt(
     ticker: str,
     req: SymbolIntelligenceRequest,
@@ -292,11 +302,7 @@ def _build_user_prompt(
     def fmt(v: float | None) -> str:
         return f"{v:.2f}" if v is not None else "N/A"
 
-    has_position = (
-        req.entry_price is not None
-        and req.r_now is not None
-        and req.days_open is not None
-    )
+    has_position = is_position_request(req)
 
     lines: list[str] = []
 
@@ -644,6 +650,7 @@ class SymbolAnalyzer:
             timeout=self._timeout,
             max_retries=self._max_retries,
         )
+        self._graph = None
 
     def _is_us_listed(self, ticker: str, req: SymbolIntelligenceRequest) -> bool:
         """US-listed proxy. Prefer the ticker-based `detect_currency` (knows e.g.
@@ -686,7 +693,10 @@ class SymbolAnalyzer:
         *,
         now: datetime | None = None,
     ) -> SymbolIntelligence:
-        from swing_screener.intelligence.graph.build import build_graph
+        if self._graph is None:
+            from swing_screener.intelligence.graph.build import build_graph
+
+            self._graph = build_graph(self)
 
         state = {
             "ticker": ticker,
@@ -695,4 +705,4 @@ class SymbolAnalyzer:
         }
         if now is not None:
             state["now"] = now
-        return build_graph(self).invoke(state)["result"]
+        return self._graph.invoke(state)["result"]

--- a/src/swing_screener/intelligence/weighting/config.py
+++ b/src/swing_screener/intelligence/weighting/config.py
@@ -4,6 +4,9 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from swing_screener.settings import get_settings_manager
+from swing_screener.utils.logging_config import get_logger
+
+logger = get_logger(__name__)
 
 _DEFAULT_SIGNALS = {
     "insider_activity": 10.0,
@@ -55,7 +58,15 @@ _DEFAULT_THRESHOLDS = {
 def _merge_defaults(defaults: dict[str, float], overrides: Any) -> dict[str, float]:
     merged = dict(defaults)
     if isinstance(overrides, dict):
-        merged.update({str(key): float(value) for key, value in overrides.items()})
+        for key, value in overrides.items():
+            try:
+                merged[str(key)] = float(value)
+            except (TypeError, ValueError):
+                logger.warning(
+                    "Ignoring non-numeric evidence weight %r=%r; keeping default",
+                    key,
+                    value,
+                )
     return merged
 
 

--- a/tests/intelligence/test_analyzer_graph_equivalence.py
+++ b/tests/intelligence/test_analyzer_graph_equivalence.py
@@ -151,6 +151,7 @@ def _mock_openai(monkeypatch):
 
         client.responses.parse.side_effect = _parse
         self._client = client
+        self._graph = None
 
     monkeypatch.setattr(mod.SymbolAnalyzer, "__init__", fake_init)
 

--- a/tests/intelligence/test_history.py
+++ b/tests/intelligence/test_history.py
@@ -210,6 +210,42 @@ def test_append_marks_prior_prediction_unresolved_when_follow_up_has_no_match(tm
     assert prior_prediction.outcome.evidence == "No matching follow-up evidence yet."
 
 
+def test_generic_two_token_overlap_does_not_confirm(tmp_path):
+    """A couple of incidentally-shared generic words must not confirm a prediction
+    against unrelated follow-up evidence."""
+    from swing_screener.intelligence.models import ThesisDelta
+
+    append_history(
+        "AAPL",
+        _result(
+            "first",
+            generated_at="2026-06-24T08:00:00Z",
+            predictions=[
+                PredictionBullet(
+                    direction="bullish",
+                    reason="earnings growth should accelerate next year",
+                    reference="growth",
+                )
+            ],
+        ),
+        max_entries=50,
+        history_root=tmp_path,
+    )
+    follow_up = _result("second", generated_at="2026-06-25T08:00:00Z")
+    follow_up.thesis_delta = ThesisDelta(
+        status="confirmed",
+        summary="Unrelated development.",
+        what_played_out=["Guidance cut despite earnings growth last quarter"],
+    )
+
+    append_history("AAPL", follow_up, max_entries=50, history_root=tmp_path)
+
+    entries = read_history("AAPL", history_root=tmp_path)
+    prior_prediction = entries[1].predictions[0]
+    assert prior_prediction.outcome is not None
+    assert prior_prediction.outcome.status == "unresolved"
+
+
 def test_read_history_accepts_legacy_predictions_without_outcomes(tmp_path):
     (tmp_path / "history").mkdir(parents=True)
     legacy = {

--- a/tests/intelligence/test_weighting_config.py
+++ b/tests/intelligence/test_weighting_config.py
@@ -1,9 +1,22 @@
 from __future__ import annotations
 
 from swing_screener.intelligence.weighting.config import (
+    _DEFAULT_SIGNALS,
     EvidenceWeightsConfig,
+    _merge_defaults,
     load_evidence_weights_config,
 )
+
+
+def test_merge_defaults_ignores_non_numeric_override():
+    """A non-numeric YAML weight must fall back to the default, not raise."""
+    merged = _merge_defaults(
+        _DEFAULT_SIGNALS, {"news": "high", "insider_activity": 3, "bad": None}
+    )
+
+    assert merged["news"] == _DEFAULT_SIGNALS["news"]  # kept default, no crash
+    assert merged["insider_activity"] == 3.0  # valid override applied
+    assert "bad" not in merged  # None override skipped, not added
 
 
 def test_defaults_seed_vision_table():

--- a/web-ui/src/components/domain/workspace/NarrativeAnalysisCard.test.tsx
+++ b/web-ui/src/components/domain/workspace/NarrativeAnalysisCard.test.tsx
@@ -453,7 +453,9 @@ describe('NarrativeAnalysisCard — analysis timeline', () => {
     openTimeline();
     expect(await screen.findByText('Hold into the open.')).toBeInTheDocument();
     expect(screen.getByText('Initial breakout entry.')).toBeInTheDocument();
-    expect(screen.getByText('Confirmed')).toBeInTheDocument();
+    expect(
+      screen.getByText(t('workspacePage.panels.analysis.intelligence.timeline.outcome.confirmed')),
+    ).toBeInTheDocument();
     expect(screen.getByText('SMA20 support held after the follow-up run.')).toBeInTheDocument();
     expect(screen.getByText('Jun 25, 2026')).toBeInTheDocument();
   });


### PR DESCRIPTION
- config: skip non-numeric evidence-weight overrides instead of crashing the whole analysis (float() was outside the try/except)
- history: require >=60% prediction-token coverage so generic 2-token overlaps no longer mark predictions confirmed/contradicted
- chat: build OpenAI client with configured timeout/max_retries
- nodes: guard upside_pct division against close == 0
- symbol_analyzer: cache the compiled langgraph instead of rebuilding it on every analyze() call
- dedup has_position predicate into is_position_request (single source)
- chat _read_messages: tolerate non-dict JSON payloads
- test: assert i18n key instead of hardcoded 'Confirmed'