### PR TITLE
fix volume-zone review findings: chart rebuild churn, dead intel branch

### DIFF
--- a/src/swing_screener/strategy/modules/momentum.py
+++ b/src/swing_screener/strategy/modules/momentum.py
@@ -325,19 +325,12 @@ class MomentumStrategyModule:
         miss_records = pd.DataFrame()
         if misses:
             miss_ohlcv = ohlcv.loc[:, ohlcv.columns.get_level_values(1).isin(misses)]
-            if quote_to_eur_rates:
-                miss_records = compute_symbol_records(
-                    miss_ohlcv,
-                    cfg,
-                    sector_benchmark_returns=sector_benchmark_returns,
-                    quote_to_eur_rates=quote_to_eur_rates,
-                )
-            else:
-                miss_records = compute_symbol_records(
-                    miss_ohlcv,
-                    cfg,
-                    sector_benchmark_returns=sector_benchmark_returns,
-                )
+            miss_records = compute_symbol_records(
+                miss_ohlcv,
+                cfg,
+                sector_benchmark_returns=sector_benchmark_returns,
+                quote_to_eur_rates=quote_to_eur_rates,
+            )
             eval_cache.write(miss_records, asof=asof_date, sig=sig)
         frames = [f for f in (hits, miss_records) if f is not None and not f.empty]
         records = pd.concat(frames) if frames else pd.DataFrame()

--- a/tests/test_screener_service.py
+++ b/tests/test_screener_service.py
@@ -297,7 +297,7 @@ def test_mixed_universe_reuses_cached_symbols(tmp_path, monkeypatch):
 
     computed_tickers: list[set] = []
 
-    def _spying_compute(ohlcv, cfg, sector_benchmark_returns=None):
+    def _spying_compute(ohlcv, cfg, sector_benchmark_returns=None, **kwargs):
         if "Close" in set(ohlcv.columns.get_level_values(0)):
             close_tickers = set(ohlcv["Close"].columns.tolist())
         else:
@@ -444,7 +444,7 @@ def test_force_refresh_bypasses_cache(tmp_path, monkeypatch):
 
     computed_tickers: list[set] = []
 
-    def _spying_compute(ohlcv_arg, cfg, sector_benchmark_returns=None):
+    def _spying_compute(ohlcv_arg, cfg, sector_benchmark_returns=None, **kwargs):
         if "Close" in set(ohlcv_arg.columns.get_level_values(0)):
             close_tickers = set(ohlcv_arg["Close"].columns.tolist())
         else:
@@ -575,7 +575,7 @@ def test_daily_review_reuses_manual_screen_cache(tmp_path, monkeypatch):
 
     computed_tickers: list[set] = []
 
-    def _spying_compute(ohlcv_arg, cfg, sector_benchmark_returns=None):
+    def _spying_compute(ohlcv_arg, cfg, sector_benchmark_returns=None, **kwargs):
         if "Close" in set(ohlcv_arg.columns.get_level_values(0)):
             close_tickers = set(ohlcv_arg["Close"].columns.tolist())
         else:

--- a/web-ui/src/components/domain/market/CandleChart.tsx
+++ b/web-ui/src/components/domain/market/CandleChart.tsx
@@ -48,6 +48,11 @@ export function selectDrawnZones(zones: ChartVolumeZone[]): ChartVolumeZone[] {
   return [...poc, ...hvn, ...lvn];
 }
 
+// Stable empty defaults: a fresh `[]` default parameter is a new reference every
+// render, which would churn the memoized derivations and rebuild the chart.
+const EMPTY_BARS: PriceHistoryPoint[] = [];
+const EMPTY_ZONES: ChartVolumeZone[] = [];
+
 interface CandleChartProps {
   ticker: string;
   bars: PriceHistoryPoint[];
@@ -128,7 +133,7 @@ export function CandleChart({
   ticker,
   bars,
   patterns,
-  benchmarkBars = [],
+  benchmarkBars = EMPTY_BARS,
   benchmarkLabel,
   outperformancePct,
   entryPrice,
@@ -139,7 +144,7 @@ export function CandleChart({
   showSma200 = false,
   showRLevels = true,
   showKeyLevels = true,
-  volumeZones = [],
+  volumeZones = EMPTY_ZONES,
   showVolumeZones = true,
   className,
   height = 320,
@@ -362,7 +367,6 @@ export function CandleChart({
     stopPrice,
     targetPrice,
     volumeZones,
-    showVolumeZones,
   ]);
 
   // Visibility effects — update series/lines without recreating the chart

--- a/web-ui/src/components/domain/workspace/VolumeZonesTab.tsx
+++ b/web-ui/src/components/domain/workspace/VolumeZonesTab.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense } from 'react';
+import { lazy, Suspense, useMemo } from 'react';
 import type { ChartVolumeZone } from '@/components/domain/market/CandleChart';
 import { useTickerCandles } from '@/features/screener/hooks';
 import { useVolumeAnalysisQuery } from '@/features/volumeZones/hooks';
@@ -26,21 +26,25 @@ export default function VolumeZonesTab({ ticker }: { ticker: string }) {
   const analysisQuery = useVolumeAnalysisQuery(ticker);
   const candlesQuery = useTickerCandles(ticker);
 
+  const analysis = analysisQuery.data;
+  const zones = useMemo<ChartVolumeZone[]>(
+    () =>
+      (analysis?.volumeZones ?? []).map((z) => ({
+        kind: z.kind,
+        center: z.center,
+        priceLow: z.priceLow,
+        priceHigh: z.priceHigh,
+        volumeShare: z.volumeShare,
+      })),
+    [analysis?.volumeZones],
+  );
+
   if (analysisQuery.isLoading) {
     return <div className="text-sm text-muted">{tk('loading')}</div>;
   }
-  if (analysisQuery.isError || !analysisQuery.data) {
+  if (analysisQuery.isError || !analysis) {
     return <div className="text-sm text-danger">{tk('loadError')}</div>;
   }
-
-  const analysis = analysisQuery.data;
-  const zones: ChartVolumeZone[] = analysis.volumeZones.map((z) => ({
-    kind: z.kind,
-    center: z.center,
-    priceLow: z.priceLow,
-    priceHigh: z.priceHigh,
-    volumeShare: z.volumeShare,
-  }));
 
   return (
     <div className="space-y-3">


### PR DESCRIPTION
CandleChart: hoist empty benchmarkBars/volumeZones defaults to stable module consts and drop showVolumeZones from the creation-effect deps, so toggling zone visibility uses the cheap line-toggle effect (like R-levels and key-levels) instead of tearing down and rebuilding the whole chart on every render. Memoize the zones array in VolumeZonesTab.

momentum: collapse the redundant compute_symbol_records if/else — the quote_to_eur_rates kwarg already defaults to None. Widen the test spies to accept it.