### PR TITLE
[codex] Refine strategic review overlay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,7 @@ data/intelligence/education_*.json
 data/intelligence/sweep_*.json
 data/intelligence/evidence/
 data/intelligence/history/
+data/intelligence/chat/
 data/screener_history.json
 
 # =========================

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ All execution stays manual. The system screens, sizes, and analyzes. You decide 
 
 **Position sizing.** Every size is computed in R-multiples: `1R = entry - stop`. No fixed-dollar or percentage-based sizing, ever. The risk model accounts for portfolio heat, regime scaling, and sector concentration.
 
-**AI analysis.** An LLM-powered intelligence layer analyzes each candidate in two passes: a quick signal read, then a deep evidence sweep pulling in price action context, SEC filings, and held positions. Returns a structured trade plan with specific entry, stop, and target.
+**AI analysis.** An LLM-powered intelligence layer enriches each candidate or held position with price action, fundamentals, evidence, and history, then runs a two-call OpenAI analysis: web-search narrative first, structured schema formatting second. Returns a structured trade plan with specific entry, stop, target, citations, and an advisory evidence ledger.
 
 **Portfolio tracking.** Manages open positions through their full lifecycle: entry, trail, exit. Tracks R-multiples realized, stop adjustments, and exhaustion scores.
 
@@ -70,7 +70,7 @@ Copy `.env.example` to `.env` at the repo root before running the API.
 
 | Variable | Required | Description |
 | --- | --- | --- |
-| `ANTHROPIC_API_KEY` | For AI analysis | Claude API key, used by `POST /api/intelligence/{ticker}` and all intelligence endpoints |
+| `OPENAI_API_KEY` | For AI analysis | OpenAI API key, used by `POST /api/intelligence/{ticker}` and all LLM-backed intelligence endpoints |
 | `SWING_SCREENER_PROVIDER` | No (defaults to `yfinance`) | EOD data provider: `yfinance` or `alpaca` |
 | `ALPACA_API_KEY` / `ALPACA_SECRET_KEY` | If using Alpaca | Alpaca market data keys. `ALPACA_PAPER` defaults to `true` |
 | `FINNHUB_API_KEY` | No (degrades analysis) | Calendar, earnings proximity, analyst and insider enrichment |
@@ -101,7 +101,7 @@ data/                  Runtime state: positions.json, orders.json
 Layer responsibilities: [`docs/engineering/MODULE_ARCHITECTURE.md`](docs/engineering/MODULE_ARCHITECTURE.md).
 API surface: [`api/README.md`](api/README.md).
 Frontend guide: [`web-ui/docs/WEB_UI_GUIDE.md`](web-ui/docs/WEB_UI_GUIDE.md).
-Intelligence pipeline: [`src/swing_screener/intelligence/README.md`](src/swing_screener/intelligence/README.md).
+Intelligence pipeline and observability diagrams: [`src/swing_screener/intelligence/README.md`](src/swing_screener/intelligence/README.md).
 
 ---
 
@@ -134,7 +134,7 @@ Key starting points:
 | Daily trading workflow | [`docs/product/DAILY_USAGE_GUIDE.md`](docs/product/DAILY_USAGE_GUIDE.md) |
 | DeGiro order setup | [`docs/product/DEGIRO_ORDER_SETUP.md`](docs/product/DEGIRO_ORDER_SETUP.md) |
 | Module architecture | [`docs/engineering/MODULE_ARCHITECTURE.md`](docs/engineering/MODULE_ARCHITECTURE.md) |
-| Intelligence pipeline | [`src/swing_screener/intelligence/README.md`](src/swing_screener/intelligence/README.md) |
+| Intelligence pipeline and observability diagrams | [`src/swing_screener/intelligence/README.md`](src/swing_screener/intelligence/README.md) |
 | Config reference | [`config/README.md`](config/README.md) |
 | Roadmap | [`docs/engineering/ROADMAP.md`](docs/engineering/ROADMAP.md) |
 

--- a/docs/overview/INDEX.md
+++ b/docs/overview/INDEX.md
@@ -43,7 +43,7 @@
 
 | Module | Doc | What it covers |
 | --- | --- | --- |
-| Intelligence | [`src/swing_screener/intelligence/README.md`](/src/swing_screener/intelligence/README.md) | LLM pipeline, two-call architecture, evidence collectors, caching, action types |
+| Intelligence | [`src/swing_screener/intelligence/README.md`](/src/swing_screener/intelligence/README.md) | LLM pipeline diagrams, data/source map, prompt flow, observability, evidence collectors, caching, action types |
 | Data | [`src/swing_screener/data/README.md`](/src/swing_screener/data/README.md) | OHLCV provider config, caching, universes, per-symbol eval cache |
 | Data providers | [`src/swing_screener/data/providers/README.md`](/src/swing_screener/data/providers/README.md) | Provider table, how to add/remove a data source |
 | Selection | [`src/swing_screener/selection/README.md`](/src/swing_screener/selection/README.md) | Universe filtering, momentum ranking, entry signal detection |

--- a/src/swing_screener/intelligence/README.md
+++ b/src/swing_screener/intelligence/README.md
@@ -29,8 +29,86 @@ POST /api/intelligence/sweep            — batch run across watchlist + open po
 ```
 
 Router: `api/routers/intelligence.py`
-Service: `api/services/intelligence_service.py`
+Services: `api/services/intelligence_enrichment.py`,
+`api/services/intelligence_chat_service.py`,
+`api/services/position_review_service.py`, and
+`api/services/strategic_review_service.py`
 Core: `symbol_analyzer.py`
+
+## Flow at a glance
+
+The current single-symbol analyzer is a linear LangGraph wrapped by the FastAPI
+intelligence endpoints. Cache checks and server-side enrichment happen before
+the graph; cache/history/metrics writes happen inside the final `persist` node.
+
+```mermaid
+flowchart TD
+  UI[React workspace UI] --> API[FastAPI /api/intelligence]
+  API --> Cache{Same-day cache hit?}
+  Cache -->|yes| Cached[Return cached SymbolIntelligence]
+  Cache -->|no or force=true| Enrich[Server-side enrichment]
+
+  Enrich --> Fundamentals[Fundamentals snapshot]
+  Enrich --> Earnings[Earnings and dividend proximity]
+  Enrich --> Evidence[Configured evidence collectors]
+  Enrich --> Prices[Polygon or portfolio OHLCV technicals]
+  Enrich --> Graph[LangGraph SymbolAnalyzer]
+
+  Graph --> Resolve[resolve_context]
+  Resolve --> Inputs[assemble_inputs]
+  Inputs --> Prompt[build_prompt]
+  Prompt --> Search[search: OpenAI Responses + web_search_preview]
+  Search --> Format[format: structured output parse]
+  Format --> Postprocess[postprocess: tokens and source counts]
+  Postprocess --> Weigh[weigh_evidence]
+  Weigh --> Assemble[assemble_result]
+  Assemble --> Persist[persist cache, history, metrics]
+  Persist --> Result[SymbolIntelligence]
+```
+
+## Data and source map
+
+The LLM sees an assembled prompt, not raw application state. The deterministic
+enrichment layer decides which app fields, market data, evidence items, and
+history entries are present before the OpenAI calls run.
+
+```mermaid
+flowchart LR
+  Candidate[Screener candidate payload] --> Prompt[Analyzer prompt]
+  Position[Open position context] --> Prompt
+  Technicals[OHLCV features: close, SMA, ATR, momentum, 52w distance, candles] --> Prompt
+  Fundamentals[Fundamentals: P/E, growth, margins, ROE, leverage] --> Prompt
+  Finnhub[Finnhub enrichment: insiders, EPS, analyst actions] --> Prompt
+  Evidence[SourceEvidence: SEC EDGAR, Polygon news, DeGiro news, Tavily refresh-only] --> Prompt
+  History[Prior analysis digest] --> Prompt
+  PastTrades[Closed positions on ticker] --> Prompt
+  PreOpen[US pre-open state] --> Prompt
+
+  Prompt --> SearchCall[Call 1: web-search narrative]
+  SearchCall --> FormatCall[Call 2: schema formatter]
+  FormatCall --> Intelligence[SymbolIntelligence]
+  Intelligence --> Ledger[EvidenceLedger]
+  Intelligence --> CacheStore[Per-ticker cache]
+  Intelligence --> HistoryStore[Per-symbol history]
+  Intelligence --> UIResult[Workspace intelligence panels]
+```
+
+## Prompt and model flow
+
+The analyzer deliberately splits research from schema extraction. Call 1 can use
+web search and write prose with citations; call 2 is tool-free and converts that
+prose into the validated pydantic schema.
+
+```mermaid
+flowchart TD
+  SystemPrompt[_SYSTEM_PROMPT: role, search strategy, trading rules, output requirements] --> SearchCall
+  UserPrompt[_build_user_prompt: trade plan, inputs, evidence, history, position mode] --> SearchCall
+  SearchCall[OpenAI Responses call 1<br/>model: config.llm.web_search_model<br/>tool: web_search_preview] --> Writeup[Markdown analyst write-up + Sources list]
+  FormatPrompt[_FORMAT_PROMPT: convert write-up into schema, do not invent fields] --> FormatCall
+  Writeup --> FormatCall[OpenAI Responses parse call 2<br/>model: config.llm.format_model<br/>tool use: none]
+  FormatCall --> Draft[_LLMAnalysis or _LLMPositionAnalysis]
+  Draft --> Result[SymbolIntelligence]
+```
 
 ## Input Context
 
@@ -200,15 +278,44 @@ Results stored as JSON under `data/intelligence/<ticker>_analysis.json`. TTL is 
 
 ## Observability
 
-`data/intelligence/intelligence_metrics.json` — append-only log (capped at 500 entries) written by `metrics.py` after each analysis. Each entry: `{ts, ticker, tokens}`. A sudden `tokens: null` run pinpoints a call that did not complete; a gap in SEC coverage is visible by diffing evidence counts in the logged evidence cache.
+The module exposes result-level observability today. A successful analysis
+contains the data categories used, cited sources, advisory ledger output, and
+history metadata; metrics add a capped token log for quick operational checks.
+
+```mermaid
+flowchart LR
+  Result[SymbolIntelligence] --> Inputs[inputs_used: trade plan, technicals, fundamentals, source counts]
+  Result --> Sources[sources: URLs cited by the model]
+  Result --> Catalysts[classified_catalysts: typed cited catalysts]
+  Result --> Ledger[evidence_ledger: deterministic bull/bear balance]
+  Result --> Timeline[history/{TICKER}.json: thesis drift timeline]
+  Result --> Chat[chat/{TICKER}/{date}.json: follow-up Q&A]
+  Persist[persist node] --> Metrics[intelligence_metrics.json: ts, ticker, tokens]
+```
+
+`data/intelligence/intelligence_metrics.json` is an append-only log (capped at
+500 entries) written by `metrics.py` after each analysis. Each entry is
+`{ts, ticker, tokens}`. A sudden `tokens: null` run pinpoints a call that did
+not complete; source coverage is visible through `inputs_used.sources` on the
+cached result and the per-date evidence cache.
+
+The next observability increment should be a durable per-run trace. That trace
+would store one row per graph step (`resolve_context`, `assemble_inputs`,
+`build_prompt`, `search`, `format`, `postprocess`, `weigh_evidence`,
+`assemble_result`, `persist`) with status, duration, prompt hash or redacted
+preview, model name, token usage, source counts, and errors. The UI can then
+render a step timeline without exposing full prompts by default.
 
 ## Action Types
 
 `SymbolIntelligence.action` is one of:
 - `BUY_NOW` — entry signal active at current price
 - `BUY_ON_PULLBACK` — waiting for price to pull back to planned entry level
+- `WAIT_FOR_BREAKOUT` — waiting for confirmation above a breakout level
+- `WATCH` — worth monitoring, but not actionable yet
+- `TACTICAL_ONLY` — short-term or event-specific setup only
+- `AVOID` — no acceptable setup under the current evidence
 - `MANAGE_ONLY` — position already held; narrative is position-management focused
-- `SKIP` — no actionable signal
 
 ## Evidence Collectors
 

--- a/web-ui/src/components/domain/workspace/StrategicReviewPanel.test.tsx
+++ b/web-ui/src/components/domain/workspace/StrategicReviewPanel.test.tsx
@@ -58,7 +58,7 @@ describe('StrategicReviewPanel', () => {
     } as never);
   });
 
-  it('runs a manual strategic review with refresh sources and defensive risk mode', async () => {
+  it('runs a manual strategic review with default watch areas, no topic, refresh sources, and defensive risk mode', async () => {
     const mutate = vi.fn();
     vi.mocked(intelligenceHooks.useStrategicReviewMutation).mockReturnValue({
       mutate,
@@ -70,6 +70,10 @@ describe('StrategicReviewPanel', () => {
 
     const { user } = renderWithProviders(<StrategicReviewPanel ticker="ASML" />);
 
+    expect(screen.getByLabelText(t(`${I18N_PREFIX}.watchArea.macro`))).toBeChecked();
+    expect(screen.getByLabelText(t(`${I18N_PREFIX}.watchArea.geopolitics`))).toBeChecked();
+    expect(screen.getByLabelText(t(`${I18N_PREFIX}.watchArea.earnings`))).toBeChecked();
+
     await user.click(screen.getByLabelText(t(`${I18N_PREFIX}.refreshSources`)));
     await user.selectOptions(screen.getByLabelText(t(`${I18N_PREFIX}.riskModeLabel`)), 'defensive');
     await user.click(screen.getByRole('button', { name: t(`${I18N_PREFIX}.runAction`) }));
@@ -80,12 +84,12 @@ describe('StrategicReviewPanel', () => {
         refreshSources: true,
         riskMode: 'defensive',
         horizonDays: 10,
-        topic: null,
+        topic: 'macro, geopolitics, earnings',
       });
     });
   });
 
-  it('renders strategic situations, predictions, actions, and memo', () => {
+  it('renders strategic situations, predictions, actions, memo, and directional indicators', () => {
     vi.mocked(intelligenceHooks.useStrategicReviewMutation).mockReturnValue({
       mutate: vi.fn(),
       data: review,
@@ -101,5 +105,7 @@ describe('StrategicReviewPanel', () => {
     expect(screen.getByText('Demand remains constructive, but policy risk can interrupt follow-through.')).toBeInTheDocument();
     expect(screen.getByText('Review exposed symbol')).toBeInTheDocument();
     expect(screen.getByText('Strategic overlay built from app context only for ASML.')).toBeInTheDocument();
+    expect(screen.getByLabelText('Mixed strategic signal')).toBeInTheDocument();
+    expect(screen.getByText(t(`${I18N_PREFIX}.signal.mixed`))).toBeInTheDocument();
   });
 });

--- a/web-ui/src/components/domain/workspace/StrategicReviewPanel.tsx
+++ b/web-ui/src/components/domain/workspace/StrategicReviewPanel.tsx
@@ -2,8 +2,9 @@ import { useState } from 'react';
 
 import Button from '@/components/common/Button';
 import { useStrategicReviewMutation } from '@/features/intelligence/hooks';
-import type { StrategicReview, StrategicSituation } from '@/features/intelligence/strategicReviewTypes';
+import type { StrategicDirection, StrategicReview, StrategicSituation } from '@/features/intelligence/strategicReviewTypes';
 import { t } from '@/i18n/t';
+import { cn } from '@/utils/cn';
 
 const I18N_PREFIX = 'workspacePage.panels.analysis.intelligence.strategic';
 
@@ -11,19 +12,80 @@ interface StrategicReviewPanelProps {
   ticker: string;
 }
 
+const WATCH_AREAS = [
+  { id: 'macro', labelKey: 'watchArea.macro' },
+  { id: 'geopolitics', labelKey: 'watchArea.geopolitics' },
+  { id: 'earnings', labelKey: 'watchArea.earnings' },
+  { id: 'sector_rotation', labelKey: 'watchArea.sectorRotation' },
+] as const;
+
+type WatchAreaId = (typeof WATCH_AREAS)[number]['id'];
+
+const DEFAULT_WATCH_AREAS: WatchAreaId[] = ['macro', 'geopolitics', 'earnings'];
+
 function formatLabel(value: string) {
   return value.replace(/_/g, ' ').toLowerCase();
 }
 
+function directionTone(direction: StrategicDirection | null) {
+  switch (direction) {
+    case 'bullish':
+      return {
+        label: t(`${I18N_PREFIX}.signal.bullish`),
+        ariaLabel: 'Bullish strategic signal',
+        border: 'border-l-success',
+        dot: 'bg-success',
+        chip: 'border-success/40 bg-success/10 text-success',
+        text: 'text-success',
+      };
+    case 'bearish':
+      return {
+        label: t(`${I18N_PREFIX}.signal.bearish`),
+        ariaLabel: 'Bearish strategic signal',
+        border: 'border-l-danger',
+        dot: 'bg-danger',
+        chip: 'border-danger/40 bg-danger/10 text-danger',
+        text: 'text-danger',
+      };
+    case 'mixed':
+      return {
+        label: t(`${I18N_PREFIX}.signal.mixed`),
+        ariaLabel: 'Mixed strategic signal',
+        border: 'border-l-primary',
+        dot: 'bg-primary',
+        chip: 'border-primary/40 bg-primary/10 text-primary',
+        text: 'text-primary',
+      };
+    default:
+      return {
+        label: t(`${I18N_PREFIX}.signal.neutral`),
+        ariaLabel: 'Neutral strategic signal',
+        border: 'border-l-border',
+        dot: 'bg-muted',
+        chip: 'border-border bg-surface text-muted',
+        text: 'text-muted',
+      };
+  }
+}
+
 function SituationCard({ situation }: { situation: StrategicSituation }) {
   const prediction = situation.predictions[0] ?? null;
+  const tone = directionTone(prediction?.direction ?? 'neutral');
   return (
-    <article className="rounded-lg border border-border bg-background/40 p-3">
+    <article className={cn('rounded-lg border border-l-4 border-border bg-background/40 p-3', tone.border)}>
       <div className="flex flex-wrap items-center justify-between gap-2">
-        <h3 className="text-sm font-semibold text-foreground">{situation.title}</h3>
-        <span className="rounded-full border border-border px-2 py-0.5 text-xs uppercase tracking-wide text-muted">
-          {situation.stage}
-        </span>
+        <div className="flex items-center gap-2">
+          <span aria-label={tone.ariaLabel} className={cn('h-2.5 w-2.5 rounded-full', tone.dot)} />
+          <h3 className="text-sm font-semibold text-foreground">{situation.title}</h3>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <span className={cn('rounded-full border px-2 py-0.5 text-xs uppercase tracking-wide', tone.chip)}>
+            {tone.label}
+          </span>
+          <span className="rounded-full border border-border px-2 py-0.5 text-xs uppercase tracking-wide text-muted">
+            {situation.stage}
+          </span>
+        </div>
       </div>
 
       {situation.affectedSymbols.length > 0 && (
@@ -41,7 +103,10 @@ function SituationCard({ situation }: { situation: StrategicSituation }) {
           <p className="text-[11px] font-semibold uppercase tracking-wide text-muted">{t(`${I18N_PREFIX}.whyNow`)}</p>
           <ul className="mt-1 grid gap-1 text-sm text-muted">
             {situation.whyNow.map((item) => (
-              <li key={item}>• {item}</li>
+              <li key={item} className="flex gap-2">
+                <span aria-hidden="true" className={cn('mt-2 h-1.5 w-1.5 shrink-0 rounded-full', tone.dot)} />
+                <span>{item}</span>
+              </li>
             ))}
           </ul>
         </div>
@@ -66,7 +131,10 @@ function SituationCard({ situation }: { situation: StrategicSituation }) {
       {situation.actions.length > 0 && (
         <div className="mt-3 grid gap-2">
           {situation.actions.map((action) => (
-            <div key={`${action.actionType}-${action.title}`} className="rounded-md border border-border bg-surface px-3 py-2">
+            <div
+              key={`${action.actionType}-${action.title}`}
+              className={cn('rounded-md border border-l-4 border-border bg-surface px-3 py-2', tone.border)}
+            >
               <p className="text-sm font-medium text-foreground">{action.title}</p>
               <p className="mt-1 text-xs text-muted">{action.rationale}</p>
             </div>
@@ -101,17 +169,28 @@ function StrategicResult({ review }: { review: StrategicReview }) {
 export default function StrategicReviewPanel({ ticker }: StrategicReviewPanelProps) {
   const [refreshSources, setRefreshSources] = useState(false);
   const [riskMode, setRiskMode] = useState<'normal' | 'defensive' | 'aggressive'>('normal');
+  const [watchAreas, setWatchAreas] = useState<WatchAreaId[]>(DEFAULT_WATCH_AREAS);
   const [topic, setTopic] = useState('');
   const mutation = useStrategicReviewMutation();
 
   const handleRun = () => {
+    const selectedWatchAreas = WATCH_AREAS.filter((area) => watchAreas.includes(area.id)).map((area) =>
+      t(`${I18N_PREFIX}.${area.labelKey}`).toLowerCase()
+    );
+    const investigationTopic = topic.trim();
+    const topicParts = [...selectedWatchAreas, ...(investigationTopic ? [investigationTopic] : [])];
+
     mutation.mutate({
       ticker,
-      topic: topic.trim() || null,
+      topic: topicParts.length > 0 ? topicParts.join(', ') : null,
       refreshSources,
       riskMode,
       horizonDays: 10,
     });
+  };
+
+  const toggleWatchArea = (id: WatchAreaId) => {
+    setWatchAreas((current) => (current.includes(id) ? current.filter((item) => item !== id) : [...current, id]));
   };
 
   return (
@@ -127,6 +206,31 @@ export default function StrategicReviewPanel({ ticker }: StrategicReviewPanelPro
       </div>
 
       <div className="grid gap-3 px-3 py-3">
+        <div className="grid gap-2">
+          <p className="text-xs font-semibold uppercase tracking-wide text-muted">{t(`${I18N_PREFIX}.watchListLabel`)}</p>
+          <div className="flex flex-wrap gap-2">
+            {WATCH_AREAS.map((area) => (
+              <label
+                key={area.id}
+                className={cn(
+                  'flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-medium',
+                  watchAreas.includes(area.id)
+                    ? 'border-primary/40 bg-primary/10 text-primary'
+                    : 'border-border bg-surface text-muted'
+                )}
+              >
+                <input
+                  type="checkbox"
+                  checked={watchAreas.includes(area.id)}
+                  disabled={mutation.isPending}
+                  onChange={() => toggleWatchArea(area.id)}
+                />
+                {t(`${I18N_PREFIX}.${area.labelKey}`)}
+              </label>
+            ))}
+          </div>
+        </div>
+
         <div className="grid gap-2 md:grid-cols-[1fr_auto_auto]">
           <label className="grid gap-1 text-xs text-muted">
             {t(`${I18N_PREFIX}.topicLabel`)}

--- a/web-ui/src/i18n/messages.en.ts
+++ b/web-ui/src/i18n/messages.en.ts
@@ -894,7 +894,20 @@ export const messagesEn = {
             runAction: 'Run strategic overlay',
             runningAction: 'Building overlay...',
             topicLabel: 'Topic',
-            topicPlaceholder: 'Optional: rates, export controls, sector rotation...',
+            topicPlaceholder: 'Optional extra topic: rates, export controls, sector rotation...',
+            watchListLabel: 'Default checks',
+            watchArea: {
+              macro: 'Macro',
+              geopolitics: 'Geopolitics',
+              earnings: 'Earnings',
+              sectorRotation: 'Sector rotation',
+            },
+            signal: {
+              bullish: 'Bullish',
+              bearish: 'Bearish',
+              mixed: 'Mixed',
+              neutral: 'Neutral',
+            },
             riskModeLabel: 'Risk mode',
             riskMode: {
               normal: 'Normal',


### PR DESCRIPTION
## Summary
- add default strategic watch-area checks and include them in overlay requests
- add directional signal indicators to strategic review cards
- document the current OpenAI intelligence pipeline and ignore runtime chat cache output