### PR TITLE
Fix intelligence strategy state

### DIFF
--- a/api/models/intelligence_chat.py
+++ b/api/models/intelligence_chat.py
@@ -33,5 +33,6 @@ class IntelligenceChatRequest(BaseModel):
 class IntelligenceChatResponse(BaseModel):
     ticker: str
     chat_date: str
+    analysis_generated_at: str
     messages: list[IntelligenceChatMessage]
     refreshed_at: str | None = None

--- a/api/models/strategy.py
+++ b/api/models/strategy.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from typing import Optional, Literal
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, field_validator
 
 
 class StrategyTrend(BaseModel):
@@ -95,29 +95,12 @@ class StrategyManage(BaseModel):
 
 class StrategyIntelligenceLLM(BaseModel):
     enabled: bool = False
-    provider: Literal["mock", "openai"] = "openai"
+    provider: Literal["openai"] = "openai"
     model: str = "gpt-4.1-mini"
-    base_url: str = "https://api.openai.com/v1"
-    enable_cache: bool = True
-    enable_audit: bool = True
-    cache_path: str = "data/intelligence/llm_cache.json"
-    audit_path: str = "data/intelligence/llm_audit"
-    max_concurrency: int = Field(default=4, ge=1, le=16)
-
-    @model_validator(mode="after")
-    def coerce_mock_fields(self) -> "StrategyIntelligenceLLM":
-        if self.provider != "mock":
-            return self
-        self.model = "mock-classifier"
-        self.base_url = ""
-        return self
 
 
 class StrategyIntelligenceCatalyst(BaseModel):
     lookback_hours: int = Field(default=72, ge=1)
-    recency_half_life_hours: int = Field(default=36, ge=1)
-    false_catalyst_return_z: float = Field(default=1.5, ge=0)
-    min_price_reaction_atr: float = Field(default=0.8, ge=0)
     require_price_confirmation: bool = True
 
 
@@ -125,7 +108,6 @@ class StrategyIntelligenceTheme(BaseModel):
     enabled: bool = True
     min_cluster_size: int = Field(default=3, ge=1)
     min_peer_confirmation: int = Field(default=2, ge=1)
-    curated_peer_map_path: str = "data/intelligence/peer_map.yaml"
 
 
 class StrategyIntelligenceOpportunity(BaseModel):
@@ -137,42 +119,10 @@ class StrategyIntelligenceOpportunity(BaseModel):
 
 class StrategyMarketIntelligence(BaseModel):
     enabled: bool = False
-    providers: list[str] = Field(default_factory=lambda: ["yahoo_finance"])
-    universe_scope: Literal["screener_universe", "strategy_universe"] = "screener_universe"
-    market_context_symbols: list[str] = Field(
-        default_factory=lambda: ["SPY", "QQQ", "XLK", "SMH", "XBI"]
-    )
     llm: StrategyIntelligenceLLM = Field(default_factory=StrategyIntelligenceLLM)
     catalyst: StrategyIntelligenceCatalyst = Field(default_factory=StrategyIntelligenceCatalyst)
     theme: StrategyIntelligenceTheme = Field(default_factory=StrategyIntelligenceTheme)
     opportunity: StrategyIntelligenceOpportunity = Field(default_factory=StrategyIntelligenceOpportunity)
-
-    @field_validator("providers")
-    @classmethod
-    def validate_intel_providers(cls, values: list[str]) -> list[str]:
-        cleaned: list[str] = []
-        for value in values:
-            text = str(value).strip().lower()
-            if not text:
-                continue
-            if text not in {"yahoo_finance", "earnings_calendar"}:
-                continue
-            if text not in cleaned:
-                cleaned.append(text)
-        return cleaned or ["yahoo_finance"]
-
-    @field_validator("market_context_symbols")
-    @classmethod
-    def validate_market_context_symbols(cls, values: list[str]) -> list[str]:
-        cleaned: list[str] = []
-        for value in values:
-            text = str(value).strip().upper()
-            if not text:
-                continue
-            if text not in cleaned:
-                cleaned.append(text)
-        return cleaned or ["SPY", "QQQ", "XLK", "SMH", "XBI"]
-
 
 class StrategyBase(BaseModel):
     name: str

--- a/api/routers/intelligence.py
+++ b/api/routers/intelligence.py
@@ -28,7 +28,7 @@ from swing_screener.intelligence.cache import read_from_cache
 from swing_screener.intelligence.history import HistoryEntry, read_history
 from swing_screener.intelligence.models import SymbolIntelligence, SymbolIntelligenceRequest
 from swing_screener.intelligence.strategic import StrategicIntelligenceReport
-from swing_screener.intelligence.config_access import intelligence_config_section
+from swing_screener.intelligence.config_access import effective_intelligence_config
 from swing_screener.intelligence.symbol_analyzer import SymbolAnalyzer
 from swing_screener.intelligence.tracing import (
     RunIndexEntry,
@@ -106,7 +106,10 @@ def _require_api_key() -> None:
 
 
 def _require_analyzer_enabled() -> None:
-    cfg = intelligence_config_section("llm")
+    runtime = effective_intelligence_config()
+    cfg = runtime.get("llm", {})
+    if not bool(runtime.get("enabled", False)) or not bool(cfg.get("enabled", True)):
+        raise HTTPException(status_code=503, detail="Symbol intelligence is disabled for the active strategy")
     if not bool(cfg.get("analyzer_enabled", True)):
         raise HTTPException(status_code=503, detail="Symbol intelligence analyzer is disabled")
 

--- a/api/services/intelligence_chat_service.py
+++ b/api/services/intelligence_chat_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 import uuid
+from hashlib import sha256
 from collections.abc import Callable
 from datetime import date, datetime, timezone
 from pathlib import Path
@@ -44,6 +45,13 @@ def _chat_root() -> Path:
 
 def _chat_file(ticker: str, chat_date: date) -> Path:
     return _chat_root() / ticker.upper() / f"{chat_date.isoformat()}.json"
+
+
+def _archive_chat_file(ticker: str, chat_date: date, analysis_generated_at: str | None) -> Path:
+    """Give a replaced conversation a stable, filesystem-safe revision name."""
+    revision = analysis_generated_at or "unknown"
+    digest = sha256(revision.encode("utf-8")).hexdigest()[:12]
+    return _chat_root() / ticker.upper() / f"{chat_date.isoformat()}.{digest}.json"
 
 
 def _normalize_evidence(items: list[SourceEvidence]) -> list[IntelligenceChatEvidence]:
@@ -102,6 +110,7 @@ def _default_answer_fn(
     model = str(configured_model)
     client = OpenAI(
         api_key=os.environ.get("OPENAI_API_KEY"),
+        base_url=(str(cfg.get("base_url")).strip() if cfg.get("base_url") else None),
         timeout=float(cfg.get("request_timeout_seconds", 60.0)),
         max_retries=int(cfg.get("max_retries", 2)),
     )
@@ -161,8 +170,21 @@ class IntelligenceChatService:
         intelligence = read_from_cache(ticker, for_date=chat_date)
         if intelligence is None:
             raise MissingIntelligenceError(f"No cached analysis for {ticker} on {chat_date.isoformat()}")
-        messages = self._read_messages(ticker, chat_date)
-        return IntelligenceChatResponse(ticker=ticker, chat_date=chat_date.isoformat(), messages=messages)
+        stored = self._read_chat(ticker, chat_date)
+        # A GET is read-only. If a refresh replaced the analysis before a later
+        # POST can archive the previous conversation, do not leak those messages
+        # into the new revision.
+        messages = (
+            self._messages_from(stored)
+            if self._stored_revision(stored) == intelligence.generated_at
+            else []
+        )
+        return IntelligenceChatResponse(
+            ticker=ticker,
+            chat_date=chat_date.isoformat(),
+            analysis_generated_at=intelligence.generated_at,
+            messages=messages,
+        )
 
     def send_message(
         self,
@@ -176,7 +198,19 @@ class IntelligenceChatService:
         if intelligence is None:
             raise MissingIntelligenceError(f"No cached analysis for {ticker} on {chat_date.isoformat()}")
 
-        existing = self._read_messages(ticker, chat_date)
+        stored = self._read_chat(ticker, chat_date)
+        requested_revision = (request.analysis_generated_at or "").strip() or None
+        current_revision = intelligence.generated_at
+        if self._stored_revision(stored) != current_revision:
+            self._archive_stale_chat(ticker, chat_date, stored)
+            existing: list[IntelligenceChatMessage] = []
+        elif requested_revision is not None and requested_revision != current_revision:
+            # The browser submitted a message from a stale analysis card. Never
+            # append it to any existing revision; the answer is grounded only in
+            # the current cached analysis.
+            existing = []
+        else:
+            existing = self._messages_from(stored)
         user_message = IntelligenceChatMessage(
             id=str(uuid.uuid4()),
             role="user",
@@ -206,24 +240,54 @@ class IntelligenceChatService:
         )
         messages = [*existing, user_message, assistant_message]
         refreshed_at = _now_iso() if request.refresh_sources else None
-        self._write_chat(ticker, chat_date, messages, intelligence.generated_at, refreshed_at)
+        self._write_chat(ticker, chat_date, messages, current_revision, refreshed_at)
         return IntelligenceChatResponse(
             ticker=ticker,
             chat_date=chat_date.isoformat(),
+            analysis_generated_at=current_revision,
             messages=messages,
             refreshed_at=refreshed_at,
         )
 
-    def _read_messages(self, ticker: str, chat_date: date) -> list[IntelligenceChatMessage]:
+    def _read_chat(self, ticker: str, chat_date: date) -> dict[str, Any] | None:
         path = _chat_file(ticker, chat_date)
         if not path.exists():
-            return []
+            return None
         try:
             raw = json.loads(path.read_text())
-            messages = raw.get("messages", []) if isinstance(raw, dict) else []
-            return [IntelligenceChatMessage.model_validate(item) for item in messages]
+            return raw if isinstance(raw, dict) else None
         except (OSError, ValueError, TypeError):
+            return None
+
+    @staticmethod
+    def _stored_revision(stored: dict[str, Any] | None) -> str | None:
+        if stored is None:
+            return None
+        value = stored.get("analysis_generated_at")
+        return value if isinstance(value, str) and value else None
+
+    @staticmethod
+    def _messages_from(stored: dict[str, Any] | None) -> list[IntelligenceChatMessage]:
+        if stored is None:
             return []
+        try:
+            messages = stored.get("messages", [])
+            return [IntelligenceChatMessage.model_validate(item) for item in messages]
+        except (ValueError, TypeError):
+            return []
+
+    def _archive_stale_chat(
+        self,
+        ticker: str,
+        chat_date: date,
+        stored: dict[str, Any] | None,
+    ) -> None:
+        if stored is None or not self._messages_from(stored):
+            return
+        archive = _archive_chat_file(ticker, chat_date, self._stored_revision(stored))
+        # Preserve the old payload rather than mutating it. The current-path
+        # write below atomically establishes the new analysis revision.
+        write_json_with_lock(archive, stored)
 
     def _write_chat(
         self,

--- a/src/swing_screener/intelligence/config_access.py
+++ b/src/swing_screener/intelligence/config_access.py
@@ -1,20 +1,122 @@
 from __future__ import annotations
 
+from copy import deepcopy
+from math import ceil
 from typing import Any
 
 from swing_screener.settings import get_settings_manager
 
 
-def intelligence_config_section(name: str) -> dict[str, Any]:
-    """Return `config.<name>` from the intelligence document, or `{}` on any error.
+def _as_mapping(value: Any) -> dict[str, Any]:
+    return deepcopy(value) if isinstance(value, dict) else {}
 
-    Single source of truth for reading a subsection of the intelligence config.
-    Fail-soft: a missing or unreadable document yields an empty dict so callers
-    degrade to their own defaults rather than raising.
-    """
+
+def _active_strategy() -> dict[str, Any]:
+    """Load the active strategy without making intelligence callers own storage."""
     try:
-        doc = get_settings_manager().load_intelligence_document()
-        section = doc.get("config", {}).get(name, {})
+        # Keep the import local to avoid an application-startup settings/storage
+        # cycle. Storage also provides the deterministic deleted-strategy fallback.
+        from swing_screener.strategy.storage import get_active_strategy
+
+        return _as_mapping(get_active_strategy())
     except Exception:
         return {}
-    return section or {}
+
+
+def effective_intelligence_config(
+    *,
+    global_config: dict[str, Any] | None = None,
+    active_strategy: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Resolve the runtime intelligence contract for the active strategy.
+
+    Global configuration owns credentials, endpoint policy, timeouts, retries,
+    tracing, source safety, and the deployment ``llm.analyzer_enabled`` kill
+    switch. The active strategy owns advisory policy: enablement, permitted
+    model/provider selection, evidence lookback/confirmation, theme policy, and
+    opportunity policy. Missing or legacy strategy policy falls back safely to
+    the global document instead of failing an in-flight request.
+    """
+    if global_config is None:
+        try:
+            document = get_settings_manager().load_intelligence_document()
+            global_config = _as_mapping(_as_mapping(document).get("config"))
+        except Exception:
+            global_config = {}
+    else:
+        global_config = _as_mapping(global_config)
+
+    resolved = deepcopy(global_config)
+    strategy = _as_mapping(active_strategy) if active_strategy is not None else _active_strategy()
+    market = _as_mapping(strategy.get("market_intelligence"))
+    if not market:
+        resolved["policy"] = {
+            "strategy_id": strategy.get("id"),
+            "enabled": bool(global_config.get("enabled", False)),
+        }
+        return resolved
+
+    global_llm = _as_mapping(global_config.get("llm"))
+    strategy_llm = _as_mapping(market.get("llm"))
+    configured_provider = str(global_llm.get("provider", "openai")).strip().lower() or "openai"
+    allowed_providers = global_llm.get("permitted_providers")
+    if not isinstance(allowed_providers, list):
+        # A deployment can explicitly permit more providers. Otherwise a strategy
+        # cannot accidentally select a provider the deployment does not support.
+        allowed_providers = [configured_provider]
+    permitted = {str(value).strip().lower() for value in allowed_providers if str(value).strip()}
+    selected_provider = str(strategy_llm.get("provider", configured_provider)).strip().lower()
+    if selected_provider not in permitted:
+        selected_provider = configured_provider
+
+    selected_model = str(strategy_llm.get("model", "")).strip()
+    llm = _as_mapping(global_llm)
+    llm["provider"] = selected_provider
+    if selected_model:
+        # The policy chooses the model, while the global document continues to
+        # govern request budgets and connection behavior for both LLM calls.
+        llm["model"] = selected_model
+        llm["web_search_model"] = selected_model
+        llm["format_model"] = selected_model
+    llm["enabled"] = bool(strategy_llm.get("enabled", True))
+    resolved["llm"] = llm
+
+    catalyst = _as_mapping(market.get("catalyst"))
+    evidence = _as_mapping(global_config.get("evidence"))
+    lookback_hours = catalyst.get("lookback_hours")
+    if isinstance(lookback_hours, (int, float)) and not isinstance(lookback_hours, bool):
+        # Evidence collection is day-based. Round up so a 25-hour strategy does
+        # not silently lose the prior day's evidence.
+        evidence["recency_window_days"] = max(1, int(ceil(float(lookback_hours) / 24)))
+    resolved["evidence"] = evidence
+
+    policy = {
+        "strategy_id": strategy.get("id"),
+        "enabled": bool(market.get("enabled", False)),
+        "llm": {
+            "enabled": llm["enabled"],
+            "provider": selected_provider,
+            "model": llm.get("model") or llm.get("web_search_model"),
+        },
+        "catalyst": catalyst,
+        "theme": _as_mapping(market.get("theme")),
+        "opportunity": _as_mapping(market.get("opportunity")),
+    }
+    resolved["policy"] = policy
+    # This is deliberately strategy-only. The global deployment kill switch is
+    # ``llm.analyzer_enabled`` and is never overridden here.
+    resolved["enabled"] = policy["enabled"]
+    return resolved
+
+
+def intelligence_config_section(name: str) -> dict[str, Any]:
+    """Return a resolved intelligence subsection, or ``{}`` on any error.
+
+    Existing consumers use this compatibility helper, so all runtime settings
+    are consistently resolved and callers cannot mutate shared configuration.
+    """
+    try:
+        section = effective_intelligence_config().get(name, {})
+    except Exception:
+        return {}
+    return _as_mapping(section)

--- a/src/swing_screener/intelligence/graph/nodes.py
+++ b/src/swing_screener/intelligence/graph/nodes.py
@@ -139,6 +139,7 @@ def build_prompt(analyzer: "SymbolAnalyzer", state: AnalyzerState) -> AnalyzerSt
         pre_open=state["pre_open"],
         pre_open_since=state["pre_open_since"],
         prior_digest=state["prior_digest"],
+        intelligence_policy=getattr(analyzer, "_intelligence_policy", None),
     )
     return state
 

--- a/src/swing_screener/intelligence/symbol_analyzer.py
+++ b/src/swing_screener/intelligence/symbol_analyzer.py
@@ -36,7 +36,7 @@ from swing_screener.intelligence.models import (
     ThesisDelta,
 )
 from swing_screener.recommendation.models import DecisionAction, DecisionConviction
-from swing_screener.settings import get_settings_manager
+from swing_screener.intelligence.config_access import effective_intelligence_config
 from swing_screener.intelligence.tracing import recording_run
 from swing_screener.utils.logging_config import get_logger
 
@@ -300,6 +300,7 @@ def _build_user_prompt(
     pre_open: bool = False,
     pre_open_since: str | None = None,
     prior_digest: list[HistoryEntry] | None = None,
+    intelligence_policy: dict | None = None,
 ) -> str:
     def fmt(v: float | None) -> str:
         return f"{v:.2f}" if v is not None else "N/A"
@@ -630,13 +631,32 @@ def _build_user_prompt(
         "then follow the most material leads with further searches and run a forward-looking catalyst pass. "
         "Cite every source. Finally write the analyst write-up, ending with a Sources list of every URL you cited."
     )
+    policy = intelligence_policy or {}
+    if policy:
+        catalyst = policy.get("catalyst") if isinstance(policy.get("catalyst"), dict) else {}
+        theme = policy.get("theme") if isinstance(policy.get("theme"), dict) else {}
+        opportunity = policy.get("opportunity") if isinstance(policy.get("opportunity"), dict) else {}
+        lines += [
+            "",
+            "--- Active strategy intelligence policy ---",
+            "Use catalyst evidence from the configured lookback and require price confirmation "
+            f"when evaluating a catalyst: {bool(catalyst.get('require_price_confirmation', True))}; "
+            f"lookback {catalyst.get('lookback_hours', 72)} hours.",
+            "Theme clustering is "
+            f"{'enabled' if bool(theme.get('enabled', True)) else 'disabled'} "
+            f"(minimum cluster {theme.get('min_cluster_size', 3)}, peer confirmation {theme.get('min_peer_confirmation', 2)}).",
+            "Opportunity policy: "
+            f"technical weight {opportunity.get('technical_weight', 0.55)}, "
+            f"catalyst weight {opportunity.get('catalyst_weight', 0.45)}, "
+            f"minimum score {opportunity.get('min_opportunity_score', 0.55)}, "
+            f"maximum daily opportunities {opportunity.get('max_daily_opportunities', 8)}.",
+        ]
     return "\n".join(lines)
 
 
 class SymbolAnalyzer:
     def __init__(self) -> None:
-        doc = get_settings_manager().load_intelligence_document()
-        cfg = doc.get("config", {})
+        cfg = effective_intelligence_config()
         llm_cfg = cfg.get("llm", {})
         self._model = llm_cfg.get("web_search_model", "gpt-4o")
         self._format_model = llm_cfg.get("format_model", "gpt-4o-mini")
@@ -647,8 +667,10 @@ class SymbolAnalyzer:
         self._history_max_entries = int(history_cfg.get("max_entries", 50))
         self._history_digest_size = int(history_cfg.get("digest_size", 5))
         self._pre_open_cfg = cfg.get("pre_open", {})
+        self._intelligence_policy = cfg.get("policy", {})
         self._client = OpenAI(
             api_key=os.environ.get("OPENAI_API_KEY"),
+            base_url=(str(llm_cfg.get("base_url")).strip() if llm_cfg.get("base_url") else None),
             timeout=self._timeout,
             max_retries=self._max_retries,
         )

--- a/src/swing_screener/strategy/storage.py
+++ b/src/swing_screener/strategy/storage.py
@@ -19,6 +19,34 @@ DATA_DIR = CONFIG_DIR
 STRATEGIES_FILE = strategies_yaml_path()
 ACTIVE_STRATEGY_FILE = STRATEGIES_FILE
 _LEGACY_REMOVED_PLUGIN_KEY = "social_overlay"
+_STRATEGY_INTELLIGENCE_SECTIONS = ("llm", "catalyst", "theme", "opportunity")
+
+
+def _sanitize_market_intelligence(payload: Any) -> dict:
+    """Keep only policy fields owned by a strategy.
+
+    Old strategy documents also contained deployment URL, cache/audit, source,
+    and concurrency settings. Those now live only in intelligence.yaml and are
+    removed on the next strategy persistence operation.
+    """
+    market = deepcopy(payload) if isinstance(payload, dict) else {}
+    for key in ("providers", "universe_scope", "market_context_symbols", "sources", "scoring_v2", "calendar"):
+        market.pop(key, None)
+
+    llm = market.get("llm")
+    if isinstance(llm, dict):
+        for key in ("api_key", "base_url", "enable_cache", "enable_audit", "cache_path", "audit_path", "max_concurrency"):
+            llm.pop(key, None)
+        if llm.get("provider") != "openai":
+            llm["provider"] = "openai"
+    catalyst = market.get("catalyst")
+    if isinstance(catalyst, dict):
+        for key in ("recency_half_life_hours", "false_catalyst_return_z", "min_price_reaction_atr"):
+            catalyst.pop(key, None)
+    theme = market.get("theme")
+    if isinstance(theme, dict):
+        theme.pop("curated_peer_map_path", None)
+    return market
 
 
 def _ensure_config_dir() -> None:
@@ -37,7 +65,7 @@ def _write_yaml(path: Path, payload: Any) -> None:
 def _default_market_intelligence_payload() -> dict:
     defaults = get_settings_manager().get_strategy_defaults_payload()
     market_intelligence = defaults.get("market_intelligence", {})
-    return deepcopy(market_intelligence if isinstance(market_intelligence, dict) else {})
+    return _sanitize_market_intelligence(market_intelligence)
 
 
 def _default_strategy_payload(now: dt.datetime | None = None) -> dict:
@@ -59,9 +87,7 @@ def _sanitize_strategy_payload(strategy: dict) -> dict:
     payload.pop(_LEGACY_REMOVED_PLUGIN_KEY, None)
     market_intelligence = payload.get("market_intelligence")
     if isinstance(market_intelligence, dict):
-        llm = market_intelligence.get("llm")
-        if isinstance(llm, dict):
-            llm.pop("api_key", None)
+        payload["market_intelligence"] = _sanitize_market_intelligence(market_intelligence)
     return payload
 
 
@@ -151,18 +177,7 @@ def _normalize_document(doc: dict[str, Any]) -> tuple[dict[str, Any], bool]:
             strategy["market_intelligence"] = deepcopy(market_intelligence_default)
             dirty = True
         else:
-            if market_intelligence.get("providers") is None:
-                market_intelligence["providers"] = deepcopy(market_intelligence_default.get("providers", ["yahoo_finance"]))
-                dirty = True
-            if market_intelligence.get("universe_scope") is None:
-                market_intelligence["universe_scope"] = market_intelligence_default.get("universe_scope", "screener_universe")
-                dirty = True
-            if market_intelligence.get("market_context_symbols") is None:
-                market_intelligence["market_context_symbols"] = deepcopy(
-                    market_intelligence_default.get("market_context_symbols", ["SPY", "QQQ", "XLK", "SMH", "XBI"])
-                )
-                dirty = True
-            for section in ("llm", "catalyst", "theme", "opportunity", "sources", "scoring_v2", "calendar"):
+            for section in _STRATEGY_INTELLIGENCE_SECTIONS:
                 current_section = market_intelligence.get(section)
                 default_section = market_intelligence_default.get(section, {})
                 if not isinstance(current_section, dict):

--- a/tests/api/test_intelligence_api.py
+++ b/tests/api/test_intelligence_api.py
@@ -23,11 +23,18 @@ _INTEL_PAYLOAD = {
 
 
 def _write_cache(tmp_path: Path, ticker: str, for_date: date) -> None:
-    cache_dir = tmp_path / "intelligence"
-    cache_dir.mkdir(parents=True, exist_ok=True)
-    cache_file = cache_dir / f"sweep_{for_date.isoformat()}.json"
-    data = {ticker.upper(): {**_INTEL_PAYLOAD, "symbol": ticker.upper(), "generated_at": "2026-05-24T10:00:00Z"}}
-    cache_file.write_text(json.dumps(data))
+    from swing_screener.intelligence.cache import write_to_cache
+    from swing_screener.intelligence.models import SymbolIntelligence
+
+    write_to_cache(
+        ticker,
+        SymbolIntelligence(
+            **_INTEL_PAYLOAD,
+            symbol=ticker.upper(),
+            generated_at="2026-05-24T10:00:00Z",
+        ),
+        for_date=for_date,
+    )
 
 
 def test_latest_returns_404_when_no_cache(tmp_path, monkeypatch):
@@ -49,6 +56,30 @@ def test_latest_returns_cached_entry(tmp_path, monkeypatch):
     data = response.json()
     assert data["symbol"] == "AAPL"
     assert data["action"] == "BUY_NOW"
+
+
+def test_latest_rejects_legacy_unversioned_cache_entry(tmp_path, monkeypatch):
+    from datetime import datetime, timezone
+
+    monkeypatch.setenv("SWING_SCREENER_DATA_DIR", str(tmp_path))
+    today = datetime.now(timezone.utc).date()
+    cache_dir = tmp_path / "intelligence"
+    cache_dir.mkdir(parents=True)
+    (cache_dir / f"sweep_{today.isoformat()}.json").write_text(
+        json.dumps(
+            {
+                "AAPL": {
+                    **_INTEL_PAYLOAD,
+                    "symbol": "AAPL",
+                    "generated_at": "2026-05-24T10:00:00Z",
+                }
+            }
+        )
+    )
+
+    response = client.get("/api/intelligence/AAPL/latest")
+
+    assert response.status_code == 404
 
 
 def _make_sweep_dep_overrides(app, monkeypatch, tmp_path):
@@ -211,7 +242,9 @@ def test_analyze_returns_503_when_kill_switch_off(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
 
     monkeypatch.setattr(
-        r, "intelligence_config_section", lambda name: {"analyzer_enabled": False}
+        r,
+        "effective_intelligence_config",
+        lambda: {"enabled": True, "llm": {"enabled": True, "analyzer_enabled": False}},
     )
 
     resp = client.post("/api/intelligence/AAA", json={"close": 1.0, "signal": "x"})

--- a/tests/api/test_strategy_endpoints.py
+++ b/tests/api/test_strategy_endpoints.py
@@ -188,3 +188,27 @@ def test_strategy_migrates_legacy_removed_plugin_out_of_payload(monkeypatch, tmp
 
     persisted = yaml.safe_load(strategy_storage.STRATEGIES_FILE.read_text(encoding="utf-8"))
     assert "soc" "ial" "_overlay" not in persisted["strategies"][0]
+
+
+def test_strategy_migrates_deployment_intelligence_settings_out_of_contract(monkeypatch, tmp_path):
+    _patch_strategy_storage(monkeypatch, tmp_path)
+    strategy_storage.STRATEGIES_FILE.parent.mkdir(parents=True, exist_ok=True)
+    legacy = strategy_storage._default_strategy_payload()  # noqa: SLF001
+    strategy_storage.STRATEGIES_FILE.write_text(
+        yaml.safe_dump({"active_strategy_id": "default", "strategies": [legacy]}, sort_keys=False),
+        encoding="utf-8",
+    )
+
+    client = TestClient(app)
+    active = client.get("/api/strategy/active").json()
+
+    assert "base_url" not in active["market_intelligence"]["llm"]
+    assert "cache_path" not in active["market_intelligence"]["llm"]
+    assert "providers" not in active["market_intelligence"]
+    # Reading a legacy document is non-destructive; an explicit strategy save
+    # persists the cleaned, current contract.
+    strategy_storage.save_strategies([legacy])
+    persisted = yaml.safe_load(strategy_storage.STRATEGIES_FILE.read_text(encoding="utf-8"))
+    persisted_llm = persisted["strategies"][0]["market_intelligence"]["llm"]
+    assert "base_url" not in persisted_llm
+    assert "max_concurrency" not in persisted_llm

--- a/tests/intelligence/test_chat_service.py
+++ b/tests/intelligence/test_chat_service.py
@@ -60,10 +60,57 @@ def test_send_persists_user_and_assistant_messages(tmp_path, monkeypatch):
     )
 
     assert [message.role for message in response.messages] == ["user", "assistant"]
+    assert response.analysis_generated_at == "2026-07-03T08:00:00Z"
     assert response.messages[0].content == "What invalidates this?"
     assert response.messages[1].content == "Guidance is the main risk."
     stored = json.loads((tmp_path / "intelligence" / "chat" / "AAPL" / "2026-07-03.json").read_text())
     assert [message["role"] for message in stored["messages"]] == ["user", "assistant"]
+
+
+def test_changed_analysis_revision_archives_old_chat_and_starts_fresh(tmp_path, monkeypatch):
+    monkeypatch.setenv("SWING_SCREENER_DATA_DIR", str(tmp_path))
+    chat_date = date(2026, 7, 3)
+    first = _make_intelligence()
+    write_to_cache("AAPL", first, for_date=chat_date)
+    service = IntelligenceChatService(today=lambda: chat_date, answer_fn=lambda **_: "Answer")
+
+    service.send_message("AAPL", IntelligenceChatRequest(message="Question for first revision"))
+    refreshed = first.model_copy(update={"generated_at": "2026-07-03T09:00:00Z"})
+    write_to_cache("AAPL", refreshed, for_date=chat_date)
+
+    response = service.send_message(
+        "AAPL",
+        IntelligenceChatRequest(
+            message="Question for refreshed revision",
+            analysis_generated_at=refreshed.generated_at,
+        ),
+    )
+
+    assert response.analysis_generated_at == refreshed.generated_at
+    assert [message.content for message in response.messages] == [
+        "Question for refreshed revision",
+        "Answer",
+    ]
+    archived = list((tmp_path / "intelligence" / "chat" / "AAPL").glob("2026-07-03.*.json"))
+    assert len(archived) == 1
+    assert "Question for first revision" in archived[0].read_text()
+
+
+def test_get_hides_messages_after_analysis_refresh_until_new_revision_is_sent(tmp_path, monkeypatch):
+    monkeypatch.setenv("SWING_SCREENER_DATA_DIR", str(tmp_path))
+    chat_date = date(2026, 7, 3)
+    first = _make_intelligence()
+    write_to_cache("AAPL", first, for_date=chat_date)
+    service = IntelligenceChatService(today=lambda: chat_date, answer_fn=lambda **_: "Answer")
+    service.send_message("AAPL", IntelligenceChatRequest(message="Old context"))
+
+    refreshed = first.model_copy(update={"generated_at": "2026-07-03T09:00:00Z"})
+    write_to_cache("AAPL", refreshed, for_date=chat_date)
+
+    response = service.get_chat("AAPL")
+
+    assert response.analysis_generated_at == refreshed.generated_at
+    assert response.messages == []
 
 
 def test_send_requires_cached_intelligence(tmp_path, monkeypatch):

--- a/tests/intelligence/test_config_access.py
+++ b/tests/intelligence/test_config_access.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from swing_screener.intelligence.config_access import effective_intelligence_config
+
+
+GLOBAL = {
+    "enabled": True,
+    "llm": {
+        "provider": "openai",
+        "base_url": "https://deployment.example/v1",
+        "request_timeout_seconds": 17,
+        "max_retries": 4,
+        "analyzer_enabled": True,
+        "web_search_model": "global-search",
+        "format_model": "global-format",
+    },
+    "evidence": {"recency_window_days": 30, "max_items_per_symbol": 8},
+    "tracing": {"enabled": True, "max_runs_per_ticker": 50},
+}
+
+
+def _strategy(strategy_id: str, *, model: str, lookback_hours: int) -> dict:
+    return {
+        "id": strategy_id,
+        "market_intelligence": {
+            "enabled": True,
+            "providers": ["yahoo_finance"],
+            "universe_scope": "strategy_universe",
+            "market_context_symbols": ["SPY", "QQQ"],
+            "llm": {"enabled": True, "provider": "openai", "model": model},
+            "catalyst": {"lookback_hours": lookback_hours, "require_price_confirmation": True},
+            "theme": {"enabled": True, "min_cluster_size": 4, "min_peer_confirmation": 3},
+            "opportunity": {"technical_weight": 0.7, "catalyst_weight": 0.3, "min_opportunity_score": 0.65},
+        },
+    }
+
+
+def test_effective_config_changes_with_active_strategy_and_preserves_global_guardrails():
+    first = effective_intelligence_config(
+        global_config=GLOBAL,
+        active_strategy=_strategy("first", model="strategy-a", lookback_hours=24),
+    )
+    second = effective_intelligence_config(
+        global_config=GLOBAL,
+        active_strategy=_strategy("second", model="strategy-b", lookback_hours=73),
+    )
+
+    assert first["policy"]["strategy_id"] == "first"
+    assert second["policy"]["strategy_id"] == "second"
+    assert first["llm"]["web_search_model"] == "strategy-a"
+    assert second["llm"]["web_search_model"] == "strategy-b"
+    assert first["evidence"]["recency_window_days"] == 1
+    assert second["evidence"]["recency_window_days"] == 4
+    assert second["policy"]["theme"]["min_cluster_size"] == 4
+    assert second["policy"]["opportunity"]["min_opportunity_score"] == 0.65
+
+    for resolved in (first, second):
+        assert resolved["llm"]["base_url"] == "https://deployment.example/v1"
+        assert resolved["llm"]["request_timeout_seconds"] == 17
+        assert resolved["llm"]["max_retries"] == 4
+        assert resolved["llm"]["analyzer_enabled"] is True
+        assert resolved["tracing"] == GLOBAL["tracing"]
+
+
+def test_invalid_strategy_provider_falls_back_to_deployment_provider():
+    strategy = _strategy("bad-provider", model="strategy-model", lookback_hours=24)
+    strategy["market_intelligence"]["llm"]["provider"] = "unsupported"
+
+    resolved = effective_intelligence_config(global_config=GLOBAL, active_strategy=strategy)
+
+    assert resolved["llm"]["provider"] == "openai"
+    assert resolved["policy"]["llm"]["provider"] == "openai"
+
+
+def test_legacy_strategy_without_market_intelligence_uses_global_fallback():
+    resolved = effective_intelligence_config(global_config=GLOBAL, active_strategy={"id": "legacy"})
+
+    assert resolved["llm"] == GLOBAL["llm"]
+    assert resolved["policy"] == {"strategy_id": "legacy", "enabled": True}

--- a/web-ui/src/components/domain/strategy/StrategyCapitalRiskSummary.test.tsx
+++ b/web-ui/src/components/domain/strategy/StrategyCapitalRiskSummary.test.tsx
@@ -60,7 +60,7 @@ const strategy: Strategy = {
     marketContextSymbols: [],
     llm: {
       enabled: false,
-      provider: 'mock',
+      provider: 'openai',
       model: 'gpt-4o-mini',
       baseUrl: '',
       enableCache: true,

--- a/web-ui/src/components/domain/workspace/AnalysisCanvasPanel.test.tsx
+++ b/web-ui/src/components/domain/workspace/AnalysisCanvasPanel.test.tsx
@@ -23,7 +23,7 @@ vi.mock('@/features/intelligence/hooks', () => ({
   useIntelligenceAnalysisMutation: vi.fn(),
   useIntelligenceLatestQuery: vi.fn(),
   useIntelligenceHistoryQuery: vi.fn(() => ({ data: [], isLoading: false })),
-  useIntelligenceChatQuery: vi.fn(() => ({ data: { ticker: 'AAPL', chatDate: '2026-07-03', messages: [], refreshedAt: null }, isLoading: false, isError: false })),
+  useIntelligenceChatQuery: vi.fn(() => ({ data: { ticker: 'AAPL', chatDate: '2026-07-03', analysisGeneratedAt: '2026-07-03T08:00:00Z', messages: [], refreshedAt: null }, isLoading: false, isError: false })),
   useSendIntelligenceChatMutation: vi.fn(() => ({ mutate: vi.fn(), isPending: false, isError: false, error: null })),
   usePositionReviewMutation: vi.fn(() => ({ mutate: vi.fn(), isPending: false, isError: false, error: null, data: undefined })),
   useStrategicReviewMutation: vi.fn(() => ({ mutate: vi.fn(), isPending: false, isError: false, error: null, data: undefined })),

--- a/web-ui/src/components/domain/workspace/IntelligenceChatPanel.test.tsx
+++ b/web-ui/src/components/domain/workspace/IntelligenceChatPanel.test.tsx
@@ -30,6 +30,7 @@ const baseIntelligence: SymbolIntelligence = {
 const emptyChat: IntelligenceChatResponse = {
   ticker: 'AAPL',
   chatDate: '2026-07-03',
+  analysisGeneratedAt: '2026-07-03T08:00:00Z',
   refreshedAt: null,
   messages: [],
 };
@@ -86,6 +87,7 @@ describe('IntelligenceChatPanel', () => {
       data: {
         ticker: 'AAPL',
         chatDate: '2026-07-03',
+        analysisGeneratedAt: '2026-07-03T08:00:00Z',
         refreshedAt: '2026-07-03T10:00:00Z',
         messages: [
           {
@@ -124,5 +126,44 @@ describe('IntelligenceChatPanel', () => {
     expect(screen.getByText('Supplier evidence improved.')).toBeInTheDocument();
     expect(screen.getByText(t('workspacePage.panels.analysis.intelligence.chat.evidenceUsed'))).toBeInTheDocument();
     expect(screen.getByText('Supplier update')).toBeInTheDocument();
+  });
+
+  it('does not display messages from a prior analysis revision after refresh', () => {
+    vi.mocked(intelligenceHooks.useIntelligenceChatQuery).mockReturnValue({
+      data: {
+        ticker: 'AAPL',
+        chatDate: '2026-07-03',
+        analysisGeneratedAt: '2026-07-03T08:00:00Z',
+        refreshedAt: null,
+        messages: [{
+          id: 'old',
+          role: 'assistant',
+          content: 'Old-revision answer',
+          createdAt: '2026-07-03T08:01:00Z',
+          refreshSources: false,
+          evidenceUsed: [],
+        }],
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as never);
+
+    const { rerender } = renderWithProviders(<IntelligenceChatPanel ticker="AAPL" intelligence={baseIntelligence} />);
+    expect(screen.getByText('Old-revision answer')).toBeInTheDocument();
+
+    rerender(
+      <IntelligenceChatPanel
+        ticker="AAPL"
+        intelligence={{ ...baseIntelligence, generatedAt: '2026-07-03T09:00:00Z' }}
+      />,
+    );
+
+    expect(screen.queryByText('Old-revision answer')).not.toBeInTheDocument();
+    expect(intelligenceHooks.useIntelligenceChatQuery).toHaveBeenLastCalledWith(
+      'AAPL',
+      true,
+      '2026-07-03T09:00:00Z',
+    );
   });
 });

--- a/web-ui/src/components/domain/workspace/IntelligenceChatPanel.tsx
+++ b/web-ui/src/components/domain/workspace/IntelligenceChatPanel.tsx
@@ -22,10 +22,15 @@ export default function IntelligenceChatPanel({
 }: IntelligenceChatPanelProps) {
   const [message, setMessage] = useState('');
   const [refreshSources, setRefreshSources] = useState(false);
-  const chatQuery = useIntelligenceChatQuery(ticker, Boolean(intelligence));
+  const chatQuery = useIntelligenceChatQuery(ticker, Boolean(intelligence), intelligence?.generatedAt);
   const sendMutation = useSendIntelligenceChatMutation(ticker);
   const disabled = !intelligence;
-  const messages = chatQuery.data?.messages ?? [];
+  // Never render a cached response that belongs to a superseded analysis while
+  // React Query is fetching the query keyed by the new revision.
+  const chat = chatQuery.data;
+  const messages = chat && chat.analysisGeneratedAt === intelligence?.generatedAt
+    ? chat.messages
+    : [];
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();

--- a/web-ui/src/components/domain/workspace/PositionReviewPanel.test.tsx
+++ b/web-ui/src/components/domain/workspace/PositionReviewPanel.test.tsx
@@ -129,6 +129,7 @@ describe('PositionReviewPanel', () => {
     const mutate = vi.fn();
     const symbolReview: PositionReview = {
       ...review,
+      ticker: 'GOOG',
       mode: 'symbol',
       suggestedAction: 'ENTER',
       thesisStatus: 'intact',
@@ -163,5 +164,26 @@ describe('PositionReviewPanel', () => {
     await waitFor(() => {
       expect(mutate).toHaveBeenCalledWith({ ticker: 'GOOG', positionId: null, refreshSources: false });
     });
+  });
+
+  it('does not show a prior ticker result or error after selection changes', () => {
+    vi.mocked(intelligenceHooks.usePositionReviewMutation).mockReturnValue({
+      mutate: vi.fn(),
+      reset: vi.fn(),
+      variables: { ticker: 'MNST', positionId: 'pos-mnst', refreshSources: false },
+      data: review,
+      isPending: false,
+      isError: true,
+      error: new Error('MNST review failed'),
+    } as never);
+
+    const { rerender } = renderWithProviders(<PositionReviewPanel ticker="MNST" position={position} />);
+    expect(screen.getByText('MNST: raise stop and protect profit.')).toBeInTheDocument();
+    expect(screen.getByText('MNST review failed')).toBeInTheDocument();
+
+    rerender(<PositionReviewPanel ticker="AAPL" />);
+
+    expect(screen.queryByText('MNST: raise stop and protect profit.')).not.toBeInTheDocument();
+    expect(screen.queryByText('MNST review failed')).not.toBeInTheDocument();
   });
 });

--- a/web-ui/src/components/domain/workspace/PositionReviewPanel.tsx
+++ b/web-ui/src/components/domain/workspace/PositionReviewPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode } from 'react';
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
 
 import Button from '@/components/common/Button';
 import { usePositionReviewMutation } from '@/features/intelligence/hooks';
@@ -156,11 +156,22 @@ function ReviewResult({ review }: { review: PositionReview }) {
 export default function PositionReviewPanel({ ticker, position = null }: PositionReviewPanelProps) {
   const [refreshSources, setRefreshSources] = useState(false);
   const mutation = usePositionReviewMutation();
+  const normalizedTicker = useMemo(() => ticker.trim().toUpperCase(), [ticker]);
   const isHeld = Boolean(position?.positionId);
+  const mutationTicker = mutation.variables?.ticker?.trim().toUpperCase();
+  const isCurrentMutation = !mutationTicker || mutationTicker === normalizedTicker;
+  const review = mutation.data?.ticker?.trim().toUpperCase() === normalizedTicker ? mutation.data : null;
+
+  useEffect(() => {
+    // A manual-review mutation belongs to its requested ticker, not to the
+    // workspace component that survives a symbol selection change.
+    mutation.reset?.();
+    setRefreshSources(false);
+  }, [normalizedTicker]);
 
   const handleRun = () => {
     mutation.mutate({
-      ticker,
+      ticker: normalizedTicker,
       positionId: position?.positionId ?? null,
       refreshSources,
     });
@@ -179,8 +190,8 @@ export default function PositionReviewPanel({ ticker, position = null }: Positio
               : 'Assess the setup thesis, what confirms or invalidates entry, and check macro/geopolitical overrides.'}
           </p>
         </div>
-        <Button type="button" size="sm" variant="secondary" onClick={handleRun} disabled={mutation.isPending}>
-          {mutation.isPending ? 'Reviewing...' : isHeld ? 'Run position review' : 'Run symbol review'}
+        <Button type="button" size="sm" variant="secondary" onClick={handleRun} disabled={isCurrentMutation && mutation.isPending}>
+          {isCurrentMutation && mutation.isPending ? 'Reviewing...' : isHeld ? 'Run position review' : 'Run symbol review'}
         </Button>
       </div>
       <div className="px-3 py-3">
@@ -188,19 +199,19 @@ export default function PositionReviewPanel({ ticker, position = null }: Positio
           <input
             type="checkbox"
             checked={refreshSources}
-            disabled={mutation.isPending}
+            disabled={isCurrentMutation && mutation.isPending}
             onChange={(event) => setRefreshSources(event.target.checked)}
           />
           Refresh app sources first
         </label>
-        {mutation.isError && (
+        {isCurrentMutation && mutation.isError && (
           <p className="mt-2 text-sm text-danger">
             {mutation.error instanceof Error ? mutation.error.message : 'Failed to run position review'}
           </p>
         )}
-        {mutation.data ? (
+        {review ? (
           <div className="mt-3">
-            <ReviewResult review={mutation.data} />
+            <ReviewResult review={review} />
           </div>
         ) : (
           <p className="mt-3 text-sm text-muted">

--- a/web-ui/src/components/domain/workspace/StrategicReviewPanel.test.tsx
+++ b/web-ui/src/components/domain/workspace/StrategicReviewPanel.test.tsx
@@ -108,4 +108,25 @@ describe('StrategicReviewPanel', () => {
     expect(screen.getByLabelText('Mixed strategic signal')).toBeInTheDocument();
     expect(screen.getByText(t(`${I18N_PREFIX}.signal.mixed`))).toBeInTheDocument();
   });
+
+  it('does not show a prior ticker result or error after selection changes', () => {
+    vi.mocked(intelligenceHooks.useStrategicReviewMutation).mockReturnValue({
+      mutate: vi.fn(),
+      reset: vi.fn(),
+      variables: { ticker: 'ASML', refreshSources: false, riskMode: 'normal', horizonDays: 10 },
+      data: review,
+      isPending: false,
+      isError: true,
+      error: new Error('ASML review failed'),
+    } as never);
+
+    const { rerender } = renderWithProviders(<StrategicReviewPanel ticker="ASML" />);
+    expect(screen.getByText('Strategic overlay built from app context only for ASML.')).toBeInTheDocument();
+    expect(screen.getByText('ASML review failed')).toBeInTheDocument();
+
+    rerender(<StrategicReviewPanel ticker="AAPL" />);
+
+    expect(screen.queryByText('Strategic overlay built from app context only for ASML.')).not.toBeInTheDocument();
+    expect(screen.queryByText('ASML review failed')).not.toBeInTheDocument();
+  });
 });

--- a/web-ui/src/components/domain/workspace/StrategicReviewPanel.tsx
+++ b/web-ui/src/components/domain/workspace/StrategicReviewPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import Button from '@/components/common/Button';
 import { useStrategicReviewMutation } from '@/features/intelligence/hooks';
@@ -172,6 +172,17 @@ export default function StrategicReviewPanel({ ticker }: StrategicReviewPanelPro
   const [watchAreas, setWatchAreas] = useState<WatchAreaId[]>(DEFAULT_WATCH_AREAS);
   const [topic, setTopic] = useState('');
   const mutation = useStrategicReviewMutation();
+  const normalizedTicker = useMemo(() => ticker.trim().toUpperCase(), [ticker]);
+  const mutationTicker = mutation.variables?.ticker?.trim().toUpperCase();
+  const isCurrentMutation = !mutationTicker || mutationTicker === normalizedTicker;
+
+  useEffect(() => {
+    mutation.reset?.();
+    setRefreshSources(false);
+    setRiskMode('normal');
+    setWatchAreas(DEFAULT_WATCH_AREAS);
+    setTopic('');
+  }, [normalizedTicker]);
 
   const handleRun = () => {
     const selectedWatchAreas = WATCH_AREAS.filter((area) => watchAreas.includes(area.id)).map((area) =>
@@ -181,7 +192,7 @@ export default function StrategicReviewPanel({ ticker }: StrategicReviewPanelPro
     const topicParts = [...selectedWatchAreas, ...(investigationTopic ? [investigationTopic] : [])];
 
     mutation.mutate({
-      ticker,
+      ticker: normalizedTicker,
       topic: topicParts.length > 0 ? topicParts.join(', ') : null,
       refreshSources,
       riskMode,
@@ -200,8 +211,8 @@ export default function StrategicReviewPanel({ ticker }: StrategicReviewPanelPro
           <p className="text-xs font-semibold uppercase tracking-wide text-muted">{t(`${I18N_PREFIX}.title`)}</p>
           <p className="mt-1 text-xs text-muted">{t(`${I18N_PREFIX}.description`)}</p>
         </div>
-        <Button type="button" size="sm" variant="secondary" onClick={handleRun} disabled={mutation.isPending}>
-          {mutation.isPending ? t(`${I18N_PREFIX}.runningAction`) : t(`${I18N_PREFIX}.runAction`)}
+        <Button type="button" size="sm" variant="secondary" onClick={handleRun} disabled={isCurrentMutation && mutation.isPending}>
+          {isCurrentMutation && mutation.isPending ? t(`${I18N_PREFIX}.runningAction`) : t(`${I18N_PREFIX}.runAction`)}
         </Button>
       </div>
 
@@ -222,7 +233,7 @@ export default function StrategicReviewPanel({ ticker }: StrategicReviewPanelPro
                 <input
                   type="checkbox"
                   checked={watchAreas.includes(area.id)}
-                  disabled={mutation.isPending}
+                  disabled={isCurrentMutation && mutation.isPending}
                   onChange={() => toggleWatchArea(area.id)}
                 />
                 {t(`${I18N_PREFIX}.${area.labelKey}`)}
@@ -237,7 +248,7 @@ export default function StrategicReviewPanel({ ticker }: StrategicReviewPanelPro
             <input
               className="rounded-md border border-border bg-surface px-3 py-2 text-sm text-foreground outline-none focus:border-primary"
               value={topic}
-              disabled={mutation.isPending}
+              disabled={isCurrentMutation && mutation.isPending}
               onChange={(event) => setTopic(event.target.value)}
               placeholder={t(`${I18N_PREFIX}.topicPlaceholder`)}
             />
@@ -248,7 +259,7 @@ export default function StrategicReviewPanel({ ticker }: StrategicReviewPanelPro
             <select
               className="rounded-md border border-border bg-surface px-3 py-2 text-sm text-foreground outline-none focus:border-primary"
               value={riskMode}
-              disabled={mutation.isPending}
+              disabled={isCurrentMutation && mutation.isPending}
               onChange={(event) => setRiskMode(event.target.value as typeof riskMode)}
             >
               <option value="normal">{t(`${I18N_PREFIX}.riskMode.normal`)}</option>
@@ -261,20 +272,20 @@ export default function StrategicReviewPanel({ ticker }: StrategicReviewPanelPro
             <input
               type="checkbox"
               checked={refreshSources}
-              disabled={mutation.isPending}
+              disabled={isCurrentMutation && mutation.isPending}
               onChange={(event) => setRefreshSources(event.target.checked)}
             />
             {t(`${I18N_PREFIX}.refreshSources`)}
           </label>
         </div>
 
-        {mutation.isError && (
+        {isCurrentMutation && mutation.isError && (
           <p className="text-sm text-danger">
             {mutation.error instanceof Error ? mutation.error.message : t(`${I18N_PREFIX}.runError`)}
           </p>
         )}
 
-        {mutation.data ? (
+        {isCurrentMutation && mutation.data ? (
           <StrategicResult review={mutation.data} />
         ) : (
           <p className="text-sm text-muted">{t(`${I18N_PREFIX}.idle`)}</p>

--- a/web-ui/src/features/intelligence/hooks.ts
+++ b/web-ui/src/features/intelligence/hooks.ts
@@ -40,6 +40,7 @@ export function useIntelligenceAnalysisMutation() {
       // A fresh analysis is appended to history server-side; refresh the timeline.
       queryClient.invalidateQueries({ queryKey: ['intelligence', 'history', ticker] });
       queryClient.invalidateQueries({ queryKey: ['intelligence', 'latest', ticker] });
+      queryClient.invalidateQueries({ queryKey: ['intelligence', 'chat', ticker] });
     },
   });
 }
@@ -67,9 +68,13 @@ export function useIntelligenceHistoryQuery(ticker: string, enabled: boolean) {
   });
 }
 
-export function useIntelligenceChatQuery(ticker: string, enabled: boolean) {
+export function useIntelligenceChatQuery(
+  ticker: string,
+  enabled: boolean,
+  analysisGeneratedAt: string | null | undefined,
+) {
   return useQuery<IntelligenceChatResponse, Error>({
-    queryKey: ['intelligence', 'chat', ticker],
+    queryKey: ['intelligence', 'chat', ticker, analysisGeneratedAt ?? null],
     queryFn: () => getIntelligenceChat(ticker),
     enabled,
     retry: false,

--- a/web-ui/src/features/intelligence/types.test.ts
+++ b/web-ui/src/features/intelligence/types.test.ts
@@ -30,6 +30,7 @@ describe('transformIntelligenceChat', () => {
     const api: IntelligenceChatResponseAPI = {
       ticker: 'AAPL',
       chat_date: '2026-07-03',
+      analysis_generated_at: '2026-07-03T08:00:00Z',
       refreshed_at: '2026-07-03T10:00:00Z',
       messages: [
         {
@@ -54,6 +55,7 @@ describe('transformIntelligenceChat', () => {
     const result = transformIntelligenceChat(api);
 
     expect(result.chatDate).toBe('2026-07-03');
+    expect(result.analysisGeneratedAt).toBe('2026-07-03T08:00:00Z');
     expect(result.refreshedAt).toBe('2026-07-03T10:00:00Z');
     expect(result.messages[0].createdAt).toBe('2026-07-03T09:00:00Z');
     expect(result.messages[0].refreshSources).toBe(true);

--- a/web-ui/src/features/intelligence/types.ts
+++ b/web-ui/src/features/intelligence/types.ts
@@ -486,6 +486,7 @@ export interface IntelligenceChatMessage {
 export interface IntelligenceChatResponseAPI {
   ticker: string;
   chat_date: string;
+  analysis_generated_at: string;
   messages: IntelligenceChatMessageAPI[];
   refreshed_at?: string | null;
 }
@@ -493,6 +494,7 @@ export interface IntelligenceChatResponseAPI {
 export interface IntelligenceChatResponse {
   ticker: string;
   chatDate: string;
+  analysisGeneratedAt: string;
   messages: IntelligenceChatMessage[];
   refreshedAt: string | null;
 }
@@ -501,6 +503,7 @@ export function transformIntelligenceChat(api: IntelligenceChatResponseAPI): Int
   return {
     ticker: api.ticker,
     chatDate: api.chat_date,
+    analysisGeneratedAt: api.analysis_generated_at,
     refreshedAt: api.refreshed_at ?? null,
     messages: (api.messages ?? []).map((message) => ({
       id: message.id,

--- a/web-ui/src/features/strategy/hooks.test.tsx
+++ b/web-ui/src/features/strategy/hooks.test.tsx
@@ -1,0 +1,93 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/features/strategy/api', () => ({
+  createStrategy: vi.fn(),
+  deleteStrategy: vi.fn(),
+  fetchActiveStrategy: vi.fn(),
+  fetchStrategies: vi.fn(),
+  setActiveStrategy: vi.fn(),
+  updateStrategy: vi.fn(),
+  validateStrategy: vi.fn(),
+}));
+
+import * as strategyApi from '@/features/strategy/api';
+import { useSetActiveStrategyMutation, useUpdateStrategyMutation } from '@/features/strategy/hooks';
+import type { Strategy } from '@/features/strategy/types';
+import { queryKeys } from '@/lib/queryKeys';
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+}
+
+function wrapper(queryClient: QueryClient) {
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+const strategy = (id: string) => ({ id, name: id }) as Strategy;
+
+describe('strategy mutation cache invalidation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('invalidates every strategy-derived prefix after activating a strategy', async () => {
+    const queryClient = createQueryClient();
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
+    vi.mocked(strategyApi.setActiveStrategy).mockResolvedValue(strategy('next'));
+
+    const { result } = renderHook(() => useSetActiveStrategyMutation(), { wrapper: wrapper(queryClient) });
+    await act(async () => {
+      await result.current.mutateAsync('next');
+    });
+
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: queryKeys.positions() });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: queryKeys.positionMetrics() });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: queryKeys.portfolioSummary() });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: queryKeys.watchlist() });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: queryKeys.watchlistPipeline() });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['dailyReview'] });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['screener'] });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['backtest'] });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: queryKeys.openPositionsIntelligence() });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['intelligence'] });
+  });
+
+  it('uses broad invalidation when the active strategy is updated', async () => {
+    const queryClient = createQueryClient();
+    queryClient.setQueryData(queryKeys.strategyActive(), strategy('active'));
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
+    vi.mocked(strategyApi.updateStrategy).mockResolvedValue(strategy('active'));
+
+    const { result } = renderHook(() => useUpdateStrategyMutation(), { wrapper: wrapper(queryClient) });
+    await act(async () => {
+      await result.current.mutateAsync(strategy('active'));
+    });
+
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: queryKeys.positions() });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['regime-breakdown'] });
+  });
+
+  it('keeps non-active strategy updates on the narrow strategy invalidation path', async () => {
+    const queryClient = createQueryClient();
+    queryClient.setQueryData(queryKeys.strategyActive(), strategy('active'));
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
+    vi.mocked(strategyApi.updateStrategy).mockResolvedValue(strategy('other'));
+
+    const { result } = renderHook(() => useUpdateStrategyMutation(), { wrapper: wrapper(queryClient) });
+    await act(async () => {
+      await result.current.mutateAsync(strategy('other'));
+    });
+
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: queryKeys.strategies() });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: queryKeys.strategyActive() });
+    expect(invalidate).not.toHaveBeenCalledWith({ queryKey: queryKeys.positions() });
+    expect(invalidate).not.toHaveBeenCalledWith({ queryKey: ['dailyReview'] });
+  });
+});

--- a/web-ui/src/features/strategy/hooks.ts
+++ b/web-ui/src/features/strategy/hooks.ts
@@ -10,7 +10,7 @@ import {
 } from '@/features/strategy/api';
 import type { Strategy, StrategyUpdateRequestAPI } from '@/features/strategy/types';
 import { queryKeys } from '@/lib/queryKeys';
-import { invalidateStrategyQueries } from '@/lib/queryInvalidation';
+import { invalidateStrategyDependentQueries, invalidateStrategyQueries } from '@/lib/queryInvalidation';
 
 export function useStrategiesQuery() {
   return useQuery({
@@ -31,7 +31,7 @@ export function useSetActiveStrategyMutation() {
   return useMutation({
     mutationFn: (strategyId: string) => setActiveStrategy(strategyId),
     onSuccess: async () => {
-      await invalidateStrategyQueries(queryClient);
+      await invalidateStrategyDependentQueries(queryClient);
     },
   });
 }
@@ -41,7 +41,12 @@ export function useUpdateStrategyMutation(onSuccess?: (updated: Strategy) => voi
   return useMutation({
     mutationFn: updateStrategy,
     onSuccess: async (updated) => {
-      await invalidateStrategyQueries(queryClient);
+      const active = queryClient.getQueryData<Strategy>(queryKeys.strategyActive());
+      if (!active || active.id === updated.id) {
+        await invalidateStrategyDependentQueries(queryClient);
+      } else {
+        await invalidateStrategyQueries(queryClient);
+      }
       onSuccess?.(updated);
     },
   });
@@ -70,8 +75,13 @@ export function useDeleteStrategyMutation(onSuccess?: () => void) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (strategyId: string) => deleteStrategy(strategyId),
-    onSuccess: async () => {
-      await invalidateStrategyQueries(queryClient);
+    onSuccess: async (_result, strategyId) => {
+      const active = queryClient.getQueryData<Strategy>(queryKeys.strategyActive());
+      if (!active || active.id === strategyId) {
+        await invalidateStrategyDependentQueries(queryClient);
+      } else {
+        await invalidateStrategyQueries(queryClient);
+      }
       onSuccess?.();
     },
   });

--- a/web-ui/src/features/strategy/types.ts
+++ b/web-ui/src/features/strategy/types.ts
@@ -78,7 +78,7 @@ export interface StrategyManage {
 
 export interface StrategyIntelligenceLLM {
   enabled: boolean;
-  provider: 'mock' | 'openai';
+  provider: 'openai';
   model: string;
   baseUrl: string;
   enableCache: boolean;
@@ -215,21 +215,12 @@ export interface StrategyManageAPI {
 
 export interface StrategyIntelligenceLLMAPI {
   enabled?: boolean;
-  provider?: 'mock' | 'openai';
+  provider?: 'openai';
   model?: string;
-  base_url?: string;
-  enable_cache?: boolean;
-  enable_audit?: boolean;
-  cache_path?: string;
-  audit_path?: string;
-  max_concurrency?: number;
 }
 
 export interface StrategyIntelligenceCatalystAPI {
   lookback_hours?: number;
-  recency_half_life_hours?: number;
-  false_catalyst_return_z?: number;
-  min_price_reaction_atr?: number;
   require_price_confirmation?: boolean;
 }
 
@@ -237,7 +228,6 @@ export interface StrategyIntelligenceThemeAPI {
   enabled?: boolean;
   min_cluster_size?: number;
   min_peer_confirmation?: number;
-  curated_peer_map_path?: string;
 }
 
 export interface StrategyIntelligenceOpportunityAPI {
@@ -249,9 +239,6 @@ export interface StrategyIntelligenceOpportunityAPI {
 
 export interface StrategyMarketIntelligenceAPI {
   enabled?: boolean;
-  providers?: string[];
-  universe_scope?: 'screener_universe' | 'strategy_universe';
-  market_context_symbols?: string[];
   llm?: StrategyIntelligenceLLMAPI;
   catalyst?: StrategyIntelligenceCatalystAPI;
   theme?: StrategyIntelligenceThemeAPI;
@@ -377,32 +364,32 @@ export function transformStrategy(api: StrategyAPI): Strategy {
     },
     marketIntelligence: {
       enabled: marketIntelligenceApi.enabled ?? false,
-      providers: marketIntelligenceApi.providers ?? ['yahoo_finance'],
-      universeScope: marketIntelligenceApi.universe_scope ?? 'screener_universe',
-      marketContextSymbols: marketIntelligenceApi.market_context_symbols ?? ['SPY', 'QQQ', 'XLK', 'SMH', 'XBI'],
+      providers: ['yahoo_finance'],
+      universeScope: 'screener_universe',
+      marketContextSymbols: ['SPY', 'QQQ', 'XLK', 'SMH', 'XBI'],
       llm: {
         enabled: marketIntelligenceLlmApi.enabled ?? false,
         provider: marketIntelligenceLlmApi.provider ?? 'openai',
         model: marketIntelligenceLlmApi.model ?? 'gpt-4.1-mini',
-        baseUrl: marketIntelligenceLlmApi.base_url ?? 'https://api.openai.com/v1',
-        enableCache: marketIntelligenceLlmApi.enable_cache ?? true,
-        enableAudit: marketIntelligenceLlmApi.enable_audit ?? true,
-        cachePath: marketIntelligenceLlmApi.cache_path ?? 'data/intelligence/llm_cache.json',
-        auditPath: marketIntelligenceLlmApi.audit_path ?? 'data/intelligence/llm_audit',
-        maxConcurrency: marketIntelligenceLlmApi.max_concurrency ?? 4,
+        baseUrl: 'https://api.openai.com/v1',
+        enableCache: true,
+        enableAudit: true,
+        cachePath: 'data/intelligence/llm_cache.json',
+        auditPath: 'data/intelligence/llm_audit',
+        maxConcurrency: 4,
       },
       catalyst: {
         lookbackHours: marketIntelligenceCatalystApi.lookback_hours ?? 72,
-        recencyHalfLifeHours: marketIntelligenceCatalystApi.recency_half_life_hours ?? 36,
-        falseCatalystReturnZ: marketIntelligenceCatalystApi.false_catalyst_return_z ?? 1.5,
-        minPriceReactionAtr: marketIntelligenceCatalystApi.min_price_reaction_atr ?? 0.8,
+        recencyHalfLifeHours: 36,
+        falseCatalystReturnZ: 1.5,
+        minPriceReactionAtr: 0.8,
         requirePriceConfirmation: marketIntelligenceCatalystApi.require_price_confirmation ?? true,
       },
       theme: {
         enabled: marketIntelligenceThemeApi.enabled ?? true,
         minClusterSize: marketIntelligenceThemeApi.min_cluster_size ?? 3,
         minPeerConfirmation: marketIntelligenceThemeApi.min_peer_confirmation ?? 2,
-        curatedPeerMapPath: marketIntelligenceThemeApi.curated_peer_map_path ?? 'data/intelligence/peer_map.yaml',
+        curatedPeerMapPath: 'data/intelligence/peer_map.yaml',
       },
       opportunity: {
         technicalWeight: marketIntelligenceOpportunityApi.technical_weight ?? 0.55,
@@ -494,32 +481,19 @@ export function toStrategyUpdateRequest(strategy: Strategy): StrategyUpdateReque
     },
     market_intelligence: {
       enabled: strategy.marketIntelligence.enabled,
-      providers: strategy.marketIntelligence.providers,
-      universe_scope: strategy.marketIntelligence.universeScope,
-      market_context_symbols: strategy.marketIntelligence.marketContextSymbols,
       llm: {
         enabled: strategy.marketIntelligence.llm.enabled,
         provider: strategy.marketIntelligence.llm.provider,
         model: strategy.marketIntelligence.llm.model,
-        base_url: strategy.marketIntelligence.llm.baseUrl,
-        enable_cache: strategy.marketIntelligence.llm.enableCache,
-        enable_audit: strategy.marketIntelligence.llm.enableAudit,
-        cache_path: strategy.marketIntelligence.llm.cachePath,
-        audit_path: strategy.marketIntelligence.llm.auditPath,
-        max_concurrency: strategy.marketIntelligence.llm.maxConcurrency,
       },
       catalyst: {
         lookback_hours: strategy.marketIntelligence.catalyst.lookbackHours,
-        recency_half_life_hours: strategy.marketIntelligence.catalyst.recencyHalfLifeHours,
-        false_catalyst_return_z: strategy.marketIntelligence.catalyst.falseCatalystReturnZ,
-        min_price_reaction_atr: strategy.marketIntelligence.catalyst.minPriceReactionAtr,
         require_price_confirmation: strategy.marketIntelligence.catalyst.requirePriceConfirmation,
       },
       theme: {
         enabled: strategy.marketIntelligence.theme.enabled,
         min_cluster_size: strategy.marketIntelligence.theme.minClusterSize,
         min_peer_confirmation: strategy.marketIntelligence.theme.minPeerConfirmation,
-        curated_peer_map_path: strategy.marketIntelligence.theme.curatedPeerMapPath,
       },
       opportunity: {
         technical_weight: strategy.marketIntelligence.opportunity.technicalWeight,

--- a/web-ui/src/lib/queryInvalidation.ts
+++ b/web-ui/src/lib/queryInvalidation.ts
@@ -1,11 +1,39 @@
 import type { QueryClient } from '@tanstack/react-query';
 import { queryKeys } from '@/lib/queryKeys';
+import { useScreenerStore } from '@/stores/screenerStore';
 
 export async function invalidateStrategyQueries(queryClient: QueryClient): Promise<void> {
   await Promise.all([
     queryClient.invalidateQueries({ queryKey: queryKeys.strategies() }),
     queryClient.invalidateQueries({ queryKey: queryKeys.strategyActive() }),
     queryClient.invalidateQueries({ queryKey: queryKeys.strategyValidation() }),
+  ]);
+}
+
+/**
+ * Invalidate every view whose response is calculated with the active strategy.
+ *
+ * Query keys intentionally do not include strategy identity: callers see a
+ * single current-decision view. Therefore an active-strategy transition must
+ * clear all of these prefixes together, including the persisted screener result
+ * that otherwise has no React Query key to invalidate.
+ */
+export async function invalidateStrategyDependentQueries(queryClient: QueryClient): Promise<void> {
+  useScreenerStore.getState().clearLastResult();
+  await Promise.all([
+    invalidateStrategyQueries(queryClient),
+    queryClient.invalidateQueries({ queryKey: queryKeys.positions() }),
+    queryClient.invalidateQueries({ queryKey: queryKeys.positionMetrics() }),
+    queryClient.invalidateQueries({ queryKey: queryKeys.portfolioSummary() }),
+    queryClient.invalidateQueries({ queryKey: queryKeys.openPositionsIntelligence() }),
+    queryClient.invalidateQueries({ queryKey: queryKeys.watchlist() }),
+    queryClient.invalidateQueries({ queryKey: queryKeys.watchlistPipeline() }),
+    queryClient.invalidateQueries({ queryKey: ['dailyReview'] }),
+    queryClient.invalidateQueries({ queryKey: ['earnings-proximity'] }),
+    queryClient.invalidateQueries({ queryKey: ['regime-breakdown'] }),
+    queryClient.invalidateQueries({ queryKey: ['screener'] }),
+    queryClient.invalidateQueries({ queryKey: ['backtest'] }),
+    queryClient.invalidateQueries({ queryKey: ['intelligence'] }),
   ]);
 }
 


### PR DESCRIPTION
## Summary
- resolve active-strategy intelligence policy at runtime while retaining deployment guardrails
- invalidate all strategy-derived frontend state on active strategy changes
- scope manual reviews and chat sessions to the selected ticker and analysis revision
- update cache-schema and regression coverage

## Why
Strategy changes could leave decision views stale, intelligence policy settings were not applied at runtime, and workspace output could be shown for a previous symbol or analysis revision.

## Validation
- `pytest -q tests/api/test_strategy_endpoints.py tests/intelligence/test_chat_service.py tests/intelligence/test_config_access.py`
- `cd web-ui && npm test -- --run` (706 tests)
- `cd web-ui && npm run typecheck && npm run lint && npm run build`

The existing local `config/strategies.yaml` edit is intentionally excluded from this PR.