### PR TITLE
Enforce authoritative order risk approval

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -113,6 +113,9 @@ RATE_LIMIT_EXPENSIVE_PER_MINUTE=5
 RATE_LIMIT_SWEEP_PER_MINUTE=2
 RATE_LIMIT_MAX_BUCKETS=10000
 INTELLIGENCE_SWEEP_MAX_SYMBOLS=20
+# Required in production; rotating it invalidates outstanding candidate tokens.
+# ORDER_APPROVAL_SIGNING_KEY=
+ORDER_APPROVAL_TTL_SECONDS=28800
 
 # ---------------------------------------------------------------------------
 # Frontend (Vite) — put these in web-ui/.env.local for local React dev

--- a/api/README.md
+++ b/api/README.md
@@ -25,6 +25,17 @@ and 2 intelligence sweeps/minute by default. Sweeps also reject more than
 multi-worker deployment requires a shared limiter before increasing
 `WEB_CONCURRENCY`.
 
+## Entry Approval Tokens
+
+Actionable screener candidates carry a short-lived HMAC approval token. Entry
+orders must return that opaque token; the API verifies its ticker, active
+strategy, signed decision gates, freshness, currency, FX, target source, and
+earnings context, then recomputes quantity, price, reward/risk, trade risk,
+position cap, cash, heat, and fees from the submitted order. Country
+concentration is a risk-share warning and does not block an otherwise valid
+trade. Configure a separate 32-byte `ORDER_APPROVAL_SIGNING_KEY` in production;
+rotation invalidates outstanding tokens.
+
 FastAPI service that exposes the Swing Screener backend as a REST API.
 
 ## Run

--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import threading
+from functools import lru_cache
 from pathlib import Path
 from typing import Optional, TYPE_CHECKING
 
@@ -22,6 +23,8 @@ from api.repositories.watchlist_repo import WatchlistRepository
 from api.repositories.weekly_reviews_repo import WeeklyReviewsRepository
 from api.services.fundamentals_service import FundamentalsService
 from api.services.orders_service import OrdersService
+from api.services.order_approval_token import OrderApprovalTokenSigner
+from api.security.settings import get_auth_settings
 from api.services.portfolio_service import PortfolioService
 from api.services.regime_analytics import RegimeAnalyticsService
 from api.services.screener_service import ScreenerService
@@ -36,6 +39,15 @@ from swing_screener.fundamentals import FundamentalsAnalysisService as _Fundamen
 _finnhub_client: FinnhubEnrichmentClient | None = None
 _finnhub_client_api_key: str | None = None
 _finnhub_client_lock = threading.Lock()
+
+
+@lru_cache(maxsize=1)
+def get_order_approval_signer() -> OrderApprovalTokenSigner:
+    settings = get_auth_settings()
+    return OrderApprovalTokenSigner(
+        settings.order_approval_signing_key,
+        ttl_seconds=settings.order_approval_ttl_seconds,
+    )
 
 
 def get_finnhub_client() -> FinnhubEnrichmentClient | None:
@@ -143,12 +155,14 @@ def get_orders_service(
     positions_repo: PositionsRepository = Depends(get_positions_repo),
     config_repo: ConfigRepository = Depends(get_config_repo),
     strategy_repo: StrategyRepository = Depends(get_strategy_repo),
+    approval_signer: OrderApprovalTokenSigner = Depends(get_order_approval_signer),
 ) -> OrdersService:
     return OrdersService(
         orders_repo=orders_repo,
         positions_repo=positions_repo,
         config_repo=config_repo,
         strategy_repo=strategy_repo,
+        approval_signer=approval_signer,
     )
 
 
@@ -185,6 +199,7 @@ def get_screener_service(
     orders_service: OrdersService = Depends(get_orders_service),
     pool_repo: SymbolPoolRepository = Depends(get_symbol_pool_repo),
     review_repo: ReviewQueueRepository = Depends(get_review_queue_repo),
+    approval_signer: OrderApprovalTokenSigner = Depends(get_order_approval_signer),
 ) -> ScreenerService:
     return ScreenerService(
         strategy_repo=strategy_repo,
@@ -192,6 +207,7 @@ def get_screener_service(
         orders_service=orders_service,
         pool_repo=pool_repo,
         review_repo=review_repo,
+        approval_signer=approval_signer,
     )
 
 

--- a/api/models/config.py
+++ b/api/models/config.py
@@ -1,4 +1,5 @@
 """Config models."""
+
 from __future__ import annotations
 
 from typing import Literal
@@ -8,12 +9,23 @@ from pydantic import BaseModel, Field
 
 class RiskConfig(BaseModel):
     account_size: float = Field(gt=0, description="Total account size in dollars")
-    risk_pct: float = Field(gt=0, le=1, description="Risk per trade as decimal (e.g., 0.01 = 1%)")
-    max_position_pct: float = Field(gt=0, le=1, description="Max position size as % of account")
+    risk_pct: float = Field(
+        gt=0, le=1, description="Risk per trade as decimal (e.g., 0.01 = 1%)"
+    )
+    max_position_pct: float = Field(
+        gt=0, le=1, description="Max position size as % of account"
+    )
     min_shares: int = Field(ge=1, description="Minimum shares to trade")
     k_atr: float = Field(gt=0, description="ATR multiplier for stops")
-    min_rr: float = Field(gt=0, default=2.0, description="Minimum reward-to-risk required")
-    max_fee_risk_pct: float = Field(ge=0, le=1, default=0.2, description="Max fees as % of planned risk")
+    min_rr: float = Field(
+        gt=0, default=2.0, description="Minimum reward-to-risk required"
+    )
+    max_fee_risk_pct: float = Field(
+        ge=0, le=1, default=0.2, description="Max fees as % of planned risk"
+    )
+    max_portfolio_heat_pct: float = Field(
+        gt=0, le=1, default=0.06, description="Maximum aggregate open and pending risk"
+    )
     max_concentration_pct: float = Field(
         ge=0,
         le=100,
@@ -36,9 +48,13 @@ class IndicatorConfig(BaseModel):
     sma_long: int = Field(gt=0, description="Long SMA window (e.g., 200)")
     atr_window: int = Field(gt=0, description="ATR window (e.g., 14)")
     lookback_6m: int = Field(gt=0, description="6-month momentum lookback (e.g., 126)")
-    lookback_12m: int = Field(gt=0, description="12-month momentum lookback (e.g., 252)")
+    lookback_12m: int = Field(
+        gt=0, description="12-month momentum lookback (e.g., 252)"
+    )
     benchmark: str = Field(description="Benchmark ticker (e.g., SPY)")
-    breakout_lookback: int = Field(gt=0, description="Breakout lookback window (e.g., 50)")
+    breakout_lookback: int = Field(
+        gt=0, description="Breakout lookback window (e.g., 50)"
+    )
     pullback_ma: int = Field(gt=0, description="Pullback MA window (e.g., 20)")
     min_history: int = Field(gt=0, description="Minimum bars required for signals")
 
@@ -47,14 +63,24 @@ class ManageConfig(BaseModel):
     breakeven_at_r: float = Field(ge=0, description="Move stop to entry when R >= this")
     trail_after_r: float = Field(ge=0, description="Start trailing when R >= this")
     trail_sma: int = Field(gt=0, description="SMA to trail under")
-    sma_buffer_pct: float = Field(ge=0, description="Buffer below SMA (e.g., 0.005 = 0.5%)")
+    sma_buffer_pct: float = Field(
+        ge=0, description="Buffer below SMA (e.g., 0.005 = 0.5%)"
+    )
     max_holding_days: int = Field(
         gt=0,
         description="Max trading bars to hold before the hard time-exit rule",
     )
-    time_stop_days: int = Field(default=15, gt=0, description="Days open before stale-trade nudge appears")
-    time_stop_min_r: float = Field(default=0.5, ge=0, description="Minimum R that suppresses stale-trade nudge")
-    exit_signal_days: int = Field(default=2, ge=0, description="N consecutive closes below SMA triggers advisory exit (0 = disabled)")
+    time_stop_days: int = Field(
+        default=15, gt=0, description="Days open before stale-trade nudge appears"
+    )
+    time_stop_min_r: float = Field(
+        default=0.5, ge=0, description="Minimum R that suppresses stale-trade nudge"
+    )
+    exit_signal_days: int = Field(
+        default=2,
+        ge=0,
+        description="N consecutive closes below SMA triggers advisory exit (0 = disabled)",
+    )
 
 
 class AppConfig(BaseModel):

--- a/api/models/portfolio.py
+++ b/api/models/portfolio.py
@@ -1,4 +1,5 @@
 """Portfolio models (positions and orders)."""
+
 from __future__ import annotations
 
 import math
@@ -112,11 +113,18 @@ class UpdateTrailMethodRequest(BaseModel):
 
 class PartialCloseEvent(BaseModel):
     """A single partial-close event stored on the position."""
+
     date: str = Field(..., description="Date of partial close (YYYY-MM-DD)")
-    shares_closed: int = Field(..., gt=0, description="Number of shares closed in this leg")
+    shares_closed: int = Field(
+        ..., gt=0, description="Number of shares closed in this leg"
+    )
     price: float = Field(..., gt=0, description="Exit price for this leg")
-    r_at_close: float = Field(..., description="R-multiple at the time of this partial close")
-    fee_eur: Optional[float] = Field(default=None, ge=0, description="Fee for this leg in EUR")
+    r_at_close: float = Field(
+        ..., description="R-multiple at the time of this partial close"
+    )
+    fee_eur: Optional[float] = Field(
+        default=None, ge=0, description="Fee for this leg in EUR"
+    )
     fx_rate: Optional[float] = Field(
         default=None,
         gt=0,
@@ -135,9 +143,12 @@ class PartialCloseEvent(BaseModel):
 
 class PartialCloseRequest(BaseModel):
     """Request to partially close an open position."""
+
     shares_closed: int = Field(..., gt=0, description="Number of shares to close")
     price: float = Field(..., gt=0, description="Exit price for this leg")
-    fee_eur: Optional[float] = Field(default=None, ge=0, description="Fee in EUR (optional)")
+    fee_eur: Optional[float] = Field(
+        default=None, ge=0, description="Fee in EUR (optional)"
+    )
     fx_rate: Optional[float] = Field(
         default=None,
         gt=0,
@@ -167,8 +178,12 @@ class ClosePositionRequest(BaseModel):
         description="EURUSD rate at exit execution (optional)",
     )
     reason: str = Field(default="", description="Reason for closing")
-    lesson: Optional[str] = Field(default=None, description="Lesson / reflection (optional)")
-    tags: list[str] = Field(default_factory=list, description="Structured tags for this trade")
+    lesson: Optional[str] = Field(
+        default=None, description="Lesson / reflection (optional)"
+    )
+    tags: list[str] = Field(
+        default_factory=list, description="Structured tags for this trade"
+    )
 
     @field_validator("exit_price")
     @classmethod
@@ -231,11 +246,15 @@ class CreatePositionRequest(BaseModel):
     stop_price: float = Field(gt=0, description="Initial stop-loss price")
     shares: int = Field(gt=0, description="Number of shares")
     entry_date: str = Field(description="Entry date (YYYY-MM-DD)")
-    target_price: Optional[float] = Field(default=None, gt=0, description="Planned price target (optional)")
+    target_price: Optional[float] = Field(
+        default=None, gt=0, description="Planned price target (optional)"
+    )
     thesis: Optional[str] = None
     isin: Optional[str] = None
     notes: str = ""
-    fee_eur: Optional[float] = Field(default=None, ge=0, description="Entry fee in EUR (optional)")
+    fee_eur: Optional[float] = Field(
+        default=None, ge=0, description="Entry fee in EUR (optional)"
+    )
 
     @field_validator("ticker")
     @classmethod
@@ -246,7 +265,9 @@ class CreatePositionRequest(BaseModel):
         if len(v) > 10:
             raise ValueError("Ticker must be 10 characters or less")
         if not re.fullmatch(r"[A-Z0-9][A-Z0-9.-]*", v):
-            raise ValueError("Ticker must contain only letters, numbers, dots, or hyphens")
+            raise ValueError(
+                "Ticker must contain only letters, numbers, dots, or hyphens"
+            )
         return v
 
     @model_validator(mode="after")
@@ -264,7 +285,9 @@ class CreateOrderRequest(BaseModel):
     quantity: int = Field(gt=0, description="Number of shares")
     limit_price: Optional[float] = Field(default=None, ge=0)
     stop_price: Optional[float] = Field(default=None, gt=0)
-    target_price: Optional[float] = Field(default=None, gt=0, description="Planned price target (optional)")
+    target_price: Optional[float] = Field(
+        default=None, gt=0, description="Planned price target (optional)"
+    )
     notes: str = ""
     order_kind: str = "entry"
     position_id: Optional[str] = None
@@ -275,12 +298,15 @@ class CreateOrderRequest(BaseModel):
     trigger_status: Literal["PASS", "WAIT", "BLOCK", "UNKNOWN"] = "UNKNOWN"
     data_status: Literal["current", "stale", "intraday", "unknown"] = "unknown"
     data_asof: Optional[str] = None
-    target_source: Literal["structural", "manual", "unknown", "unvalidated_r_multiple"] = "unknown"
+    target_source: Literal[
+        "structural", "manual", "unknown", "unvalidated_r_multiple"
+    ] = "unknown"
     sector: Optional[str] = None
     currency: Optional[str] = None
     account_to_quote_rate: Optional[float] = Field(default=None, gt=0)
     days_to_earnings: Optional[int] = None
     strategy_id: Optional[str] = None
+    approval_token: Optional[str] = None
 
     @field_validator("ticker")
     @classmethod
@@ -308,12 +334,14 @@ class CreateOrderRequest(BaseModel):
             and self.limit_price is not None
             and self.stop_price >= self.limit_price
         ):
-            raise ValueError("stop_price must be below limit_price for a long entry order")
+            raise ValueError(
+                "stop_price must be below limit_price for a long entry order"
+            )
         return self
 
 
 class PortfolioApprovalGate(BaseModel):
-    status: Literal["PASS", "BLOCK"]
+    status: Literal["PASS", "WARN", "BLOCK"]
     explanation: str
     current: Optional[float] = None
     projected: Optional[float] = None
@@ -322,21 +350,43 @@ class PortfolioApprovalGate(BaseModel):
 
 class PortfolioOrderApproval(BaseModel):
     approved: bool
+    decision: Optional[PortfolioApprovalGate] = None
+    coherence: Optional[PortfolioApprovalGate] = None
+    reward_risk: Optional[PortfolioApprovalGate] = None
+    trade_risk: Optional[PortfolioApprovalGate] = None
+    position: Optional[PortfolioApprovalGate] = None
     cash: PortfolioApprovalGate
     heat: PortfolioApprovalGate
+    fees: Optional[PortfolioApprovalGate] = None
+    fx: Optional[PortfolioApprovalGate] = None
     concentration: PortfolioApprovalGate
     event: PortfolioApprovalGate
     projected_risk: float
     projected_notional: float
+    estimated_fees: float = 0.0
+    current_exposure: dict[str, float] = Field(default_factory=dict)
+    projected_exposure: dict[str, float] = Field(default_factory=dict)
+    policy_version: str = "order-risk-v1"
+    policy_values: dict[str, float | str] = Field(default_factory=dict)
+    token_id: Optional[str] = None
+    plan_fingerprint: Optional[str] = None
+    verified_context: dict = Field(default_factory=dict)
 
 
 class FillOrderRequest(BaseModel):
     """Request to manually mark a pending order as filled."""
+
     filled_price: float = Field(gt=0, description="Actual fill price")
     filled_date: str = Field(description="Fill date (YYYY-MM-DD)")
-    stop_price: Optional[float] = Field(default=None, gt=0, description="Override stop price from order")
-    fee_eur: Optional[float] = Field(default=None, ge=0, description="Execution fee in EUR")
-    fill_fx_rate: Optional[float] = Field(default=None, gt=0, description="FX rate at fill")
+    stop_price: Optional[float] = Field(
+        default=None, gt=0, description="Override stop price from order"
+    )
+    fee_eur: Optional[float] = Field(
+        default=None, ge=0, description="Execution fee in EUR"
+    )
+    fill_fx_rate: Optional[float] = Field(
+        default=None, gt=0, description="FX rate at fill"
+    )
 
     @field_validator("filled_price")
     @classmethod
@@ -349,6 +399,7 @@ class FillOrderRequest(BaseModel):
     @classmethod
     def validate_filled_date(cls, v: str) -> str:
         import re
+
         if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", v):
             raise ValueError("filled_date must be in YYYY-MM-DD format")
         return v
@@ -361,9 +412,15 @@ class FillOrderResponse(BaseModel):
 
 class EarningsProximityResponse(BaseModel):
     ticker: str
-    next_earnings_date: Optional[str] = Field(default=None, description="Next earnings date as YYYY-MM-DD")
-    days_until: Optional[int] = Field(default=None, description="Calendar days until next earnings")
-    warning: bool = Field(default=False, description="True when earnings are within the warning window")
+    next_earnings_date: Optional[str] = Field(
+        default=None, description="Next earnings date as YYYY-MM-DD"
+    )
+    days_until: Optional[int] = Field(
+        default=None, description="Calendar days until next earnings"
+    )
+    warning: bool = Field(
+        default=False, description="True when earnings are within the warning window"
+    )
 
 
 class RegimeStats(BaseModel):
@@ -383,8 +440,12 @@ class ConcentrationGroup(BaseModel):
     country: str = Field(..., description="Derived country or market group")
     risk_amount: float = Field(..., description="Open risk amount in this group")
     risk_pct: float = Field(..., description="Share of total open risk as a percentage")
-    position_count: int = Field(..., description="Number of open positions in this group")
-    warning: bool = Field(..., description="True when concentration exceeds configured threshold")
+    position_count: int = Field(
+        ..., description="Number of open positions in this group"
+    )
+    warning: bool = Field(
+        ..., description="True when concentration exceeds configured threshold"
+    )
 
 
 class PositionsResponse(BaseModel):
@@ -396,13 +457,21 @@ class PositionWithMetrics(Position):
     """Position with precomputed financial metrics."""
 
     pnl: float = Field(..., description="Absolute profit/loss in dollars")
-    fees_eur: float = Field(default=0.0, description="Accumulated execution fees in EUR")
+    fees_eur: float = Field(
+        default=0.0, description="Accumulated execution fees in EUR"
+    )
     pnl_percent: float = Field(..., description="P&L as percentage")
     r_now: float = Field(..., description="Current R-multiple")
-    entry_value: float = Field(..., description="Total entry value (shares × entry_price)")
-    current_value: float = Field(..., description="Current market value (shares × current_price)")
+    entry_value: float = Field(
+        ..., description="Total entry value (shares × entry_price)"
+    )
+    current_value: float = Field(
+        ..., description="Current market value (shares × current_price)"
+    )
     per_share_risk: float = Field(..., description="Risk per share in dollars")
-    total_risk: float = Field(..., description="Total position risk (per_share_risk × shares)")
+    total_risk: float = Field(
+        ..., description="Total position risk (per_share_risk × shares)"
+    )
     days_open: int = Field(default=0, description="Calendar days since entry date")
     time_stop_warning: bool = Field(
         default=False,
@@ -432,13 +501,21 @@ class PositionMetrics(BaseModel):
 
     ticker: str = Field(..., description="Stock ticker symbol")
     pnl: float = Field(..., description="Absolute profit/loss in dollars")
-    fees_eur: float = Field(default=0.0, description="Accumulated execution fees in EUR")
+    fees_eur: float = Field(
+        default=0.0, description="Accumulated execution fees in EUR"
+    )
     pnl_percent: float = Field(..., description="P&L as percentage")
     r_now: float = Field(..., description="Current R-multiple")
-    entry_value: float = Field(..., description="Total entry value (shares × entry_price)")
-    current_value: float = Field(..., description="Current market value (shares × current_price)")
+    entry_value: float = Field(
+        ..., description="Total entry value (shares × entry_price)"
+    )
+    current_value: float = Field(
+        ..., description="Current market value (shares × current_price)"
+    )
     per_share_risk: float = Field(..., description="Risk per share in dollars")
-    total_risk: float = Field(..., description="Total position risk (per_share_risk × shares)")
+    total_risk: float = Field(
+        ..., description="Total position risk (per_share_risk × shares)"
+    )
     partial_closes: list[PartialCloseEvent] = Field(
         default_factory=list,
         description="Partial-close events recorded on this position",
@@ -465,16 +542,30 @@ class PortfolioSummary(BaseModel):
     """Portfolio-level aggregations."""
 
     total_positions: int = Field(..., description="Number of open positions")
-    total_value: float = Field(..., description="Total market value of all open positions")
-    total_cost_basis: float = Field(..., description="Total entry value of all open positions")
-    total_pnl: float = Field(..., description="Total unrealized P&L across open positions")
-    total_fees_eur: float = Field(default=0.0, description="Total execution fees across open positions (EUR)")
-    total_pnl_percent: float = Field(..., description="Portfolio unrealized P&L percentage")
+    total_value: float = Field(
+        ..., description="Total market value of all open positions"
+    )
+    total_cost_basis: float = Field(
+        ..., description="Total entry value of all open positions"
+    )
+    total_pnl: float = Field(
+        ..., description="Total unrealized P&L across open positions"
+    )
+    total_fees_eur: float = Field(
+        default=0.0, description="Total execution fees across open positions (EUR)"
+    )
+    total_pnl_percent: float = Field(
+        ..., description="Portfolio unrealized P&L percentage"
+    )
     open_risk: float = Field(..., description="Total open risk (sum of position risks)")
     open_risk_percent: float = Field(..., description="Open risk as % of account size")
     account_size: float = Field(..., description="Account size from strategy config")
-    available_capital: float = Field(..., description="Account size minus total position value")
-    largest_position_value: float = Field(..., description="Value of largest single position")
+    available_capital: float = Field(
+        ..., description="Account size minus total position value"
+    )
+    largest_position_value: float = Field(
+        ..., description="Value of largest single position"
+    )
     largest_position_ticker: str = Field(..., description="Ticker of largest position")
     best_performer_ticker: str = Field(..., description="Ticker with highest P&L %")
     best_performer_pnl_pct: float = Field(..., description="Best P&L percentage")
@@ -485,7 +576,9 @@ class PortfolioSummary(BaseModel):
     positions_losing: int = Field(..., description="Number of positions at loss")
     win_rate: float = Field(..., description="Percentage of positions profitable")
     concentration: list[ConcentrationGroup] = Field(default_factory=list)
-    realized_pnl: float = Field(default=0.0, description="Total realized P&L from closed positions")
+    realized_pnl: float = Field(
+        default=0.0, description="Total realized P&L from closed positions"
+    )
     effective_account_size: float = Field(
         default=0.0,
         description="Account size adjusted for realized P&L when mode=equity",

--- a/api/models/portfolio.py
+++ b/api/models/portfolio.py
@@ -61,6 +61,8 @@ class Position(BaseModel):
         default=None,
         description="FX rate (EURUSD) at position entry — used for FX-adjusted R display",
     )
+    quote_currency: Optional[str] = None
+    account_currency: Optional[str] = None
     trail_method: TrailMethod = Field(
         default="sma20",
         description="Trail stop method: sma20 | atr | fixed_pct | manual",
@@ -255,6 +257,24 @@ class CreatePositionRequest(BaseModel):
     fee_eur: Optional[float] = Field(
         default=None, ge=0, description="Entry fee in EUR (optional)"
     )
+    quote_currency: Optional[str] = None
+    account_currency: Optional[str] = None
+    entry_fx_rate: Optional[float] = Field(default=None, gt=0)
+
+    @field_validator(
+        "entry_price", "stop_price", "target_price", "fee_eur", "entry_fx_rate"
+    )
+    @classmethod
+    def validate_finite_position_values(cls, value: Optional[float]) -> Optional[float]:
+        if value is not None and not math.isfinite(value):
+            raise ValueError("position financial values must be finite")
+        return value
+
+    @field_validator("quote_currency", "account_currency")
+    @classmethod
+    def normalize_position_currency(cls, value: Optional[str]) -> Optional[str]:
+        normalized = str(value or "").strip().upper()
+        return normalized or None
 
     @field_validator("ticker")
     @classmethod
@@ -289,7 +309,7 @@ class CreateOrderRequest(BaseModel):
         default=None, gt=0, description="Planned price target (optional)"
     )
     notes: str = ""
-    order_kind: str = "entry"
+    order_kind: Literal["entry", "stop", "take_profit"] = "entry"
     position_id: Optional[str] = None
     entry_mode: str = "NEW_ENTRY"
     isin: Optional[str] = None
@@ -323,8 +343,29 @@ class CreateOrderRequest(BaseModel):
     def validate_order_type(cls, v: str) -> str:
         return v.strip().upper()
 
+    @field_validator(
+        "limit_price",
+        "stop_price",
+        "target_price",
+        "account_to_quote_rate",
+    )
+    @classmethod
+    def validate_finite_order_values(cls, value: Optional[float]) -> Optional[float]:
+        if value is not None and not math.isfinite(value):
+            raise ValueError("order financial values must be finite")
+        return value
+
     @model_validator(mode="after")
     def validate_stop_below_limit(self):
+        valid_types = {
+            "entry": {"BUY_LIMIT", "BUY_STOP", "BUY_MARKET"},
+            "stop": {"SELL_STOP"},
+            "take_profit": {"SELL_LIMIT", "SELL_MARKET"},
+        }
+        if self.order_type not in valid_types[self.order_kind]:
+            raise ValueError(
+                f"order_kind {self.order_kind!r} is incompatible with order_type {self.order_type!r}"
+            )
         # Long entry orders require stop below the limit entry. A protective SELL
         # stop-limit legitimately has stop_price >= limit_price, so skip sells.
         is_sell = self.order_type.upper().startswith("SELL")

--- a/api/models/screener.py
+++ b/api/models/screener.py
@@ -49,6 +49,7 @@ class SameSymbolCandidateContext(BaseModel):
 
 class ScreenerCandidate(BaseModel):
     ticker: str
+    approval_token: Optional[str] = None
     currency: str = "USD"
     exchange_mic: Optional[str] = None
     instrument_type: Optional[str] = None

--- a/api/models/strategy.py
+++ b/api/models/strategy.py
@@ -1,4 +1,5 @@
 """Strategy models."""
+
 from __future__ import annotations
 
 from typing import Optional, Literal
@@ -69,6 +70,7 @@ class StrategyRisk(BaseModel):
     rr_target: float = Field(gt=0, default=2.0)
     commission_pct: float = Field(ge=0, default=0.0)
     max_fee_risk_pct: float = Field(ge=0, le=1, default=0.2)
+    max_portfolio_heat_pct: float = Field(gt=0, le=1, default=0.06)
     account_size_mode: Literal["base", "equity"] = "equity"
     regime_enabled: bool = False
     regime_trend_sma: int = Field(gt=1, default=200)
@@ -120,9 +122,14 @@ class StrategyIntelligenceOpportunity(BaseModel):
 class StrategyMarketIntelligence(BaseModel):
     enabled: bool = False
     llm: StrategyIntelligenceLLM = Field(default_factory=StrategyIntelligenceLLM)
-    catalyst: StrategyIntelligenceCatalyst = Field(default_factory=StrategyIntelligenceCatalyst)
+    catalyst: StrategyIntelligenceCatalyst = Field(
+        default_factory=StrategyIntelligenceCatalyst
+    )
     theme: StrategyIntelligenceTheme = Field(default_factory=StrategyIntelligenceTheme)
-    opportunity: StrategyIntelligenceOpportunity = Field(default_factory=StrategyIntelligenceOpportunity)
+    opportunity: StrategyIntelligenceOpportunity = Field(
+        default_factory=StrategyIntelligenceOpportunity
+    )
+
 
 class StrategyBase(BaseModel):
     name: str
@@ -133,7 +140,9 @@ class StrategyBase(BaseModel):
     signals: StrategySignals
     risk: StrategyRisk
     manage: StrategyManage
-    market_intelligence: StrategyMarketIntelligence = Field(default_factory=StrategyMarketIntelligence)
+    market_intelligence: StrategyMarketIntelligence = Field(
+        default_factory=StrategyMarketIntelligence
+    )
 
 
 class StrategyCreateRequest(StrategyBase):
@@ -159,14 +168,18 @@ class ValidationWarningModel(BaseModel):
     """Validation warning for a strategy parameter."""
 
     parameter: str = Field(..., description="Parameter name that triggered warning")
-    level: Literal["danger", "warning", "info"] = Field(..., description="Warning severity")
+    level: Literal["danger", "warning", "info"] = Field(
+        ..., description="Warning severity"
+    )
     message: str = Field(..., description="Human-readable warning message")
 
 
 class StrategyValidationResult(BaseModel):
     """Result payload for strategy validation."""
 
-    is_valid: bool = Field(..., description="True if no danger-level warnings are present")
+    is_valid: bool = Field(
+        ..., description="True if no danger-level warnings are present"
+    )
     warnings: list[ValidationWarningModel] = Field(default_factory=list)
     safety_score: int = Field(..., ge=0, le=100)
     safety_level: Literal["beginner-safe", "requires-discipline", "expert-only"]

--- a/api/security/settings.py
+++ b/api/security/settings.py
@@ -1,8 +1,10 @@
 """Typed, fail-closed security configuration."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from functools import lru_cache
+import hashlib
 from os import environ as process_environ
 from typing import Literal, Mapping
 
@@ -14,9 +16,7 @@ class SecurityConfigurationError(RuntimeError):
     """Raised when the security environment is invalid."""
 
 
-def _enum(
-    env: Mapping[str, str], name: str, default: str, allowed: set[str]
-) -> str:
+def _enum(env: Mapping[str, str], name: str, default: str, allowed: set[str]) -> str:
     value = env.get(name, default).strip().lower()
     if value not in allowed:
         choices = ", ".join(sorted(allowed))
@@ -52,7 +52,9 @@ def _positive_int(
 
 def _values(env: Mapping[str, str], name: str, default: str) -> frozenset[str]:
     return frozenset(
-        part.strip().lower() for part in env.get(name, default).split(",") if part.strip()
+        part.strip().lower()
+        for part in env.get(name, default).split(",")
+        if part.strip()
     )
 
 
@@ -79,11 +81,11 @@ class AuthSettings:
     rate_limit_sweep_per_minute: int
     rate_limit_max_buckets: int
     intelligence_sweep_max_symbols: int
+    order_approval_signing_key: bytes = field(repr=False)
+    order_approval_ttl_seconds: int = 28_800
 
     @classmethod
-    def from_env(
-        cls, environ: Mapping[str, str] | None = None
-    ) -> "AuthSettings":
+    def from_env(cls, environ: Mapping[str, str] | None = None) -> "AuthSettings":
         env = process_environ if environ is None else environ
         app_env = _enum(
             env, "APP_ENV", "development", {"development", "test", "production"}
@@ -95,6 +97,13 @@ class AuthSettings:
             if auth_mode == "disabled"
             else ""
         )
+        session_secret = env.get("SESSION_SECRET", default_secret)
+        raw_approval_key = env.get("ORDER_APPROVAL_SIGNING_KEY", "")
+        approval_key = raw_approval_key.encode("utf-8")
+        if not approval_key and app_env != "production":
+            approval_key = hashlib.sha256(
+                f"order-approval:{session_secret}".encode("utf-8")
+            ).digest()
         return cls(
             app_env=app_env,  # type: ignore[arg-type]
             auth_mode=auth_mode,  # type: ignore[arg-type]
@@ -105,19 +114,13 @@ class AuthSettings:
             oidc_role_claim=env.get("OIDC_ROLE_CLAIM", "roles").strip(),
             oidc_admin_values=_values(env, "OIDC_ADMIN_VALUES", "admin"),
             oidc_viewer_values=_values(env, "OIDC_VIEWER_VALUES", "viewer"),
-            session_secret=env.get("SESSION_SECRET", default_secret),
-            session_ttl_seconds=_positive_int(
-                env, "SESSION_TTL_SECONDS", 8 * 60 * 60
-            ),
-            session_cookie_name=env.get(
-                "SESSION_COOKIE_NAME", "swing_session"
-            ).strip(),
+            session_secret=session_secret,
+            session_ttl_seconds=_positive_int(env, "SESSION_TTL_SECONDS", 8 * 60 * 60),
+            session_cookie_name=env.get("SESSION_COOKIE_NAME", "swing_session").strip(),
             session_cookie_secure=_boolean(
                 env, "SESSION_COOKIE_SECURE", app_env == "production"
             ),
-            api_docs_enabled=_boolean(
-                env, "API_DOCS_ENABLED", app_env != "production"
-            ),
+            api_docs_enabled=_boolean(env, "API_DOCS_ENABLED", app_env != "production"),
             trust_proxy_headers=_boolean(env, "AUTH_TRUST_PROXY_HEADERS", False),
             rate_limit_default_per_minute=_positive_int(
                 env, "RATE_LIMIT_DEFAULT_PER_MINUTE", 120
@@ -131,11 +134,13 @@ class AuthSettings:
             rate_limit_sweep_per_minute=_positive_int(
                 env, "RATE_LIMIT_SWEEP_PER_MINUTE", 2
             ),
-            rate_limit_max_buckets=_positive_int(
-                env, "RATE_LIMIT_MAX_BUCKETS", 10_000
-            ),
+            rate_limit_max_buckets=_positive_int(env, "RATE_LIMIT_MAX_BUCKETS", 10_000),
             intelligence_sweep_max_symbols=_positive_int(
                 env, "INTELLIGENCE_SWEEP_MAX_SYMBOLS", 20, maximum=100
+            ),
+            order_approval_signing_key=approval_key,
+            order_approval_ttl_seconds=_positive_int(
+                env, "ORDER_APPROVAL_TTL_SECONDS", 28_800
             ),
         )
 
@@ -171,6 +176,14 @@ class AuthSettings:
             if not self.session_cookie_secure:
                 raise SecurityConfigurationError(
                     "SESSION_COOKIE_SECURE must be enabled in production"
+                )
+            if len(self.order_approval_signing_key) < 32:
+                raise SecurityConfigurationError(
+                    "ORDER_APPROVAL_SIGNING_KEY must contain at least 32 bytes in production"
+                )
+            if self.order_approval_ttl_seconds > 86_400:
+                raise SecurityConfigurationError(
+                    "ORDER_APPROVAL_TTL_SECONDS must not exceed 86400 in production"
                 )
 
 

--- a/api/services/order_approval.py
+++ b/api/services/order_approval.py
@@ -76,8 +76,13 @@ def evaluate_order_approval(
         "Signed decision or freshness permission does not pass.",
     )
 
+    finite_plan = all(
+        value.is_finite()
+        for value in (submitted.entry, submitted.stop, submitted.target)
+    )
     coherent = (
-        submitted.quantity > 0
+        finite_plan
+        and submitted.quantity > 0
         and submitted.stop > 0
         and submitted.stop < submitted.entry < submitted.target
     )

--- a/api/services/order_approval.py
+++ b/api/services/order_approval.py
@@ -1,0 +1,240 @@
+"""Pure, deterministic entry-order approval policy."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from decimal import Decimal
+
+from api.models.portfolio import PortfolioApprovalGate, PortfolioOrderApproval
+from api.services.order_approval_token import VerifiedApprovalToken
+from api.services.order_exposure import ExposureSnapshot, country_from_ticker
+
+
+@dataclass(frozen=True)
+class EffectiveOrderPolicy:
+    account_size: Decimal
+    risk_pct: Decimal
+    max_position_pct: Decimal
+    max_portfolio_heat_pct: Decimal
+    min_rr: Decimal
+    commission_pct: Decimal
+    max_fee_risk_pct: Decimal
+    max_concentration_pct: Decimal
+    account_currency: str
+    version: str = "order-risk-v1"
+
+
+@dataclass(frozen=True)
+class SubmittedPlan:
+    ticker: str
+    quantity: int
+    entry: Decimal
+    stop: Decimal
+    target: Decimal
+
+
+def _number(value: Decimal) -> float:
+    return round(float(value), 4)
+
+
+def _gate(
+    passed: bool,
+    pass_text: str,
+    block_text: str,
+    *,
+    current: Decimal | None = None,
+    projected: Decimal | None = None,
+    limit: Decimal | None = None,
+) -> PortfolioApprovalGate:
+    return PortfolioApprovalGate(
+        status="PASS" if passed else "BLOCK",
+        explanation=pass_text if passed else block_text,
+        current=_number(current) if current is not None else None,
+        projected=_number(projected) if projected is not None else None,
+        limit=_number(limit) if limit is not None else None,
+    )
+
+
+def evaluate_order_approval(
+    context: VerifiedApprovalToken,
+    submitted: SubmittedPlan,
+    snapshot: ExposureSnapshot,
+    policy: EffectiveOrderPolicy,
+) -> PortfolioOrderApproval:
+    proposed = next(line for line in snapshot.lines if line.source == "proposed")
+    decision_pass = (
+        context.setup_status == "PASS"
+        and context.trigger_status == "PASS"
+        and context.plan_status == "PASS"
+        and context.data_status == "current"
+        and bool(context.data_asof)
+        and context.target_source in {"structural", "manual"}
+    )
+    decision = _gate(
+        decision_pass,
+        "Signed decision and freshness permissions pass.",
+        "Signed decision or freshness permission does not pass.",
+    )
+
+    coherent = (
+        submitted.quantity > 0
+        and submitted.stop > 0
+        and submitted.stop < submitted.entry < submitted.target
+    )
+    coherence = _gate(
+        coherent,
+        "Submitted entry, stop, and target form a coherent long plan.",
+        "Submitted entry, stop, and target do not form a coherent long plan.",
+    )
+    rr = (
+        (submitted.target - submitted.entry) / (submitted.entry - submitted.stop)
+        if coherent
+        else Decimal("0")
+    )
+    reward_risk = _gate(
+        coherent and rr >= policy.min_rr,
+        "Structural reward/risk meets policy.",
+        "Structural reward/risk is below policy.",
+        projected=rr,
+        limit=policy.min_rr,
+    )
+
+    fees = proposed.notional_account * policy.commission_pct * Decimal("2")
+    planned_risk = proposed.price_risk_account + fees
+    trade_risk_limit = policy.account_size * policy.risk_pct
+    trade_risk = _gate(
+        planned_risk <= trade_risk_limit,
+        "Planned trade risk is within policy.",
+        "Planned trade risk exceeds policy.",
+        projected=planned_risk,
+        limit=trade_risk_limit,
+    )
+
+    same_symbol_notional = sum(
+        (
+            line.notional_account
+            for line in snapshot.lines
+            if line.ticker == submitted.ticker.upper()
+        ),
+        Decimal("0"),
+    )
+    position_limit = policy.account_size * policy.max_position_pct
+    position = _gate(
+        same_symbol_notional <= position_limit,
+        "Projected same-symbol position is within policy.",
+        "Projected same-symbol position exceeds policy.",
+        projected=same_symbol_notional,
+        limit=position_limit,
+    )
+    cash = _gate(
+        snapshot.projected_notional <= policy.account_size,
+        "Projected notional fits available capital.",
+        "Projected notional exceeds available capital.",
+        current=snapshot.current_notional,
+        projected=snapshot.projected_notional,
+        limit=policy.account_size,
+    )
+    projected_heat = snapshot.projected_price_risk + fees
+    heat_limit = policy.account_size * policy.max_portfolio_heat_pct
+    heat = _gate(
+        projected_heat <= heat_limit,
+        "Projected portfolio heat is within policy.",
+        "Projected portfolio heat exceeds policy.",
+        current=snapshot.current_risk,
+        projected=projected_heat,
+        limit=heat_limit,
+    )
+    fee_ratio = (
+        fees / proposed.price_risk_account
+        if proposed.price_risk_account > 0
+        else Decimal("Infinity")
+    )
+    fee_gate = _gate(
+        fee_ratio.is_finite() and fee_ratio <= policy.max_fee_risk_pct,
+        "Estimated fees are within the risk budget.",
+        "Estimated fees consume too much planned price risk.",
+        projected=fee_ratio if fee_ratio.is_finite() else None,
+        limit=policy.max_fee_risk_pct,
+    )
+    event = _gate(
+        context.days_to_earnings > 3,
+        "Earnings are outside the three-day risk window.",
+        "Earnings are inside the three-day risk window.",
+    )
+    fx = _gate(
+        True,
+        "All exposure has complete currency context.",
+        "Currency context is missing.",
+    )
+
+    total_risk = snapshot.projected_price_risk
+    proposed_country = country_from_ticker(submitted.ticker)
+    country_risk = sum(
+        (
+            line.price_risk_account
+            for line in snapshot.lines
+            if line.country == proposed_country
+        ),
+        Decimal("0"),
+    )
+    concentration_pct = (
+        country_risk / total_risk * Decimal("100") if total_risk > 0 else Decimal("0")
+    )
+    warn = concentration_pct >= policy.max_concentration_pct
+    concentration = PortfolioApprovalGate(
+        status="WARN" if warn else "PASS",
+        explanation=(
+            f"Projected {proposed_country} risk concentration meets or exceeds the warning threshold."
+            if warn
+            else f"Projected {proposed_country} risk concentration is below the warning threshold."
+        ),
+        projected=_number(concentration_pct),
+        limit=_number(policy.max_concentration_pct),
+    )
+
+    hard_gates = (
+        decision,
+        coherence,
+        reward_risk,
+        trade_risk,
+        position,
+        cash,
+        heat,
+        fee_gate,
+        event,
+        fx,
+    )
+    policy_values = {
+        key: (_number(value) if isinstance(value, Decimal) else value)
+        for key, value in asdict(policy).items()
+    }
+    return PortfolioOrderApproval(
+        approved=all(gate.status != "BLOCK" for gate in hard_gates),
+        decision=decision,
+        coherence=coherence,
+        reward_risk=reward_risk,
+        trade_risk=trade_risk,
+        position=position,
+        cash=cash,
+        heat=heat,
+        fees=fee_gate,
+        fx=fx,
+        concentration=concentration,
+        event=event,
+        projected_risk=_number(planned_risk),
+        projected_notional=_number(proposed.notional_account),
+        estimated_fees=_number(fees),
+        current_exposure={
+            "notional": _number(snapshot.current_notional),
+            "risk": _number(snapshot.current_risk),
+        },
+        projected_exposure={
+            "notional": _number(snapshot.projected_notional),
+            "risk": _number(projected_heat),
+        },
+        policy_version=policy.version,
+        policy_values=policy_values,
+        token_id=context.token_id,
+        plan_fingerprint=context.plan_fingerprint,
+        verified_context=context.model_dump(mode="json"),
+    )

--- a/api/services/order_approval_token.py
+++ b/api/services/order_approval_token.py
@@ -1,0 +1,132 @@
+"""Versioned HMAC approval tokens for actionable screener candidates."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import math
+import time
+import uuid
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+
+class ApprovalTokenError(ValueError):
+    """Raised when an order approval token cannot be trusted."""
+
+
+class ApprovalTokenClaims(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    ticker: str
+    order_type: str
+    setup_status: str
+    trigger_status: str
+    plan_status: str
+    data_status: str
+    data_asof: str
+    strategy_id: str
+    account_currency: str
+    quote_currency: str
+    account_to_quote_rate: float
+    target_source: str
+    days_to_earnings: int
+    generated_entry: float
+    generated_stop: float
+    generated_target: float
+
+    @field_validator(
+        "account_to_quote_rate",
+        "generated_entry",
+        "generated_stop",
+        "generated_target",
+    )
+    @classmethod
+    def validate_positive_finite(cls, value: float) -> float:
+        if not math.isfinite(value) or value <= 0:
+            raise ValueError("approval numeric values must be finite and positive")
+        return value
+
+
+class VerifiedApprovalToken(ApprovalTokenClaims):
+    version: int
+    token_id: str
+    issued_at: int
+    expires_at: int
+    plan_fingerprint: str
+
+
+def _canonical(value: dict) -> bytes:
+    return json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode("utf-8")
+
+
+def _encode(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).rstrip(b"=").decode("ascii")
+
+
+def _decode(value: str) -> bytes:
+    padding = "=" * (-len(value) % 4)
+    return base64.urlsafe_b64decode((value + padding).encode("ascii"))
+
+
+class OrderApprovalTokenSigner:
+    def __init__(self, key: bytes, *, ttl_seconds: int = 28_800) -> None:
+        if len(key) < 32:
+            raise ValueError("approval signing key must contain at least 32 bytes")
+        if ttl_seconds <= 0:
+            raise ValueError("approval token TTL must be positive")
+        self._key = key
+        self._ttl_seconds = ttl_seconds
+
+    def issue(self, claims: ApprovalTokenClaims, now: int | None = None) -> str:
+        issued_at = int(time.time()) if now is None else now
+        plan = {
+            "ticker": claims.ticker.upper(),
+            "order_type": claims.order_type.upper(),
+            "strategy_id": claims.strategy_id,
+            "entry": claims.generated_entry,
+            "stop": claims.generated_stop,
+            "target": claims.generated_target,
+        }
+        payload = {
+            **claims.model_dump(),
+            "ticker": claims.ticker.upper(),
+            "order_type": claims.order_type.upper(),
+            "account_currency": claims.account_currency.upper(),
+            "quote_currency": claims.quote_currency.upper(),
+            "version": 1,
+            "token_id": uuid.uuid4().hex,
+            "issued_at": issued_at,
+            "expires_at": issued_at + self._ttl_seconds,
+            "plan_fingerprint": hashlib.sha256(_canonical(plan)).hexdigest(),
+        }
+        encoded = _encode(_canonical(payload))
+        signature = _encode(
+            hmac.new(self._key, encoded.encode("ascii"), hashlib.sha256).digest()
+        )
+        return f"{encoded}.{signature}"
+
+    def verify(self, token: str, now: int | None = None) -> VerifiedApprovalToken:
+        try:
+            encoded, supplied = token.split(".", 1)
+            if not encoded or not supplied or "." in supplied:
+                raise ValueError
+            expected = _encode(
+                hmac.new(self._key, encoded.encode("ascii"), hashlib.sha256).digest()
+            )
+            if not hmac.compare_digest(expected, supplied):
+                raise ValueError
+            raw = json.loads(_decode(encoded))
+            verified = VerifiedApprovalToken.model_validate(raw)
+            if verified.version != 1:
+                raise ValueError
+        except Exception as exc:
+            raise ApprovalTokenError("approval token is invalid") from exc
+        current = int(time.time()) if now is None else now
+        if current >= verified.expires_at:
+            raise ApprovalTokenError("approval token is expired")
+        return verified

--- a/api/services/order_approval_token.py
+++ b/api/services/order_approval_token.py
@@ -9,6 +9,7 @@ import json
 import math
 import time
 import uuid
+from typing import Mapping
 
 from pydantic import BaseModel, ConfigDict, field_validator
 
@@ -28,6 +29,7 @@ class ApprovalTokenClaims(BaseModel):
     data_status: str
     data_asof: str
     strategy_id: str
+    strategy_revision: str
     account_currency: str
     quote_currency: str
     account_to_quote_rate: float
@@ -62,6 +64,11 @@ def _canonical(value: dict) -> bytes:
     return json.dumps(
         value, sort_keys=True, separators=(",", ":"), ensure_ascii=True
     ).encode("utf-8")
+
+
+def strategy_revision(strategy: Mapping[str, object]) -> str:
+    """Return a stable revision that changes whenever strategy policy changes."""
+    return hashlib.sha256(_canonical(dict(strategy))).hexdigest()
 
 
 def _encode(value: bytes) -> str:

--- a/api/services/order_exposure.py
+++ b/api/services/order_exposure.py
@@ -1,0 +1,179 @@
+"""Canonical account-currency exposure normalization."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+from typing import Literal, Mapping, Sequence
+
+from swing_screener.data.currency import detect_currency
+
+
+class ExposureContextError(ValueError):
+    """Raised when an exposure cannot be normalized safely."""
+
+
+def _decimal(value: object, field: str) -> Decimal:
+    if isinstance(value, bool) or value is None:
+        raise ExposureContextError(f"{field} is invalid")
+    try:
+        number = Decimal(str(value))
+    except (InvalidOperation, ValueError) as exc:
+        raise ExposureContextError(f"{field} is invalid") from exc
+    if not number.is_finite():
+        raise ExposureContextError(f"{field} is invalid")
+    return number
+
+
+def quote_to_account(
+    amount: Decimal,
+    account_currency: str,
+    quote_currency: str,
+    rate: Decimal | None,
+) -> Decimal:
+    account = account_currency.upper()
+    quote = quote_currency.upper()
+    if account == quote:
+        return amount
+    if rate is None or not rate.is_finite() or rate <= 0:
+        raise ExposureContextError(
+            f"FX_CONTEXT_MISSING: {quote}/{account} exposure has no positive persisted rate"
+        )
+    return amount / rate
+
+
+def country_from_ticker(ticker: str) -> str:
+    suffix = ticker.upper().rsplit(".", 1)[-1] if "." in ticker else "US"
+    return {
+        "AS": "NL",
+        "DE": "DE",
+        "PA": "FR",
+        "MI": "IT",
+        "MC": "ES",
+        "L": "UK",
+        "SW": "CH",
+        "ST": "SE",
+        "CO": "DK",
+        "OL": "NO",
+    }.get(suffix, "US")
+
+
+@dataclass(frozen=True)
+class ProposedExposure:
+    ticker: str
+    quantity: int
+    entry: Decimal
+    stop: Decimal
+    account_currency: str
+    quote_currency: str
+    account_to_quote_rate: Decimal
+
+
+@dataclass(frozen=True)
+class ExposureLine:
+    ticker: str
+    country: str
+    source: Literal["position", "pending", "proposed"]
+    notional_account: Decimal
+    price_risk_account: Decimal
+
+
+@dataclass(frozen=True)
+class ExposureSnapshot:
+    lines: tuple[ExposureLine, ...]
+    current_notional: Decimal
+    current_risk: Decimal
+    projected_notional: Decimal
+    projected_price_risk: Decimal
+
+
+def _quote_currency(row: Mapping[str, object], ticker: str) -> str:
+    value = row.get("quote_currency") or row.get("currency")
+    if value:
+        return str(value).upper()
+    return str(detect_currency(ticker) or "UNKNOWN").upper()
+
+
+def _line(
+    row: Mapping[str, object],
+    source: Literal["position", "pending"],
+    account_currency: str,
+) -> ExposureLine:
+    ticker = str(row.get("ticker") or "").upper()
+    quantity_field = "shares" if source == "position" else "quantity"
+    entry_field = "entry_price" if source == "position" else "limit_price"
+    quantity = _decimal(row.get(quantity_field), quantity_field)
+    entry = _decimal(row.get(entry_field), entry_field)
+    stop = _decimal(row.get("stop_price"), "stop_price")
+    quote_currency = _quote_currency(row, ticker)
+    rate_value = (
+        row.get("entry_fx_rate")
+        if source == "position"
+        else row.get("account_to_quote_rate")
+    )
+    if rate_value is None:
+        rate_value = row.get("approval_fx_rate")
+    rate = (
+        _decimal(rate_value, "account_to_quote_rate")
+        if rate_value is not None
+        else None
+    )
+    return ExposureLine(
+        ticker=ticker,
+        country=country_from_ticker(ticker),
+        source=source,
+        notional_account=quote_to_account(
+            quantity * entry, account_currency, quote_currency, rate
+        ),
+        price_risk_account=quote_to_account(
+            quantity * max(Decimal("0"), entry - stop),
+            account_currency,
+            quote_currency,
+            rate,
+        ),
+    )
+
+
+def build_exposure_snapshot(
+    positions: Sequence[Mapping[str, object]],
+    orders: Sequence[Mapping[str, object]],
+    proposed: ProposedExposure,
+) -> ExposureSnapshot:
+    lines: list[ExposureLine] = []
+    for position in positions:
+        if position.get("status") == "open":
+            lines.append(_line(position, "position", proposed.account_currency))
+    for order in orders:
+        if (
+            order.get("status") in {"pending", "submitted"}
+            and order.get("order_kind") == "entry"
+        ):
+            lines.append(_line(order, "pending", proposed.account_currency))
+    proposed_line = ExposureLine(
+        ticker=proposed.ticker.upper(),
+        country=country_from_ticker(proposed.ticker),
+        source="proposed",
+        notional_account=quote_to_account(
+            Decimal(proposed.quantity) * proposed.entry,
+            proposed.account_currency,
+            proposed.quote_currency,
+            proposed.account_to_quote_rate,
+        ),
+        price_risk_account=quote_to_account(
+            Decimal(proposed.quantity)
+            * max(Decimal("0"), proposed.entry - proposed.stop),
+            proposed.account_currency,
+            proposed.quote_currency,
+            proposed.account_to_quote_rate,
+        ),
+    )
+    current_notional = sum((line.notional_account for line in lines), Decimal("0"))
+    current_risk = sum((line.price_risk_account for line in lines), Decimal("0"))
+    lines.append(proposed_line)
+    return ExposureSnapshot(
+        lines=tuple(lines),
+        current_notional=current_notional,
+        current_risk=current_risk,
+        projected_notional=current_notional + proposed_line.notional_account,
+        projected_price_risk=current_risk + proposed_line.price_risk_account,
+    )

--- a/api/services/order_exposure.py
+++ b/api/services/order_exposure.py
@@ -55,6 +55,9 @@ def country_from_ticker(ticker: str) -> str:
         "ST": "SE",
         "CO": "DK",
         "OL": "NO",
+        "BR": "BE",
+        "LS": "PT",
+        "HE": "FI",
     }.get(suffix, "US")
 
 
@@ -100,6 +103,12 @@ def _line(
     account_currency: str,
 ) -> ExposureLine:
     ticker = str(row.get("ticker") or "").upper()
+    persisted_account = str(row.get("account_currency") or "").upper()
+    if persisted_account and persisted_account != account_currency.upper():
+        raise ExposureContextError(
+            "ACCOUNT_CURRENCY_MISMATCH: "
+            f"{ticker} was approved in {persisted_account}, not {account_currency.upper()}"
+        )
     quantity_field = "shares" if source == "position" else "quantity"
     entry_field = "entry_price" if source == "position" else "limit_price"
     quantity = _decimal(row.get(quantity_field), quantity_field)

--- a/api/services/orders_service.py
+++ b/api/services/orders_service.py
@@ -1,10 +1,13 @@
 """Orders service - local order lifecycle management."""
+
 from __future__ import annotations
 
 import uuid
 import logging
 import math
-from typing import Optional
+import time
+from decimal import Decimal
+from typing import Callable, Optional
 
 from swing_screener.errors import (
     NotFoundError,
@@ -25,6 +28,21 @@ from api.repositories.strategy_repo import StrategyRepository
 from api.repositories.orders_repo import OrdersRepository
 from api.repositories.positions_repo import PositionsRepository
 from api.utils.files import get_today_str
+from api.services.order_approval import (
+    EffectiveOrderPolicy,
+    SubmittedPlan,
+    evaluate_order_approval,
+)
+from api.services.order_approval_token import (
+    ApprovalTokenError,
+    OrderApprovalTokenSigner,
+    VerifiedApprovalToken,
+)
+from api.services.order_exposure import (
+    ExposureContextError,
+    ProposedExposure,
+    build_exposure_snapshot,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -40,63 +58,196 @@ class OrdersService:
         positions_repo: PositionsRepository,
         config_repo: ConfigRepository | None = None,
         strategy_repo: StrategyRepository | None = None,
+        approval_signer: OrderApprovalTokenSigner | None = None,
+        approval_now: Callable[[], int] | None = None,
     ) -> None:
         self._orders_repo = orders_repo
         self._positions_repo = positions_repo
         self._config_repo = config_repo
         self._strategy_repo = strategy_repo
+        self._approval_signer = approval_signer
+        self._approval_now = approval_now or (lambda: int(time.time()))
 
     @staticmethod
     def _country(ticker: str) -> str:
         suffix = ticker.upper().rsplit(".", 1)[-1] if "." in ticker else "US"
         return {
-            "AS": "NL", "DE": "DE", "PA": "FR", "MI": "IT", "MC": "ES",
-            "L": "UK", "SW": "CH", "ST": "SE", "CO": "DK", "OL": "NO",
+            "AS": "NL",
+            "DE": "DE",
+            "PA": "FR",
+            "MI": "IT",
+            "MC": "ES",
+            "L": "UK",
+            "SW": "CH",
+            "ST": "SE",
+            "CO": "DK",
+            "OL": "NO",
         }.get(suffix, "US")
 
     def _risk_policy(self) -> dict:
-        strategy = self._strategy_repo.get_active_strategy() if self._strategy_repo else {}
+        strategy = (
+            self._strategy_repo.get_active_strategy() if self._strategy_repo else {}
+        )
         risk = dict(strategy.get("risk") or {})
         if self._config_repo is not None:
             configured = self._config_repo.get().risk
             risk.setdefault("account_size", configured.account_size)
             risk.setdefault("risk_pct", configured.risk_pct)
+            risk.setdefault("max_position_pct", configured.max_position_pct)
+            risk.setdefault("max_fee_risk_pct", configured.max_fee_risk_pct)
+            risk.setdefault("max_portfolio_heat_pct", configured.max_portfolio_heat_pct)
             risk.setdefault("max_concentration_pct", configured.max_concentration_pct)
+            risk.setdefault("account_currency", configured.account_currency)
         risk.setdefault("account_size", 0.0)
         risk.setdefault("risk_pct", 0.01)
         risk.setdefault("min_rr", 2.0)
+        risk.setdefault("max_position_pct", 0.60)
+        risk.setdefault("commission_pct", 0.0)
+        risk.setdefault("max_fee_risk_pct", 0.20)
         risk.setdefault("max_portfolio_heat_pct", 0.06)
         risk.setdefault("max_concentration_pct", 60.0)
+        risk.setdefault("account_currency", "EUR")
         return risk
+
+    def _approve_signed_entry_order(
+        self, request: CreateOrderRequest, orders: list[dict], positions: list[dict]
+    ) -> tuple[PortfolioOrderApproval, VerifiedApprovalToken]:
+        if not request.approval_token:
+            raise UnprocessableError("Order blocked: approval token is required.")
+        assert self._approval_signer is not None
+        try:
+            context = self._approval_signer.verify(
+                request.approval_token, now=self._approval_now()
+            )
+        except ApprovalTokenError as exc:
+            raise UnprocessableError(f"Order blocked: {exc}.") from exc
+        ticker = request.ticker.upper()
+        if context.ticker != ticker:
+            raise UnprocessableError("Order blocked: approval token ticker mismatch.")
+        if context.order_type != request.order_type.upper():
+            raise UnprocessableError(
+                "Order blocked: approval token order type mismatch."
+            )
+
+        strategy = (
+            self._strategy_repo.get_active_strategy() if self._strategy_repo else {}
+        )
+        active_strategy_id = str(strategy.get("id") or "")
+        if not active_strategy_id and self._strategy_repo is not None:
+            getter = getattr(self._strategy_repo, "get_active_strategy_id", None)
+            if callable(getter):
+                active_strategy_id = str(getter())
+        if not active_strategy_id or context.strategy_id != active_strategy_id:
+            raise UnprocessableError("Order blocked: approval token strategy is stale.")
+
+        entry = Decimal(str(self._entry_price(request)))
+        if request.stop_price is None or request.target_price is None:
+            raise UnprocessableError(
+                "Order blocked: entry, stop, and target are required."
+            )
+        stop = Decimal(str(request.stop_price))
+        target = Decimal(str(request.target_price))
+        rate = (
+            Decimal("1")
+            if context.account_currency == context.quote_currency
+            else Decimal(str(context.account_to_quote_rate))
+        )
+        proposed = ProposedExposure(
+            ticker=ticker,
+            quantity=request.quantity,
+            entry=entry,
+            stop=stop,
+            account_currency=context.account_currency,
+            quote_currency=context.quote_currency,
+            account_to_quote_rate=rate,
+        )
+        try:
+            snapshot = build_exposure_snapshot(positions, orders, proposed)
+        except ExposureContextError as exc:
+            raise UnprocessableError(f"Order blocked: {exc}") from exc
+
+        raw = self._risk_policy()
+        policy = EffectiveOrderPolicy(
+            account_size=Decimal(str(raw["account_size"])),
+            risk_pct=Decimal(str(raw["risk_pct"])),
+            max_position_pct=Decimal(str(raw["max_position_pct"])),
+            max_portfolio_heat_pct=Decimal(str(raw["max_portfolio_heat_pct"])),
+            min_rr=Decimal(str(raw["min_rr"])),
+            commission_pct=Decimal(str(raw["commission_pct"])),
+            max_fee_risk_pct=Decimal(str(raw["max_fee_risk_pct"])),
+            max_concentration_pct=Decimal(str(raw["max_concentration_pct"])),
+            account_currency=context.account_currency,
+        )
+        approval = evaluate_order_approval(
+            context,
+            SubmittedPlan(ticker, request.quantity, entry, stop, target),
+            snapshot,
+            policy,
+        )
+        if not approval.approved:
+            gate_names = (
+                "decision",
+                "coherence",
+                "reward_risk",
+                "trade_risk",
+                "position",
+                "cash",
+                "heat",
+                "fees",
+                "event",
+                "fx",
+            )
+            blockers = [
+                name
+                for name in gate_names
+                if getattr(approval, name) is not None
+                and getattr(approval, name).status == "BLOCK"
+            ]
+            raise UnprocessableError(
+                "Order blocked by portfolio approval: " + ", ".join(blockers)
+            )
+        return approval, context
 
     @staticmethod
     def _entry_price(request: CreateOrderRequest) -> float:
         price = request.limit_price
         if price is None or not math.isfinite(price) or price <= 0:
-            raise UnprocessableError("A finite planned entry price is required for portfolio approval.")
+            raise UnprocessableError(
+                "A finite planned entry price is required for portfolio approval."
+            )
         return float(price)
 
     def _approve_entry_order(
         self, request: CreateOrderRequest, orders: list[dict], positions: list[dict]
     ) -> PortfolioOrderApproval:
         if request.setup_status != "PASS" or request.trigger_status != "PASS":
-            raise UnprocessableError("Order blocked: setup and observed entry-trigger gates must both pass.")
+            raise UnprocessableError(
+                "Order blocked: setup and observed entry-trigger gates must both pass."
+            )
         if request.data_status != "current" or not request.data_asof:
-            raise UnprocessableError("Order blocked: critical market data is stale, intraday, or unknown.")
+            raise UnprocessableError(
+                "Order blocked: critical market data is stale, intraday, or unknown."
+            )
         if request.target_source not in {"structural", "manual"}:
-            raise UnprocessableError("Order blocked: target is not independently validated.")
+            raise UnprocessableError(
+                "Order blocked: target is not independently validated."
+            )
 
         entry = self._entry_price(request)
         stop = request.stop_price
         target = request.target_price
         if stop is None or target is None or stop >= entry or target <= entry:
-            raise UnprocessableError("Order blocked: entry, stop, and target do not form a coherent long plan.")
+            raise UnprocessableError(
+                "Order blocked: entry, stop, and target do not form a coherent long plan."
+            )
 
         policy = self._risk_policy()
         min_rr = float(policy["min_rr"])
         rr = (target - entry) / (entry - stop)
         if rr < min_rr:
-            raise UnprocessableError(f"Order blocked: structural reward/risk {rr:.2f} is below {min_rr:.2f}.")
+            raise UnprocessableError(
+                f"Order blocked: structural reward/risk {rr:.2f} is below {min_rr:.2f}."
+            )
 
         rate = request.account_to_quote_rate or 1.0
         notional = request.quantity * entry / rate
@@ -105,21 +256,29 @@ class OrdersService:
 
         position_notional = sum(
             float(p.get("entry_price") or 0) * int(p.get("shares") or 0)
-            for p in positions if p.get("status") == "open"
+            for p in positions
+            if p.get("status") == "open"
         )
         position_risk = sum(
             max(0.0, float(p.get("entry_price") or 0) - float(p.get("stop_price") or 0))
             * int(p.get("shares") or 0)
-            for p in positions if p.get("status") == "open"
+            for p in positions
+            if p.get("status") == "open"
         )
         pending = [
-            order for order in orders
-            if order.get("status") in {"pending", "submitted"} and order.get("order_kind") == "entry"
+            order
+            for order in orders
+            if order.get("status") in {"pending", "submitted"}
+            and order.get("order_kind") == "entry"
         ]
-        pending_notional = sum(float(o.get("limit_price") or 0) * int(o.get("quantity") or 0) for o in pending)
+        pending_notional = sum(
+            float(o.get("limit_price") or 0) * int(o.get("quantity") or 0)
+            for o in pending
+        )
         pending_risk = sum(
             max(0.0, float(o.get("limit_price") or 0) - float(o.get("stop_price") or 0))
-            * int(o.get("quantity") or 0) for o in pending
+            * int(o.get("quantity") or 0)
+            for o in pending
         )
 
         available = account_size - position_notional - pending_notional
@@ -132,34 +291,51 @@ class OrdersService:
         country_notional = sum(
             float(p.get("entry_price") or 0) * int(p.get("shares") or 0)
             for p in positions
-            if p.get("status") == "open" and self._country(str(p.get("ticker") or "")) == country
+            if p.get("status") == "open"
+            and self._country(str(p.get("ticker") or "")) == country
         ) + sum(
             float(o.get("limit_price") or 0) * int(o.get("quantity") or 0)
-            for o in pending if self._country(str(o.get("ticker") or "")) == country
+            for o in pending
+            if self._country(str(o.get("ticker") or "")) == country
         )
         projected_concentration = (
-            (country_notional + notional) / account_size * 100.0 if account_size > 0 else 100.0
+            (country_notional + notional) / account_size * 100.0
+            if account_size > 0
+            else 100.0
         )
         concentration_limit = float(policy["max_concentration_pct"])
         concentration_pass = projected_concentration <= concentration_limit + 1e-9
 
-        event_pass = request.days_to_earnings is not None and request.days_to_earnings > 3
+        event_pass = (
+            request.days_to_earnings is not None and request.days_to_earnings > 3
+        )
         approval = PortfolioOrderApproval(
             approved=cash_pass and heat_pass and concentration_pass and event_pass,
             cash=PortfolioApprovalGate(
                 status="PASS" if cash_pass else "BLOCK",
-                explanation="Sufficient unreserved capital." if cash_pass else "Insufficient capital after open and pending exposure.",
-                current=round(available, 2), projected=round(available - notional, 2), limit=0.0,
+                explanation="Sufficient unreserved capital."
+                if cash_pass
+                else "Insufficient capital after open and pending exposure.",
+                current=round(available, 2),
+                projected=round(available - notional, 2),
+                limit=0.0,
             ),
             heat=PortfolioApprovalGate(
                 status="PASS" if heat_pass else "BLOCK",
-                explanation="Projected portfolio heat is within policy." if heat_pass else "Projected portfolio heat exceeds policy.",
-                current=round(position_risk + pending_risk, 2), projected=round(projected_heat, 2), limit=round(heat_limit, 2),
+                explanation="Projected portfolio heat is within policy."
+                if heat_pass
+                else "Projected portfolio heat exceeds policy.",
+                current=round(position_risk + pending_risk, 2),
+                projected=round(projected_heat, 2),
+                limit=round(heat_limit, 2),
             ),
             concentration=PortfolioApprovalGate(
                 status="PASS" if concentration_pass else "BLOCK",
-                explanation=f"Projected {country} risk concentration is within policy." if concentration_pass else f"Projected {country} risk concentration exceeds policy.",
-                projected=round(projected_concentration, 2), limit=round(concentration_limit, 2),
+                explanation=f"Projected {country} risk concentration is within policy."
+                if concentration_pass
+                else f"Projected {country} risk concentration exceeds policy.",
+                projected=round(projected_concentration, 2),
+                limit=round(concentration_limit, 2),
             ),
             event=PortfolioApprovalGate(
                 status="PASS" if event_pass else "BLOCK",
@@ -176,12 +352,18 @@ class OrdersService:
         )
         if not approval.approved:
             blockers = [
-                name for name, gate in (
-                    ("cash", approval.cash), ("heat", approval.heat),
-                    ("concentration", approval.concentration), ("event", approval.event),
-                ) if gate.status == "BLOCK"
+                name
+                for name, gate in (
+                    ("cash", approval.cash),
+                    ("heat", approval.heat),
+                    ("concentration", approval.concentration),
+                    ("event", approval.event),
+                )
+                if gate.status == "BLOCK"
             ]
-            raise UnprocessableError("Order blocked by portfolio approval: " + ", ".join(blockers))
+            raise UnprocessableError(
+                "Order blocked by portfolio approval: " + ", ".join(blockers)
+            )
         return approval
 
     def create_order(self, request: CreateOrderRequest) -> dict:
@@ -199,18 +381,29 @@ class OrdersService:
                 raise ConflictError(f"{ticker}: pending entry order already exists.")
 
             positions, _ = self._positions_repo.list_positions(status="open")
-            open_position = next((p for p in positions if p.get("ticker") == ticker), None)
+            open_position = next(
+                (p for p in positions if p.get("ticker") == ticker), None
+            )
 
             if request.entry_mode == "ADD_ON":
                 if not open_position:
-                    raise ConflictError(f"{ticker}: no open position found for add-on order.")
+                    raise ConflictError(
+                        f"{ticker}: no open position found for add-on order."
+                    )
             elif open_position:
                 raise ConflictError(
                     f"{ticker}: open position already exists. Create this as an ADD_ON order instead.",
                 )
-            approval = self._approve_entry_order(request, orders, positions)
+            if self._approval_signer is not None:
+                approval, verified_context = self._approve_signed_entry_order(
+                    request, orders, positions
+                )
+            else:
+                approval = self._approve_entry_order(request, orders, positions)
+                verified_context = None
         else:
             approval = None
+            verified_context = None
 
         existing_ids = {o.get("order_id", "") for o in orders}
         base = f"ORD-{ticker}"
@@ -236,13 +429,26 @@ class OrdersService:
             "notes": request.notes.strip(),
             "order_kind": request.order_kind,
             "parent_order_id": None,
-            "position_id": request.position_id if request.entry_mode == "ADD_ON" else None,
+            "position_id": request.position_id
+            if request.entry_mode == "ADD_ON"
+            else None,
             "tif": "GTC",
             "fee_eur": None,
             "fill_fx_rate": None,
             "isin": isin,
             "thesis": request.thesis,
-            "decision_context": {
+            "quote_currency": verified_context.quote_currency
+            if verified_context
+            else request.currency,
+            "account_currency": verified_context.account_currency
+            if verified_context
+            else None,
+            "approval_fx_rate": verified_context.account_to_quote_rate
+            if verified_context
+            else request.account_to_quote_rate,
+            "decision_context": verified_context.model_dump(mode="json")
+            if verified_context
+            else {
                 "setup_status": request.setup_status,
                 "trigger_status": request.trigger_status,
                 "data_status": request.data_status,
@@ -250,7 +456,9 @@ class OrdersService:
                 "target_source": request.target_source,
                 "strategy_id": request.strategy_id,
             },
-            "portfolio_approval": approval.model_dump(mode="json") if approval else None,
+            "portfolio_approval": approval.model_dump(mode="json")
+            if approval
+            else None,
         }
         self._orders_repo.append_order(order)
         return order
@@ -283,7 +491,11 @@ class OrdersService:
             raise ConflictError(f"Order {order_id} is already {order.get('status')}")
 
         ticker = order["ticker"]
-        stop_price = request.stop_price if request.stop_price is not None else order.get("stop_price")
+        stop_price = (
+            request.stop_price
+            if request.stop_price is not None
+            else order.get("stop_price")
+        )
         if not stop_price or stop_price <= 0:
             raise UnprocessableError(f"No valid stop price for order {order_id}")
         if stop_price >= request.filled_price:
@@ -325,19 +537,23 @@ class OrdersService:
                         new_entry = old_entry
                         if new_shares > 0:
                             new_entry = (
-                                (old_entry * old_shares + request.filled_price * add_shares)
-                                / new_shares
-                            )
+                                old_entry * old_shares
+                                + request.filled_price * add_shares
+                            ) / new_shares
                         if existing_stop >= new_entry:
                             raise UnprocessableError(
                                 "existing stop_price must be below blended entry_price"
                             )
                         pos["entry_price"] = round(new_entry, 6)
                         pos["shares"] = new_shares
-                        pos["initial_risk"] = round(pos["entry_price"] - existing_stop, 4)
+                        pos["initial_risk"] = round(
+                            pos["entry_price"] - existing_stop, 4
+                        )
                         if request.fee_eur is not None:
                             prior_fee = pos.get("entry_fee_eur") or 0.0
-                            pos["entry_fee_eur"] = float(prior_fee) + float(request.fee_eur)
+                            pos["entry_fee_eur"] = float(prior_fee) + float(
+                                request.fee_eur
+                            )
                         data["asof"] = get_today_str()
                         merged["position"] = dict(pos)
                         return data
@@ -346,7 +562,9 @@ class OrdersService:
                 )
 
             self._positions_repo.update(_merge)
-            return FillOrderResponse(order_id=order_id, position=Position(**merged["position"]))
+            return FillOrderResponse(
+                order_id=order_id, position=Position(**merged["position"])
+            )
 
         isin = order.get("isin") or _resolve_isin(ticker)
         position_id = f"POS-{uuid.uuid4().hex[:8].upper()}"
@@ -367,7 +585,9 @@ class OrdersService:
             "thesis": order.get("thesis"),
             "notes": order.get("notes", ""),
             "entry_fee_eur": request.fee_eur,
-            "entry_fx_rate": request.fill_fx_rate,
+            "entry_fx_rate": request.fill_fx_rate or order.get("approval_fx_rate"),
+            "quote_currency": order.get("quote_currency"),
+            "account_currency": order.get("account_currency"),
         }
 
         def _append(data: dict) -> dict:

--- a/api/services/orders_service.py
+++ b/api/services/orders_service.py
@@ -37,6 +37,7 @@ from api.services.order_approval_token import (
     ApprovalTokenError,
     OrderApprovalTokenSigner,
     VerifiedApprovalToken,
+    strategy_revision,
 )
 from api.services.order_exposure import (
     ExposureContextError,
@@ -137,7 +138,12 @@ class OrdersService:
             getter = getattr(self._strategy_repo, "get_active_strategy_id", None)
             if callable(getter):
                 active_strategy_id = str(getter())
-        if not active_strategy_id or context.strategy_id != active_strategy_id:
+        active_strategy_revision = strategy_revision(strategy)
+        if (
+            not active_strategy_id
+            or context.strategy_id != active_strategy_id
+            or context.strategy_revision != active_strategy_revision
+        ):
             raise UnprocessableError("Order blocked: approval token strategy is stale.")
 
         entry = Decimal(str(self._entry_price(request)))
@@ -394,13 +400,13 @@ class OrdersService:
                 raise ConflictError(
                     f"{ticker}: open position already exists. Create this as an ADD_ON order instead.",
                 )
-            if self._approval_signer is not None:
-                approval, verified_context = self._approve_signed_entry_order(
-                    request, orders, positions
+            if self._approval_signer is None:
+                raise UnprocessableError(
+                    "Order blocked: approval token signer is not configured."
                 )
-            else:
-                approval = self._approve_entry_order(request, orders, positions)
-                verified_context = None
+            approval, verified_context = self._approve_signed_entry_order(
+                request, orders, positions
+            )
         else:
             approval = None
             verified_context = None
@@ -529,6 +535,31 @@ class OrdersService:
                         old_shares = int(pos.get("shares", 0))
                         old_entry = float(pos.get("entry_price", 0.0))
                         new_shares = old_shares + add_shares
+                        position_quote = str(pos.get("quote_currency") or "").upper()
+                        position_account = str(
+                            pos.get("account_currency") or ""
+                        ).upper()
+                        order_quote = str(order.get("quote_currency") or "").upper()
+                        order_account = str(order.get("account_currency") or "").upper()
+                        if (
+                            not position_quote
+                            or not position_account
+                            or position_quote != order_quote
+                            or position_account != order_account
+                        ):
+                            raise UnprocessableError(
+                                "Add-on currency context does not match the open position."
+                            )
+                        old_rate = float(pos.get("entry_fx_rate") or 0.0)
+                        new_rate = float(
+                            request.fill_fx_rate or order.get("approval_fx_rate") or 0.0
+                        )
+                        if position_quote == position_account:
+                            old_rate = new_rate = 1.0
+                        if old_rate <= 0 or new_rate <= 0:
+                            raise UnprocessableError(
+                                "Add-on FX context must contain positive persisted rates."
+                            )
                         existing_stop = float(pos.get("stop_price", 0.0))
                         if existing_stop <= 0:
                             raise UnprocessableError(
@@ -546,6 +577,18 @@ class OrdersService:
                             )
                         pos["entry_price"] = round(new_entry, 6)
                         pos["shares"] = new_shares
+                        combined_quote_cost = (
+                            old_entry * old_shares + request.filled_price * add_shares
+                        )
+                        combined_account_cost = (
+                            old_entry * old_shares / old_rate
+                            + request.filled_price * add_shares / new_rate
+                        )
+                        pos["entry_fx_rate"] = (
+                            combined_quote_cost / combined_account_cost
+                        )
+                        pos["quote_currency"] = position_quote
+                        pos["account_currency"] = position_account
                         pos["initial_risk"] = round(
                             pos["entry_price"] - existing_stop, 4
                         )

--- a/api/services/portfolio/write.py
+++ b/api/services/portfolio/write.py
@@ -1,4 +1,5 @@
 """Write-model: create/close/update positions."""
+
 from __future__ import annotations
 
 import logging
@@ -9,6 +10,7 @@ from typing import Optional
 import pandas as pd
 
 from swing_screener.errors import NotFoundError, ValidationError
+from swing_screener.data.currency import detect_currency
 from swing_screener.data.providers import MarketDataProvider, get_default_provider
 
 from api.models.portfolio import (
@@ -20,6 +22,7 @@ from api.models.portfolio import (
     UpdateTrailMethodRequest,
 )
 from api.repositories.positions_repo import PositionsRepository
+from api.repositories.config_repo import ConfigRepository
 from api.utils.files import get_today_str
 
 logger = logging.getLogger(__name__)
@@ -36,9 +39,11 @@ class PortfolioWriteService:
         self,
         positions_repo: PositionsRepository,
         provider: Optional[MarketDataProvider] = None,
+        config_repo: Optional[ConfigRepository] = None,
     ) -> None:
         self._positions_repo = positions_repo
         self._provider = provider or get_default_provider()
+        self._config_repo = config_repo or ConfigRepository()
 
     def create_position(self, request: CreatePositionRequest) -> Position:
         """Register a position directly (after manual fill at DeGiro)."""
@@ -46,6 +51,19 @@ class PortfolioWriteService:
         position_id = f"POS-{uuid.uuid4().hex[:8].upper()}"
         initial_risk = round(request.entry_price - request.stop_price, 4)
         isin = request.isin
+        quote_currency = str(
+            request.quote_currency or detect_currency(ticker) or "UNKNOWN"
+        ).upper()
+        account_currency = str(
+            request.account_currency or self._config_repo.get().risk.account_currency
+        ).upper()
+        entry_fx_rate = request.entry_fx_rate
+        if quote_currency == account_currency:
+            entry_fx_rate = 1.0
+        elif entry_fx_rate is None:
+            raise ValidationError(
+                f"FX rate is required for {quote_currency}/{account_currency} positions"
+            )
 
         new_position: dict = {
             "position_id": position_id,
@@ -62,6 +80,9 @@ class PortfolioWriteService:
             "notes": request.notes,
             "broker": "manual",
             "entry_fee_eur": request.fee_eur,
+            "quote_currency": quote_currency,
+            "account_currency": account_currency,
+            "entry_fx_rate": entry_fx_rate,
         }
 
         def _modify(data: dict) -> dict:
@@ -75,7 +96,9 @@ class PortfolioWriteService:
 
         return Position(**new_position)
 
-    def update_position_stop(self, position_id: str, request: UpdateStopRequest) -> dict:
+    def update_position_stop(
+        self, position_id: str, request: UpdateStopRequest
+    ) -> dict:
         new_stop = _round_price(request.new_stop)
 
         # Validate against a snapshot first (the price fetch is network I/O and must
@@ -96,8 +119,12 @@ class PortfolioWriteService:
         current_price = None
         try:
             end_date = get_today_str()
-            start_date = (pd.Timestamp(end_date) - pd.Timedelta(days=5)).strftime("%Y-%m-%d")
-            ohlcv = self._provider.fetch_ohlcv([ticker], start_date=start_date, end_date=end_date)
+            start_date = (pd.Timestamp(end_date) - pd.Timedelta(days=5)).strftime(
+                "%Y-%m-%d"
+            )
+            ohlcv = self._provider.fetch_ohlcv(
+                [ticker], start_date=start_date, end_date=end_date
+            )
             if not ohlcv.empty and ticker in ohlcv.columns.get_level_values(1):
                 latest_close = ohlcv[("Close", ticker)].iloc[-1]
                 if not pd.isna(latest_close):
@@ -119,7 +146,9 @@ class PortfolioWriteService:
                     pos["stop_price"] = new_stop
                     if request.reason:
                         current_notes = pos.get("notes", "")
-                        pos["notes"] = f"{current_notes}\nStop updated to {new_stop}: {request.reason}".strip()
+                        pos["notes"] = (
+                            f"{current_notes}\nStop updated to {new_stop}: {request.reason}".strip()
+                        )
                     data["asof"] = get_today_str()
                     return data
             raise NotFoundError(f"Position not found: {position_id}")
@@ -147,7 +176,9 @@ class PortfolioWriteService:
                     pos["exit_fx_rate"] = request.exit_fx_rate
                     if request.reason:
                         current_notes = pos.get("notes", "")
-                        pos["notes"] = f"{current_notes}\nClosed: {request.reason}".strip()
+                        pos["notes"] = (
+                            f"{current_notes}\nClosed: {request.reason}".strip()
+                        )
                     if request.lesson is not None:
                         pos["lesson"] = request.lesson
                     pos["tags"] = list(request.tags)
@@ -165,7 +196,9 @@ class PortfolioWriteService:
             "exit_fx_rate": request.exit_fx_rate,
         }
 
-    def partial_close_position(self, position_id: str, request: PartialCloseRequest) -> dict:
+    def partial_close_position(
+        self, position_id: str, request: PartialCloseRequest
+    ) -> dict:
         """Close a subset of shares on an open position, recording a partial-close event."""
         result: dict = {}
 
@@ -189,7 +222,11 @@ class PortfolioWriteService:
                     per_share_risk = float(initial_risk)
                 else:
                     per_share_risk = entry_price - float(pos.get("stop_price", 0.0))
-                r_at_close = (request.price - entry_price) / per_share_risk if per_share_risk != 0 else 0.0
+                r_at_close = (
+                    (request.price - entry_price) / per_share_risk
+                    if per_share_risk != 0
+                    else 0.0
+                )
 
                 event = {
                     "date": get_today_str(),
@@ -223,7 +260,9 @@ class PortfolioWriteService:
             "fx_rate": request.fx_rate,
         }
 
-    def update_trail_method(self, position_id: str, request: UpdateTrailMethodRequest) -> dict:
+    def update_trail_method(
+        self, position_id: str, request: UpdateTrailMethodRequest
+    ) -> dict:
         def _modify(data: dict) -> dict:
             for pos in data.get("positions", []):
                 if pos.get("position_id") == position_id:

--- a/api/services/portfolio_service.py
+++ b/api/services/portfolio_service.py
@@ -1,4 +1,5 @@
 """Portfolio service - positions and local order management."""
+
 from __future__ import annotations
 
 from typing import Optional
@@ -45,11 +46,19 @@ class PortfolioService:
         self._config_repo = config_repo or ConfigRepository()
 
         self._pricing = PositionPricingService(self._provider)
-        self._read = PortfolioReadService(self._positions_repo, self._pricing, self._config_repo)
-        self._write = PortfolioWriteService(self._positions_repo, self._provider)
-        self._advisor = PositionStopAdvisor(self._positions_repo, self._provider, self._config_repo)
+        self._read = PortfolioReadService(
+            self._positions_repo, self._pricing, self._config_repo
+        )
+        self._write = PortfolioWriteService(
+            self._positions_repo, self._provider, self._config_repo
+        )
+        self._advisor = PositionStopAdvisor(
+            self._positions_repo, self._provider, self._config_repo
+        )
 
-    def fetch_recent_ohlcv(self, ticker: str, *, lookback_days: int = 400) -> pd.DataFrame:
+    def fetch_recent_ohlcv(
+        self, ticker: str, *, lookback_days: int = 400
+    ) -> pd.DataFrame:
         return self._pricing.fetch_recent_ohlcv(ticker, lookback_days=lookback_days)
 
     def list_positions(
@@ -59,7 +68,11 @@ class PortfolioService:
         time_stop_days: int | None = None,
         time_stop_min_r: float | None = None,
     ) -> PositionsWithMetricsResponse:
-        return self._read.list_positions(status=status, time_stop_days=time_stop_days, time_stop_min_r=time_stop_min_r)
+        return self._read.list_positions(
+            status=status,
+            time_stop_days=time_stop_days,
+            time_stop_min_r=time_stop_min_r,
+        )
 
     def get_position(self, position_id: str) -> Position:
         return self._read.get_position(position_id)
@@ -67,7 +80,9 @@ class PortfolioService:
     def get_position_metrics(self, position_id: str) -> PositionMetrics:
         return self._read.get_position_metrics(position_id)
 
-    def get_portfolio_summary(self, account_size: float, account_size_mode: str = "equity") -> PortfolioSummary:
+    def get_portfolio_summary(
+        self, account_size: float, account_size_mode: str = "equity"
+    ) -> PortfolioSummary:
         return self._read.get_portfolio_summary(account_size, account_size_mode)
 
     def get_earnings_proximity(self, ticker: str) -> EarningsProximityResponse:
@@ -76,16 +91,22 @@ class PortfolioService:
     def create_position(self, request: CreatePositionRequest) -> Position:
         return self._write.create_position(request)
 
-    def update_position_stop(self, position_id: str, request: UpdateStopRequest) -> dict:
+    def update_position_stop(
+        self, position_id: str, request: UpdateStopRequest
+    ) -> dict:
         return self._write.update_position_stop(position_id, request)
 
     def close_position(self, position_id: str, request: ClosePositionRequest) -> dict:
         return self._write.close_position(position_id, request)
 
-    def partial_close_position(self, position_id: str, request: PartialCloseRequest) -> dict:
+    def partial_close_position(
+        self, position_id: str, request: PartialCloseRequest
+    ) -> dict:
         return self._write.partial_close_position(position_id, request)
 
-    def update_trail_method(self, position_id: str, request: UpdateTrailMethodRequest) -> dict:
+    def update_trail_method(
+        self, position_id: str, request: UpdateTrailMethodRequest
+    ) -> dict:
         return self._write.update_trail_method(position_id, request)
 
     def compute_position_stop_suggestion(
@@ -93,7 +114,9 @@ class PortfolioService:
         position_payload: dict,
         manage_payload: Optional[dict] = None,
     ) -> PositionUpdate:
-        return self._advisor.compute_position_stop_suggestion(position_payload, manage_payload)
+        return self._advisor.compute_position_stop_suggestion(
+            position_payload, manage_payload
+        )
 
     def suggest_position_stop(self, position_id: str) -> PositionUpdate:
         return self._advisor.suggest_position_stop(position_id)

--- a/api/services/screener_service.py
+++ b/api/services/screener_service.py
@@ -32,6 +32,7 @@ from api.services.portfolio_service import PortfolioService
 from api.services.order_approval_token import (
     ApprovalTokenClaims,
     OrderApprovalTokenSigner,
+    strategy_revision,
 )
 from api.services.same_symbol_reentry import SameSymbolReentryEvaluator
 from swing_screener.risk.engine import RiskEngineConfig, evaluate_recommendation
@@ -179,7 +180,7 @@ def _account_currency_from_strategy(strategy: dict) -> str:
 
 
 def _approval_claims_for_candidate(
-    candidate: object, strategy_id: str
+    candidate: object, strategy_id: str, strategy_revision_value: str
 ) -> ApprovalTokenClaims | None:
     recommendation = getattr(candidate, "recommendation", None)
     if (
@@ -243,6 +244,7 @@ def _approval_claims_for_candidate(
         data_status="current",
         data_asof=data_asof,
         strategy_id=strategy_id,
+        strategy_revision=strategy_revision_value,
         account_currency=account_currency,
         quote_currency=quote_currency,
         account_to_quote_rate=float(values[3]),
@@ -1454,9 +1456,12 @@ class ScreenerService:
                     or request.strategy_id
                     or self._strategy_repo.get_active_strategy_id()
                 )
+                active_strategy_revision = strategy_revision(ctx.strategy)
                 signed_candidates: list[ScreenerCandidate] = []
                 for candidate in candidates:
-                    claims = _approval_claims_for_candidate(candidate, strategy_id)
+                    claims = _approval_claims_for_candidate(
+                        candidate, strategy_id, active_strategy_revision
+                    )
                     token = self._approval_signer.issue(claims) if claims else None
                     signed_candidates.append(
                         candidate.model_copy(update={"approval_token": token})

--- a/api/services/screener_service.py
+++ b/api/services/screener_service.py
@@ -29,6 +29,10 @@ from api.models.screener import (
 )
 from api.models.recommendation import Recommendation
 from api.services.portfolio_service import PortfolioService
+from api.services.order_approval_token import (
+    ApprovalTokenClaims,
+    OrderApprovalTokenSigner,
+)
 from api.services.same_symbol_reentry import SameSymbolReentryEvaluator
 from swing_screener.risk.engine import RiskEngineConfig, evaluate_recommendation
 from swing_screener.indicators.candles import detect_patterns, CandleConfig
@@ -72,7 +76,6 @@ from swing_screener.utils.coerce import (
     is_na_scalar,
     safe_float,
     safe_optional_float,
-    safe_optional_int,
 )
 from api.services.decision_context import (
     apply_cached_fundamentals_context,
@@ -175,7 +178,85 @@ def _account_currency_from_strategy(strategy: dict) -> str:
     return str(raw_risk.get("account_currency") or "EUR").upper()
 
 
-def _normalize_quote_currency_value(*values: object, fallback_ticker: str | None = None) -> str:
+def _approval_claims_for_candidate(
+    candidate: object, strategy_id: str
+) -> ApprovalTokenClaims | None:
+    recommendation = getattr(candidate, "recommendation", None)
+    if (
+        recommendation is None
+        or getattr(recommendation, "verdict", None) != "RECOMMENDED"
+    ):
+        return None
+    gates = getattr(recommendation, "decision_gates", None)
+    if gates is None or any(
+        getattr(getattr(gates, name, None), "status", None) != "PASS"
+        for name in ("setup", "trigger", "plan")
+    ):
+        return None
+    data_asof = getattr(candidate, "data_asof", None)
+    days_to_earnings = getattr(candidate, "days_to_earnings", None)
+    if (
+        getattr(candidate, "data_status", None) != "current"
+        or not isinstance(data_asof, str)
+        or not data_asof
+        or not isinstance(days_to_earnings, int)
+        or days_to_earnings <= 3
+        or not strategy_id
+    ):
+        return None
+    risk = getattr(recommendation, "risk", None)
+    if risk is None:
+        return None
+    target_source = str(getattr(risk, "target_source", ""))
+    account_currency = str(getattr(risk, "account_currency", "") or "").upper()
+    quote_currency = str(getattr(risk, "currency", "") or "").upper()
+    account_to_quote_rate = getattr(risk, "account_to_quote_rate", None)
+    if account_currency == quote_currency:
+        account_to_quote_rate = 1.0
+    values = (
+        getattr(risk, "entry", None),
+        getattr(risk, "stop", None),
+        getattr(risk, "target", None),
+        account_to_quote_rate,
+    )
+    if (
+        target_source not in {"structural", "manual"}
+        or account_currency in {"", "UNKNOWN"}
+        or quote_currency in {"", "UNKNOWN"}
+        or any(
+            isinstance(value, bool)
+            or not isinstance(value, (int, float))
+            or not math.isfinite(float(value))
+            or float(value) <= 0
+            for value in values
+        )
+    ):
+        return None
+    return ApprovalTokenClaims(
+        ticker=str(getattr(candidate, "ticker", "")).upper(),
+        order_type=str(
+            getattr(candidate, "suggested_order_type", None) or "BUY_LIMIT"
+        ).upper(),
+        setup_status="PASS",
+        trigger_status="PASS",
+        plan_status="PASS",
+        data_status="current",
+        data_asof=data_asof,
+        strategy_id=strategy_id,
+        account_currency=account_currency,
+        quote_currency=quote_currency,
+        account_to_quote_rate=float(values[3]),
+        target_source=target_source,
+        days_to_earnings=days_to_earnings,
+        generated_entry=float(values[0]),
+        generated_stop=float(values[1]),
+        generated_target=float(values[2]),
+    )
+
+
+def _normalize_quote_currency_value(
+    *values: object, fallback_ticker: str | None = None
+) -> str:
     for value in values:
         if is_na_scalar(value):
             continue
@@ -254,11 +335,13 @@ class ScreenerService:
         eval_cache: Optional[EvalCache] = None,
         pool_repo=None,
         review_repo=None,
+        approval_signer: OrderApprovalTokenSigner | None = None,
     ) -> None:
         self._strategy_repo = strategy_repo
         self._portfolio_service = portfolio_service
         self._provider = provider or get_default_provider()
         self._orders_service = orders_service
+        self._approval_signer = approval_signer
         if eval_cache is not None:
             self._eval_cache: EvalCache = eval_cache
         else:
@@ -646,9 +729,7 @@ class ScreenerService:
             self._review_repo.apply_fetch_results(
                 ok, failed, ctx.asof_str, threshold, meta=meta
             )
-        except (
-            Exception
-        ) as exc:  # noqa: BLE001 - health tracking must never break a screen
+        except Exception as exc:  # noqa: BLE001 - health tracking must never break a screen
             logger.warning("Fetch-health tracking failed: %s", exc)
             ctx.warnings.append("Fetch-health tracking unavailable this run.")
 
@@ -842,11 +923,15 @@ class ScreenerService:
             eurusd_rate = _last_close_for_ticker(fx, "EURUSD=X")
         except Exception as exc:
             logger.warning("Failed to fetch EURUSD rate for screener sizing: %s", exc)
-            ctx.warnings.append("EURUSD FX rate unavailable; cross-currency sizing may be omitted.")
+            ctx.warnings.append(
+                "EURUSD FX rate unavailable; cross-currency sizing may be omitted."
+            )
             return {}, {}
 
         if eurusd_rate is None or eurusd_rate <= 0:
-            ctx.warnings.append("EURUSD FX rate unavailable; cross-currency sizing may be omitted.")
+            ctx.warnings.append(
+                "EURUSD FX rate unavailable; cross-currency sizing may be omitted."
+            )
             return {}, {}
 
         account_to_quote_rates: dict[str, float] = {}
@@ -869,7 +954,8 @@ class ScreenerService:
         )
         if unsupported:
             ctx.warnings.append(
-                "Unsupported FX conversion for quote currencies: " + ", ".join(unsupported)
+                "Unsupported FX conversion for quote currencies: "
+                + ", ".join(unsupported)
             )
         return account_to_quote_rates, quote_to_eur_rates
 
@@ -948,9 +1034,7 @@ class ScreenerService:
                 ]
             )
             currency = _normalize_quote_currency_value(
-                info.get("currency")
-                if isinstance(info, dict)
-                else None,
+                info.get("currency") if isinstance(info, dict) else None,
                 row.get("currency"),
                 instrument.get("currency"),
                 fallback_ticker=ticker_str,
@@ -969,7 +1053,9 @@ class ScreenerService:
                         getattr(risk_cfg, "k_atr", 2.0), default=2.0
                     )
                     stop_val = round(entry_val - atr_multiplier * atr_val, 4)
-            account_to_quote_rate = safe_optional_float(row.get("account_to_quote_rate"))
+            account_to_quote_rate = safe_optional_float(
+                row.get("account_to_quote_rate")
+            )
 
             candidate_history = price_history_by_ticker.get(ticker_str, [])
             suggested_order_type = (
@@ -977,7 +1063,9 @@ class ScreenerService:
                 if not is_na_scalar(row.get("suggested_order_type"))
                 else None
             )
-            suggested_order_price = safe_optional_float(row.get("suggested_order_price"))
+            suggested_order_price = safe_optional_float(
+                row.get("suggested_order_price")
+            )
             # The price shown in the order form owns every dependent number. A
             # conditional BUY_LIMIT/BUY_STOP is not an observed entry trigger.
             plan_entry = (
@@ -1007,7 +1095,9 @@ class ScreenerService:
                 if suggested_order_type == "BUY_LIMIT"
                 else "WAIT_FOR_BREAKOUT"
                 if suggested_order_type == "BUY_STOP"
-                else str(signal) if not is_na_scalar(signal) else None
+                else str(signal)
+                if not is_na_scalar(signal)
+                else None
             )
             structural_target = (
                 _structural_target_from_history(candidate_history, entry=plan_entry)
@@ -1027,7 +1117,9 @@ class ScreenerService:
                 risk_cfg=risk_cfg,
                 rr_target=rr_target,
                 target=structural_target,
-                target_source="structural" if structural_target is not None else "unknown",
+                target_source="structural"
+                if structural_target is not None
+                else "unknown",
                 data_status=candidate_data_status,
                 costs=RiskEngineConfig(
                     commission_pct=commission_pct,
@@ -1264,7 +1356,6 @@ class ScreenerService:
         """
         asof_str = ctx.asof_str
         combined_priority_cfg = ctx.combined_priority_cfg
-        risk_cfg = ctx.risk_cfg
         ticker_info = ctx.ticker_info
         warnings = ctx.warnings
 
@@ -1357,6 +1448,20 @@ class ScreenerService:
             candidates = self._enrich_and_rank(
                 ctx, candidates, requested_top, same_symbol_suppressed_count
             )
+            if self._approval_signer is not None:
+                strategy_id = str(
+                    ctx.strategy.get("id")
+                    or request.strategy_id
+                    or self._strategy_repo.get_active_strategy_id()
+                )
+                signed_candidates: list[ScreenerCandidate] = []
+                for candidate in candidates:
+                    claims = _approval_claims_for_candidate(candidate, strategy_id)
+                    token = self._approval_signer.issue(claims) if claims else None
+                    signed_candidates.append(
+                        candidate.model_copy(update={"approval_token": token})
+                    )
+                candidates = signed_candidates
 
             response = ScreenerResponse(
                 candidates=candidates,

--- a/app.json
+++ b/app.json
@@ -48,6 +48,13 @@
     "SESSION_COOKIE_SECURE": {
       "value": "true"
     },
+    "ORDER_APPROVAL_SIGNING_KEY": {
+      "description": "Random secret of at least 32 bytes used only for candidate approvals",
+      "required": true
+    },
+    "ORDER_APPROVAL_TTL_SECONDS": {
+      "value": "28800"
+    },
     "SERVE_WEB_UI": {
       "value": "1"
     },

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -9,6 +9,7 @@ app_config:
     k_atr: 2.0
     min_rr: 2.0
     max_fee_risk_pct: 0.2
+    max_portfolio_heat_pct: 0.06
     max_concentration_pct: 60.0
   indicators:
     sma_fast: 20
@@ -81,6 +82,7 @@ strategy:
     rr_target: 2.0
     commission_pct: 0.0
     max_fee_risk_pct: 0.2
+    max_portfolio_heat_pct: 0.06
     regime_enabled: false
     regime_trend_sma: 200
     regime_trend_multiplier: 0.5
@@ -346,6 +348,7 @@ low_level:
     rr_target: 2.0
     commission_pct: 0.0
     max_fee_risk_pct: 0.2
+    max_portfolio_heat_pct: 0.06
     regime_enabled: false
     regime_trend_sma: 200
     regime_trend_multiplier: 0.5

--- a/src/swing_screener/risk/position_sizing.py
+++ b/src/swing_screener/risk/position_sizing.py
@@ -16,23 +16,68 @@ def _risk_defaults() -> dict:
 
 @dataclass(frozen=True)
 class RiskConfig:
-    account_size: float = field(default_factory=lambda: float(_risk_defaults().get("account_size", 500.0)))
-    account_currency: str = field(default_factory=lambda: str(_risk_defaults().get("account_currency", "EUR")).upper())
-    risk_pct: float = field(default_factory=lambda: float(_risk_defaults().get("risk_pct", 0.01)))
-    k_atr: float = field(default_factory=lambda: float(_risk_defaults().get("k_atr", 2.0)))
-    max_position_pct: float = field(default_factory=lambda: float(_risk_defaults().get("max_position_pct", 0.60)))
-    min_shares: int = field(default_factory=lambda: int(_risk_defaults().get("min_shares", 1)))
-    min_rr: float = field(default_factory=lambda: float(_risk_defaults().get("min_rr", 2.0)))
-    rr_target: float = field(default_factory=lambda: float(_risk_defaults().get("rr_target", 2.0)))
-    commission_pct: float = field(default_factory=lambda: float(_risk_defaults().get("commission_pct", 0.0)))
-    max_fee_risk_pct: float = field(default_factory=lambda: float(_risk_defaults().get("max_fee_risk_pct", 0.20)))
+    account_size: float = field(
+        default_factory=lambda: float(_risk_defaults().get("account_size", 500.0))
+    )
+    account_currency: str = field(
+        default_factory=lambda: str(
+            _risk_defaults().get("account_currency", "EUR")
+        ).upper()
+    )
+    risk_pct: float = field(
+        default_factory=lambda: float(_risk_defaults().get("risk_pct", 0.01))
+    )
+    k_atr: float = field(
+        default_factory=lambda: float(_risk_defaults().get("k_atr", 2.0))
+    )
+    max_position_pct: float = field(
+        default_factory=lambda: float(_risk_defaults().get("max_position_pct", 0.60))
+    )
+    min_shares: int = field(
+        default_factory=lambda: int(_risk_defaults().get("min_shares", 1))
+    )
+    min_rr: float = field(
+        default_factory=lambda: float(_risk_defaults().get("min_rr", 2.0))
+    )
+    rr_target: float = field(
+        default_factory=lambda: float(_risk_defaults().get("rr_target", 2.0))
+    )
+    commission_pct: float = field(
+        default_factory=lambda: float(_risk_defaults().get("commission_pct", 0.0))
+    )
+    max_fee_risk_pct: float = field(
+        default_factory=lambda: float(_risk_defaults().get("max_fee_risk_pct", 0.20))
+    )
+    max_portfolio_heat_pct: float = field(
+        default_factory=lambda: float(
+            _risk_defaults().get("max_portfolio_heat_pct", 0.06)
+        )
+    )
     # Regime-aware risk scaling (optional)
-    regime_enabled: bool = field(default_factory=lambda: bool(_risk_defaults().get("regime_enabled", False)))
-    regime_trend_sma: int = field(default_factory=lambda: int(_risk_defaults().get("regime_trend_sma", 200)))
-    regime_trend_multiplier: float = field(default_factory=lambda: float(_risk_defaults().get("regime_trend_multiplier", 0.5)))
-    regime_vol_atr_window: int = field(default_factory=lambda: int(_risk_defaults().get("regime_vol_atr_window", 14)))
-    regime_vol_atr_pct_threshold: float = field(default_factory=lambda: float(_risk_defaults().get("regime_vol_atr_pct_threshold", 6.0)))
-    regime_vol_multiplier: float = field(default_factory=lambda: float(_risk_defaults().get("regime_vol_multiplier", 0.5)))
+    regime_enabled: bool = field(
+        default_factory=lambda: bool(_risk_defaults().get("regime_enabled", False))
+    )
+    regime_trend_sma: int = field(
+        default_factory=lambda: int(_risk_defaults().get("regime_trend_sma", 200))
+    )
+    regime_trend_multiplier: float = field(
+        default_factory=lambda: float(
+            _risk_defaults().get("regime_trend_multiplier", 0.5)
+        )
+    )
+    regime_vol_atr_window: int = field(
+        default_factory=lambda: int(_risk_defaults().get("regime_vol_atr_window", 14))
+    )
+    regime_vol_atr_pct_threshold: float = field(
+        default_factory=lambda: float(
+            _risk_defaults().get("regime_vol_atr_pct_threshold", 6.0)
+        )
+    )
+    regime_vol_multiplier: float = field(
+        default_factory=lambda: float(
+            _risk_defaults().get("regime_vol_multiplier", 0.5)
+        )
+    )
 
 
 def _normalize_currency(value: object, fallback: str = "EUR") -> str:

--- a/tests/api/test_candidate_approval.py
+++ b/tests/api/test_candidate_approval.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from api.services.screener_service import _approval_claims_for_candidate
+
+
+def _candidate(**updates):
+    gates = SimpleNamespace(
+        setup=SimpleNamespace(status="PASS"),
+        trigger=SimpleNamespace(status="PASS"),
+        plan=SimpleNamespace(status="PASS"),
+    )
+    risk = SimpleNamespace(
+        entry=100.0,
+        stop=95.0,
+        target=112.0,
+        target_source="structural",
+        account_currency="EUR",
+        currency="USD",
+        account_to_quote_rate=1.1,
+    )
+    values = {
+        "ticker": "AAPL",
+        "suggested_order_type": "BUY_LIMIT",
+        "data_status": "current",
+        "data_asof": "2026-07-15",
+        "days_to_earnings": 20,
+        "recommendation": SimpleNamespace(
+            verdict="RECOMMENDED", decision_gates=gates, risk=risk
+        ),
+    }
+    values.update(updates)
+    return SimpleNamespace(**values)
+
+
+def test_actionable_candidate_produces_complete_signed_claims():
+    claims = _approval_claims_for_candidate(_candidate(), "momentum-v1")
+
+    assert claims is not None
+    assert claims.ticker == "AAPL"
+    assert claims.strategy_id == "momentum-v1"
+    assert claims.account_to_quote_rate == 1.1
+    assert claims.target_source == "structural"
+
+
+@pytest.mark.parametrize(
+    "candidate",
+    [
+        _candidate(data_status="stale"),
+        _candidate(data_asof=None),
+        _candidate(days_to_earnings=3),
+        _candidate(recommendation=None),
+    ],
+)
+def test_incomplete_candidate_receives_no_claims(candidate):
+    assert _approval_claims_for_candidate(candidate, "momentum-v1") is None
+
+
+def test_nonpassing_decision_gate_receives_no_claims():
+    candidate = _candidate()
+    candidate.recommendation.decision_gates.trigger.status = "WAIT"
+
+    assert _approval_claims_for_candidate(candidate, "momentum-v1") is None
+
+
+def test_same_currency_candidate_uses_identity_without_provider_fx():
+    candidate = _candidate()
+    candidate.recommendation.risk.currency = "EUR"
+    candidate.recommendation.risk.account_to_quote_rate = None
+
+    claims = _approval_claims_for_candidate(candidate, "momentum-v1")
+
+    assert claims is not None
+    assert claims.account_to_quote_rate == 1

--- a/tests/api/test_candidate_approval.py
+++ b/tests/api/test_candidate_approval.py
@@ -37,11 +37,12 @@ def _candidate(**updates):
 
 
 def test_actionable_candidate_produces_complete_signed_claims():
-    claims = _approval_claims_for_candidate(_candidate(), "momentum-v1")
+    claims = _approval_claims_for_candidate(_candidate(), "momentum-v1", "revision-1")
 
     assert claims is not None
     assert claims.ticker == "AAPL"
     assert claims.strategy_id == "momentum-v1"
+    assert claims.strategy_revision == "revision-1"
     assert claims.account_to_quote_rate == 1.1
     assert claims.target_source == "structural"
 
@@ -56,14 +57,18 @@ def test_actionable_candidate_produces_complete_signed_claims():
     ],
 )
 def test_incomplete_candidate_receives_no_claims(candidate):
-    assert _approval_claims_for_candidate(candidate, "momentum-v1") is None
+    assert (
+        _approval_claims_for_candidate(candidate, "momentum-v1", "revision-1") is None
+    )
 
 
 def test_nonpassing_decision_gate_receives_no_claims():
     candidate = _candidate()
     candidate.recommendation.decision_gates.trigger.status = "WAIT"
 
-    assert _approval_claims_for_candidate(candidate, "momentum-v1") is None
+    assert (
+        _approval_claims_for_candidate(candidate, "momentum-v1", "revision-1") is None
+    )
 
 
 def test_same_currency_candidate_uses_identity_without_provider_fx():
@@ -71,7 +76,7 @@ def test_same_currency_candidate_uses_identity_without_provider_fx():
     candidate.recommendation.risk.currency = "EUR"
     candidate.recommendation.risk.account_to_quote_rate = None
 
-    claims = _approval_claims_for_candidate(candidate, "momentum-v1")
+    claims = _approval_claims_for_candidate(candidate, "momentum-v1", "revision-1")
 
     assert claims is not None
     assert claims.account_to_quote_rate == 1

--- a/tests/api/test_order_approval_policy.py
+++ b/tests/api/test_order_approval_policy.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from api.services.order_approval import (
+    EffectiveOrderPolicy,
+    SubmittedPlan,
+    evaluate_order_approval,
+)
+from api.services.order_approval_token import VerifiedApprovalToken
+from api.services.order_exposure import ProposedExposure, build_exposure_snapshot
+
+
+def _context(**updates) -> VerifiedApprovalToken:
+    payload = {
+        "ticker": "AAPL",
+        "order_type": "BUY_LIMIT",
+        "setup_status": "PASS",
+        "trigger_status": "PASS",
+        "plan_status": "PASS",
+        "data_status": "current",
+        "data_asof": "2026-07-15",
+        "strategy_id": "momentum-v1",
+        "account_currency": "EUR",
+        "quote_currency": "EUR",
+        "account_to_quote_rate": 1,
+        "target_source": "structural",
+        "days_to_earnings": 20,
+        "generated_entry": 100,
+        "generated_stop": 95,
+        "generated_target": 112,
+        "version": 1,
+        "token_id": "a" * 32,
+        "issued_at": 1000,
+        "expires_at": 2000,
+        "plan_fingerprint": "f" * 64,
+    }
+    payload.update(updates)
+    return VerifiedApprovalToken(**payload)
+
+
+def _policy(**updates) -> EffectiveOrderPolicy:
+    values = {
+        "account_size": Decimal("10000"),
+        "risk_pct": Decimal("0.01"),
+        "max_position_pct": Decimal("0.20"),
+        "max_portfolio_heat_pct": Decimal("0.06"),
+        "min_rr": Decimal("2"),
+        "commission_pct": Decimal("0.001"),
+        "max_fee_risk_pct": Decimal("0.20"),
+        "max_concentration_pct": Decimal("60"),
+        "account_currency": "EUR",
+    }
+    values.update(updates)
+    return EffectiveOrderPolicy(**values)
+
+
+def _evaluate(
+    *,
+    quantity=10,
+    entry="100",
+    stop="95",
+    target="112",
+    positions=(),
+    orders=(),
+    policy=None,
+    context=None,
+):
+    submitted = SubmittedPlan(
+        ticker="AAPL",
+        quantity=quantity,
+        entry=Decimal(entry),
+        stop=Decimal(stop),
+        target=Decimal(target),
+    )
+    proposed = ProposedExposure(
+        ticker="AAPL",
+        quantity=quantity,
+        entry=Decimal(entry),
+        stop=Decimal(stop),
+        account_currency="EUR",
+        quote_currency="EUR",
+        account_to_quote_rate=Decimal("1"),
+    )
+    snapshot = build_exposure_snapshot(list(positions), list(orders), proposed)
+    return evaluate_order_approval(
+        context or _context(), submitted, snapshot, policy or _policy()
+    )
+
+
+def test_valid_first_position_is_approved_with_concentration_warning():
+    approval = _evaluate()
+
+    assert approval.approved is True
+    assert approval.trade_risk.status == "PASS"
+    assert approval.concentration.status == "WARN"
+    assert approval.concentration.projected == 100
+    assert approval.estimated_fees == 2
+    assert approval.projected_risk == 52
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "gate"),
+    [
+        ({"stop": "100"}, "coherence"),
+        ({"target": "108"}, "reward_risk"),
+        ({"quantity": 30}, "trade_risk"),
+        ({"quantity": 21}, "position"),
+        ({"quantity": 101}, "cash"),
+        ({"policy": _policy(commission_pct=Decimal("0.02"))}, "fees"),
+        ({"context": _context(days_to_earnings=3)}, "event"),
+    ],
+)
+def test_each_hard_gate_blocks_independently(kwargs, gate):
+    approval = _evaluate(**kwargs)
+
+    assert approval.approved is False
+    assert getattr(approval, gate).status == "BLOCK"
+
+
+def test_heat_includes_existing_open_risk():
+    positions = (
+        {
+            "ticker": "SAP.DE",
+            "status": "open",
+            "entry_price": 100,
+            "stop_price": 94.5,
+            "shares": 100,
+            "quote_currency": "EUR",
+            "entry_fx_rate": 1,
+        },
+    )
+
+    approval = _evaluate(positions=positions)
+
+    assert approval.heat.status == "BLOCK"
+
+
+def test_country_concentration_uses_risk_share_not_notional():
+    positions = (
+        {
+            "ticker": "SAP.DE",
+            "status": "open",
+            "entry_price": 100,
+            "stop_price": 99,
+            "shares": 100,
+            "quote_currency": "EUR",
+            "entry_fx_rate": 1,
+        },
+    )
+
+    approval = _evaluate(positions=positions)
+
+    assert approval.concentration.projected == pytest.approx(33.33, abs=0.01)
+    assert approval.concentration.status == "PASS"

--- a/tests/api/test_order_approval_policy.py
+++ b/tests/api/test_order_approval_policy.py
@@ -23,6 +23,7 @@ def _context(**updates) -> VerifiedApprovalToken:
         "data_status": "current",
         "data_asof": "2026-07-15",
         "strategy_id": "momentum-v1",
+        "strategy_revision": "revision-1",
         "account_currency": "EUR",
         "quote_currency": "EUR",
         "account_to_quote_rate": 1,

--- a/tests/api/test_order_approval_token.py
+++ b/tests/api/test_order_approval_token.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import pytest
+
+from api.security.settings import AuthSettings, SecurityConfigurationError
+from api.services.order_approval_token import (
+    ApprovalTokenClaims,
+    ApprovalTokenError,
+    OrderApprovalTokenSigner,
+)
+
+
+def _claims(**updates) -> ApprovalTokenClaims:
+    payload = {
+        "ticker": "AAPL",
+        "order_type": "BUY_LIMIT",
+        "setup_status": "PASS",
+        "trigger_status": "PASS",
+        "plan_status": "PASS",
+        "data_status": "current",
+        "data_asof": "2026-07-15",
+        "strategy_id": "momentum-v1",
+        "account_currency": "EUR",
+        "quote_currency": "USD",
+        "account_to_quote_rate": 1.1,
+        "target_source": "structural",
+        "days_to_earnings": 20,
+        "generated_entry": 100.0,
+        "generated_stop": 95.0,
+        "generated_target": 112.0,
+    }
+    payload.update(updates)
+    return ApprovalTokenClaims(**payload)
+
+
+def test_token_round_trip_contains_versioned_audit_context():
+    signer = OrderApprovalTokenSigner(b"k" * 32, ttl_seconds=100)
+
+    token = signer.issue(_claims(), now=1_000)
+    verified = signer.verify(token, now=1_050)
+
+    assert verified.version == 1
+    assert verified.ticker == "AAPL"
+    assert verified.issued_at == 1_000
+    assert verified.expires_at == 1_100
+    assert len(verified.token_id) >= 32
+    assert len(verified.plan_fingerprint) == 64
+
+
+@pytest.mark.parametrize("part", [0, 1])
+def test_payload_or_signature_tampering_is_rejected(part: int):
+    signer = OrderApprovalTokenSigner(b"k" * 32, ttl_seconds=100)
+    pieces = signer.issue(_claims(), now=1_000).split(".")
+    pieces[part] = ("A" if pieces[part][0] != "A" else "B") + pieces[part][1:]
+
+    with pytest.raises(ApprovalTokenError, match="invalid"):
+        signer.verify(".".join(pieces), now=1_001)
+
+
+def test_token_expires_at_exact_boundary():
+    signer = OrderApprovalTokenSigner(b"k" * 32, ttl_seconds=100)
+    token = signer.issue(_claims(), now=1_000)
+
+    with pytest.raises(ApprovalTokenError, match="expired"):
+        signer.verify(token, now=1_100)
+
+
+@pytest.mark.parametrize("token", ["", "only-one-part", "!!.!!", "e30.invalid"])
+def test_malformed_token_is_rejected(token: str):
+    signer = OrderApprovalTokenSigner(b"k" * 32, ttl_seconds=100)
+
+    with pytest.raises(ApprovalTokenError, match="invalid"):
+        signer.verify(token, now=1_000)
+
+
+def test_production_requires_signing_key_and_bounds_ttl():
+    base = {
+        "APP_ENV": "production",
+        "OIDC_DISCOVERY_URL": "https://id.example/.well-known/openid-configuration",
+        "OIDC_CLIENT_ID": "client",
+        "OIDC_CLIENT_SECRET": "secret",
+        "OIDC_REDIRECT_URI": "https://app.example/api/auth/callback",
+        "SESSION_SECRET": "s" * 32,
+    }
+    missing = AuthSettings.from_env(base)
+    with pytest.raises(SecurityConfigurationError, match="ORDER_APPROVAL_SIGNING_KEY"):
+        missing.validate_runtime()
+
+    too_long = AuthSettings.from_env(
+        {
+            **base,
+            "ORDER_APPROVAL_SIGNING_KEY": "k" * 32,
+            "ORDER_APPROVAL_TTL_SECONDS": "86401",
+        }
+    )
+    with pytest.raises(SecurityConfigurationError, match="ORDER_APPROVAL_TTL_SECONDS"):
+        too_long.validate_runtime()
+
+
+def test_test_mode_derives_a_distinct_approval_key():
+    settings = AuthSettings.from_env({"APP_ENV": "test", "AUTH_MODE": "disabled"})
+
+    assert len(settings.order_approval_signing_key) == 32
+    assert settings.order_approval_signing_key != settings.session_secret.encode()

--- a/tests/api/test_order_approval_token.py
+++ b/tests/api/test_order_approval_token.py
@@ -20,6 +20,7 @@ def _claims(**updates) -> ApprovalTokenClaims:
         "data_status": "current",
         "data_asof": "2026-07-15",
         "strategy_id": "momentum-v1",
+        "strategy_revision": "revision-1",
         "account_currency": "EUR",
         "quote_currency": "USD",
         "account_to_quote_rate": 1.1,

--- a/tests/api/test_order_exposure.py
+++ b/tests/api/test_order_exposure.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from api.services.order_exposure import (
+    ExposureContextError,
+    ProposedExposure,
+    build_exposure_snapshot,
+    quote_to_account,
+)
+
+
+def test_same_currency_uses_identity_even_when_rate_is_supplied():
+    assert quote_to_account(Decimal("100"), "EUR", "EUR", Decimal("1.5")) == Decimal(
+        "100"
+    )
+
+
+def test_cross_currency_amounts_divide_by_account_to_quote_rate():
+    assert quote_to_account(Decimal("110"), "EUR", "USD", Decimal("1.1")) == Decimal(
+        "100"
+    )
+
+
+def test_snapshot_normalizes_open_pending_and_proposed_exposure():
+    positions = [
+        {
+            "ticker": "SAP.DE",
+            "status": "open",
+            "entry_price": 100,
+            "stop_price": 95,
+            "shares": 10,
+            "quote_currency": "EUR",
+            "entry_fx_rate": 1,
+        }
+    ]
+    orders = [
+        {
+            "ticker": "MSFT",
+            "status": "pending",
+            "order_kind": "entry",
+            "limit_price": 110,
+            "stop_price": 99,
+            "quantity": 10,
+            "quote_currency": "USD",
+            "account_to_quote_rate": 1.1,
+        }
+    ]
+    proposed = ProposedExposure(
+        ticker="AAPL",
+        quantity=10,
+        entry=Decimal("110"),
+        stop=Decimal("104.5"),
+        account_currency="EUR",
+        quote_currency="USD",
+        account_to_quote_rate=Decimal("1.1"),
+    )
+
+    snapshot = build_exposure_snapshot(positions, orders, proposed)
+
+    assert snapshot.current_notional == Decimal("2000")
+    assert snapshot.current_risk == Decimal("150")
+    assert snapshot.projected_notional == Decimal("3000")
+    assert snapshot.projected_price_risk == Decimal("200")
+    assert len(snapshot.lines) == 3
+
+
+def test_closed_and_cancelled_rows_are_excluded():
+    proposed = ProposedExposure(
+        ticker="SAP.DE",
+        quantity=1,
+        entry=Decimal("100"),
+        stop=Decimal("95"),
+        account_currency="EUR",
+        quote_currency="EUR",
+        account_to_quote_rate=Decimal("1"),
+    )
+    snapshot = build_exposure_snapshot(
+        [
+            {
+                "ticker": "OLD",
+                "status": "closed",
+                "entry_price": 100,
+                "stop_price": 1,
+                "shares": 100,
+            }
+        ],
+        [
+            {
+                "ticker": "OLD",
+                "status": "cancelled",
+                "order_kind": "entry",
+                "limit_price": 100,
+                "stop_price": 1,
+                "quantity": 100,
+            }
+        ],
+        proposed,
+    )
+    assert snapshot.current_notional == 0
+    assert snapshot.projected_notional == Decimal("100")
+
+
+def test_missing_legacy_cross_currency_fx_fails_closed():
+    proposed = ProposedExposure(
+        ticker="SAP.DE",
+        quantity=1,
+        entry=Decimal("100"),
+        stop=Decimal("95"),
+        account_currency="EUR",
+        quote_currency="EUR",
+        account_to_quote_rate=Decimal("1"),
+    )
+    positions = [
+        {
+            "ticker": "AAPL",
+            "status": "open",
+            "entry_price": 100,
+            "stop_price": 95,
+            "shares": 10,
+            "quote_currency": "USD",
+        }
+    ]
+
+    with pytest.raises(ExposureContextError, match="FX_CONTEXT_MISSING"):
+        build_exposure_snapshot(positions, [], proposed)

--- a/tests/api/test_order_exposure.py
+++ b/tests/api/test_order_exposure.py
@@ -126,3 +126,30 @@ def test_missing_legacy_cross_currency_fx_fails_closed():
 
     with pytest.raises(ExposureContextError, match="FX_CONTEXT_MISSING"):
         build_exposure_snapshot(positions, [], proposed)
+
+
+def test_existing_exposure_with_different_account_currency_fails_closed():
+    proposed = ProposedExposure(
+        ticker="SAP.DE",
+        quantity=1,
+        entry=Decimal("100"),
+        stop=Decimal("95"),
+        account_currency="GBP",
+        quote_currency="EUR",
+        account_to_quote_rate=Decimal("1.16"),
+    )
+    positions = [
+        {
+            "ticker": "AAPL",
+            "status": "open",
+            "entry_price": 100,
+            "stop_price": 95,
+            "shares": 10,
+            "account_currency": "EUR",
+            "quote_currency": "USD",
+            "entry_fx_rate": 1.1,
+        }
+    ]
+
+    with pytest.raises(ExposureContextError, match="ACCOUNT_CURRENCY_MISMATCH"):
+        build_exposure_snapshot(positions, [], proposed)

--- a/tests/api/test_order_fill.py
+++ b/tests/api/test_order_fill.py
@@ -52,35 +52,43 @@ def test_create_order_rejects_stop_at_or_above_limit(client_with_empty_order_boo
 def client_with_pending_order(tmp_path, monkeypatch):
     orders_path = tmp_path / "orders.json"
     positions_path = tmp_path / "positions.json"
-    orders_path.write_text(json.dumps({
-        "orders": [{
-            "order_id": "ORD-SBMO-001",
-            "ticker": "SBMO",
-            "status": "pending",
-            "order_kind": "entry",
-            "order_type": "LIMIT",
-            "quantity": 200,
-            "limit_price": 12.50,
-            "stop_price": 11.20,
-            "order_date": "2026-04-25",
-            "filled_date": None,
-            "entry_price": None,
-            "notes": "",
-            "parent_order_id": None,
-            "position_id": None,
-            "tif": "GTC",
-            "fee_eur": None,
-            "fill_fx_rate": None,
-            "isin": "NL0010273215",
-            "thesis": None,
-        }],
-        "asof": "2026-04-25",
-    }))
+    orders_path.write_text(
+        json.dumps(
+            {
+                "orders": [
+                    {
+                        "order_id": "ORD-SBMO-001",
+                        "ticker": "SBMO",
+                        "status": "pending",
+                        "order_kind": "entry",
+                        "order_type": "LIMIT",
+                        "quantity": 200,
+                        "limit_price": 12.50,
+                        "stop_price": 11.20,
+                        "order_date": "2026-04-25",
+                        "filled_date": None,
+                        "entry_price": None,
+                        "notes": "",
+                        "parent_order_id": None,
+                        "position_id": None,
+                        "tif": "GTC",
+                        "fee_eur": None,
+                        "fill_fx_rate": None,
+                        "isin": "NL0010273215",
+                        "thesis": None,
+                    }
+                ],
+                "asof": "2026-04-25",
+            }
+        )
+    )
     positions_path.write_text(json.dumps({"positions": [], "asof": "2026-04-25"}))
     import api.dependencies as deps
+
     monkeypatch.setattr(deps, "_orders_path", orders_path)
     monkeypatch.setattr(deps, "_positions_path", positions_path)
     return TestClient(app)
+
 
 def test_fill_order_creates_position(client_with_pending_order):
     resp = client_with_pending_order.post(
@@ -97,6 +105,7 @@ def test_fill_order_creates_position(client_with_pending_order):
     assert pos["source_order_id"] == "ORD-SBMO-001"
     assert abs(pos["initial_risk"] - (12.34 - 11.20)) < 0.01  # per-share: 1.14
 
+
 def test_fill_order_already_filled_returns_409(client_with_pending_order):
     first = client_with_pending_order.post(
         "/api/portfolio/orders/ORD-SBMO-001/fill",
@@ -109,12 +118,14 @@ def test_fill_order_already_filled_returns_409(client_with_pending_order):
     )
     assert resp.status_code == 409
 
+
 def test_fill_order_not_found_returns_404(client_with_pending_order):
     resp = client_with_pending_order.post(
         "/api/portfolio/orders/ORD-MISSING-001/fill",
         json={"filled_price": 12.34, "filled_date": "2026-04-26"},
     )
     assert resp.status_code == 404
+
 
 def test_list_local_orders_returns_pending(client_with_pending_order):
     resp = client_with_pending_order.get("/api/portfolio/orders/local")
@@ -134,38 +145,44 @@ def test_cancel_pending_order_marks_cancelled(client_with_pending_order):
     assert orders_resp.json()["orders"][0]["status"] == "cancelled"
 
 
-
 @pytest.fixture()
 def client_with_target_order(tmp_path, monkeypatch):
     orders_path = tmp_path / "orders.json"
     positions_path = tmp_path / "positions.json"
-    orders_path.write_text(json.dumps({
-        "orders": [{
-            "order_id": "ORD-SBMO-001",
-            "ticker": "SBMO",
-            "status": "pending",
-            "order_kind": "entry",
-            "order_type": "LIMIT",
-            "quantity": 200,
-            "limit_price": 12.50,
-            "stop_price": 11.20,
-            "target_price": 15.00,
-            "order_date": "2026-04-25",
-            "filled_date": None,
-            "entry_price": None,
-            "notes": "",
-            "parent_order_id": None,
-            "position_id": None,
-            "tif": "GTC",
-            "fee_eur": None,
-            "fill_fx_rate": None,
-            "isin": "NL0010273215",
-            "thesis": None,
-        }],
-        "asof": "2026-04-25",
-    }))
+    orders_path.write_text(
+        json.dumps(
+            {
+                "orders": [
+                    {
+                        "order_id": "ORD-SBMO-001",
+                        "ticker": "SBMO",
+                        "status": "pending",
+                        "order_kind": "entry",
+                        "order_type": "LIMIT",
+                        "quantity": 200,
+                        "limit_price": 12.50,
+                        "stop_price": 11.20,
+                        "target_price": 15.00,
+                        "order_date": "2026-04-25",
+                        "filled_date": None,
+                        "entry_price": None,
+                        "notes": "",
+                        "parent_order_id": None,
+                        "position_id": None,
+                        "tif": "GTC",
+                        "fee_eur": None,
+                        "fill_fx_rate": None,
+                        "isin": "NL0010273215",
+                        "thesis": None,
+                    }
+                ],
+                "asof": "2026-04-25",
+            }
+        )
+    )
     positions_path.write_text(json.dumps({"positions": [], "asof": "2026-04-25"}))
     import api.dependencies as deps
+
     monkeypatch.setattr(deps, "_orders_path", orders_path)
     monkeypatch.setattr(deps, "_positions_path", positions_path)
     return TestClient(app)
@@ -185,45 +202,64 @@ def test_fill_order_carries_target_price_to_position(client_with_target_order):
 def client_with_addon_order(tmp_path, monkeypatch):
     orders_path = tmp_path / "orders.json"
     positions_path = tmp_path / "positions.json"
-    orders_path.write_text(json.dumps({
-        "orders": [{
-            "order_id": "ORD-SBMO-002",
-            "ticker": "SBMO",
-            "status": "pending",
-            "order_kind": "entry",
-            "order_type": "LIMIT",
-            "quantity": 50,
-            "limit_price": 13.00,
-            "stop_price": 11.20,
-            "order_date": "2026-04-25",
-            "filled_date": None,
-            "entry_price": None,
-            "notes": "",
-            "parent_order_id": None,
-            "position_id": "POS-EXIST",
-            "tif": "GTC",
-            "fee_eur": None,
-            "fill_fx_rate": None,
-            "isin": "NL0010273215",
-            "thesis": None,
-        }],
-        "asof": "2026-04-25",
-    }))
-    positions_path.write_text(json.dumps({
-        "positions": [{
-            "position_id": "POS-EXIST",
-            "ticker": "SBMO",
-            "status": "open",
-            "entry_date": "2026-04-20",
-            "entry_price": 12.0,
-            "stop_price": 11.0,
-            "shares": 100,
-            "initial_risk": 1.0,
-            "entry_fee_eur": 2.0,
-        }],
-        "asof": "2026-04-25",
-    }))
+    orders_path.write_text(
+        json.dumps(
+            {
+                "orders": [
+                    {
+                        "order_id": "ORD-SBMO-002",
+                        "ticker": "SBMO",
+                        "status": "pending",
+                        "order_kind": "entry",
+                        "order_type": "LIMIT",
+                        "quantity": 50,
+                        "limit_price": 13.00,
+                        "stop_price": 11.20,
+                        "order_date": "2026-04-25",
+                        "filled_date": None,
+                        "entry_price": None,
+                        "notes": "",
+                        "parent_order_id": None,
+                        "position_id": "POS-EXIST",
+                        "tif": "GTC",
+                        "fee_eur": None,
+                        "fill_fx_rate": None,
+                        "isin": "NL0010273215",
+                        "thesis": None,
+                        "quote_currency": "USD",
+                        "account_currency": "EUR",
+                        "approval_fx_rate": 1.1,
+                    }
+                ],
+                "asof": "2026-04-25",
+            }
+        )
+    )
+    positions_path.write_text(
+        json.dumps(
+            {
+                "positions": [
+                    {
+                        "position_id": "POS-EXIST",
+                        "ticker": "SBMO",
+                        "status": "open",
+                        "entry_date": "2026-04-20",
+                        "entry_price": 12.0,
+                        "stop_price": 11.0,
+                        "shares": 100,
+                        "initial_risk": 1.0,
+                        "entry_fee_eur": 2.0,
+                        "quote_currency": "USD",
+                        "account_currency": "EUR",
+                        "entry_fx_rate": 1.2,
+                    }
+                ],
+                "asof": "2026-04-25",
+            }
+        )
+    )
     import api.dependencies as deps
+
     monkeypatch.setattr(deps, "_orders_path", orders_path)
     monkeypatch.setattr(deps, "_positions_path", positions_path)
     return TestClient(app)
@@ -232,7 +268,12 @@ def client_with_addon_order(tmp_path, monkeypatch):
 def test_fill_addon_merges_into_existing_position(client_with_addon_order):
     resp = client_with_addon_order.post(
         "/api/portfolio/orders/ORD-SBMO-002/fill",
-        json={"filled_price": 13.00, "filled_date": "2026-04-26", "fee_eur": 1.5},
+        json={
+            "filled_price": 13.00,
+            "filled_date": "2026-04-26",
+            "fee_eur": 1.5,
+            "fill_fx_rate": 1.1,
+        },
     )
     assert resp.status_code == 201
     pos = resp.json()["position"]
@@ -243,8 +284,16 @@ def test_fill_addon_merges_into_existing_position(client_with_addon_order):
     assert pos["stop_price"] == 11.0
     assert abs(pos["initial_risk"] - (pos["entry_price"] - 11.0)) < 1e-4
     assert abs(pos["entry_fee_eur"] - 3.5) < 1e-6  # 2.0 prior + 1.5 add-on
+    old_account_cost = 12.0 * 100 / 1.2
+    added_account_cost = 13.0 * 50 / 1.1
+    expected_rate = (12.0 * 100 + 13.0 * 50) / (old_account_cost + added_account_cost)
+    assert abs(pos["entry_fx_rate"] - expected_rate) < 1e-6
+    assert pos["quote_currency"] == "USD"
+    assert pos["account_currency"] == "EUR"
     # No duplicate position was created.
-    positions = client_with_addon_order.get("/api/portfolio/positions").json()["positions"]
+    positions = client_with_addon_order.get("/api/portfolio/positions").json()[
+        "positions"
+    ]
     sbmo = [p for p in positions if p["ticker"] == "SBMO"]
     assert len(sbmo) == 1
 
@@ -253,43 +302,55 @@ def test_fill_addon_merges_into_existing_position(client_with_addon_order):
 def client_with_addon_order_below_live_stop(tmp_path, monkeypatch):
     orders_path = tmp_path / "orders.json"
     positions_path = tmp_path / "positions.json"
-    orders_path.write_text(json.dumps({
-        "orders": [{
-            "order_id": "ORD-SBMO-003",
-            "ticker": "SBMO",
-            "status": "pending",
-            "order_kind": "entry",
-            "order_type": "LIMIT",
-            "quantity": 50,
-            "limit_price": 8.00,
-            "stop_price": 7.00,
-            "order_date": "2026-04-25",
-            "filled_date": None,
-            "entry_price": None,
-            "notes": "",
-            "parent_order_id": None,
-            "position_id": "POS-EXIST",
-            "tif": "GTC",
-            "fee_eur": None,
-            "fill_fx_rate": None,
-            "isin": "NL0010273215",
-            "thesis": None,
-        }],
-        "asof": "2026-04-25",
-    }))
-    positions_path.write_text(json.dumps({
-        "positions": [{
-            "position_id": "POS-EXIST",
-            "ticker": "SBMO",
-            "status": "open",
-            "entry_date": "2026-04-20",
-            "entry_price": 12.0,
-            "stop_price": 11.0,
-            "shares": 100,
-            "initial_risk": 1.0,
-        }],
-        "asof": "2026-04-25",
-    }))
+    orders_path.write_text(
+        json.dumps(
+            {
+                "orders": [
+                    {
+                        "order_id": "ORD-SBMO-003",
+                        "ticker": "SBMO",
+                        "status": "pending",
+                        "order_kind": "entry",
+                        "order_type": "LIMIT",
+                        "quantity": 50,
+                        "limit_price": 8.00,
+                        "stop_price": 7.00,
+                        "order_date": "2026-04-25",
+                        "filled_date": None,
+                        "entry_price": None,
+                        "notes": "",
+                        "parent_order_id": None,
+                        "position_id": "POS-EXIST",
+                        "tif": "GTC",
+                        "fee_eur": None,
+                        "fill_fx_rate": None,
+                        "isin": "NL0010273215",
+                        "thesis": None,
+                    }
+                ],
+                "asof": "2026-04-25",
+            }
+        )
+    )
+    positions_path.write_text(
+        json.dumps(
+            {
+                "positions": [
+                    {
+                        "position_id": "POS-EXIST",
+                        "ticker": "SBMO",
+                        "status": "open",
+                        "entry_date": "2026-04-20",
+                        "entry_price": 12.0,
+                        "stop_price": 11.0,
+                        "shares": 100,
+                        "initial_risk": 1.0,
+                    }
+                ],
+                "asof": "2026-04-25",
+            }
+        )
+    )
     import api.dependencies as deps
 
     monkeypatch.setattr(deps, "_orders_path", orders_path)

--- a/tests/api/test_order_portfolio_approval.py
+++ b/tests/api/test_order_portfolio_approval.py
@@ -3,6 +3,11 @@ from __future__ import annotations
 import pytest
 
 from api.models.portfolio import CreateOrderRequest
+from api.services.order_approval_token import (
+    ApprovalTokenClaims,
+    OrderApprovalTokenSigner,
+    strategy_revision,
+)
 from api.services.orders_service import OrdersService
 from swing_screener.errors import UnprocessableError
 
@@ -32,16 +37,51 @@ class _Positions:
 class _Strategies:
     def get_active_strategy(self):
         return {
+            "id": "momentum-v1",
+            "updated_at": "2026-07-13T10:00:00",
             "risk": {
                 "account_size": 10_000,
+                "risk_pct": 0.01,
+                "max_position_pct": 0.60,
                 "min_rr": 2.0,
+                "commission_pct": 0,
+                "max_fee_risk_pct": 0.20,
                 "max_portfolio_heat_pct": 0.06,
                 "max_concentration_pct": 60.0,
-            }
+                "account_currency": "EUR",
+            },
         }
 
 
-def _request(**updates) -> CreateOrderRequest:
+SIGNER = OrderApprovalTokenSigner(b"p" * 32, ttl_seconds=100)
+
+
+def _token(**updates) -> str:
+    strategy = _Strategies().get_active_strategy()
+    payload = {
+        "ticker": "AAPL",
+        "order_type": "BUY_LIMIT",
+        "setup_status": "PASS",
+        "trigger_status": "PASS",
+        "plan_status": "PASS",
+        "data_status": "current",
+        "data_asof": "2026-07-13",
+        "strategy_id": "momentum-v1",
+        "strategy_revision": strategy_revision(strategy),
+        "account_currency": "EUR",
+        "quote_currency": "EUR",
+        "account_to_quote_rate": 1,
+        "target_source": "structural",
+        "days_to_earnings": 20,
+        "generated_entry": 100,
+        "generated_stop": 95,
+        "generated_target": 110,
+    }
+    payload.update(updates)
+    return SIGNER.issue(ApprovalTokenClaims(**payload), now=1_000)
+
+
+def _request(*, token_updates=None, **updates) -> CreateOrderRequest:
     payload = {
         "ticker": "AAPL",
         "order_type": "BUY_LIMIT",
@@ -49,12 +89,7 @@ def _request(**updates) -> CreateOrderRequest:
         "limit_price": 100.0,
         "stop_price": 95.0,
         "target_price": 110.0,
-        "setup_status": "PASS",
-        "trigger_status": "PASS",
-        "data_status": "current",
-        "data_asof": "2026-07-13",
-        "target_source": "structural",
-        "days_to_earnings": 20,
+        "approval_token": _token(**(token_updates or {})),
     }
     payload.update(updates)
     return CreateOrderRequest(**payload)
@@ -65,6 +100,8 @@ def _service(*, orders=None, positions=None) -> OrdersService:
         _Orders(orders),
         _Positions(positions),
         strategy_repo=_Strategies(),
+        approval_signer=SIGNER,
+        approval_now=lambda: 1_050,
     )
 
 
@@ -77,34 +114,53 @@ def test_order_persists_portfolio_approval_only_after_all_gates_pass():
 
 
 @pytest.mark.parametrize(
-    ("updates", "message"),
+    ("token_updates", "message"),
     [
-        ({"trigger_status": "WAIT"}, "trigger"),
-        ({"data_status": "stale"}, "stale"),
-        ({"target_source": "unknown"}, "independently validated"),
-        ({"days_to_earnings": None}, "event"),
+        ({"trigger_status": "WAIT"}, "decision"),
+        ({"data_status": "stale"}, "decision"),
+        ({"target_source": "unknown"}, "decision"),
+        ({"days_to_earnings": 3}, "event"),
     ],
 )
-def test_order_cannot_bypass_decision_or_event_permission(updates, message):
+def test_signed_decision_or_event_permission_cannot_be_bypassed(token_updates, message):
     with pytest.raises(UnprocessableError, match=message):
-        _service().create_order(_request(**updates))
+        _service().create_order(_request(token_updates=token_updates))
 
 
 def test_order_blocks_projected_heat_including_pending_entries():
-    pending = [{
-        "ticker": "MSFT", "status": "pending", "order_kind": "entry",
-        "limit_price": 100.0, "stop_price": 94.2, "quantity": 95,
-    }]
+    pending = [
+        {
+            "ticker": "MSFT",
+            "status": "pending",
+            "order_kind": "entry",
+            "limit_price": 100.0,
+            "stop_price": 94.2,
+            "quantity": 95,
+            "quote_currency": "EUR",
+            "account_currency": "EUR",
+            "approval_fx_rate": 1,
+        }
+    ]
 
     with pytest.raises(UnprocessableError, match="heat"):
         _service(orders=pending).create_order(_request())
 
 
-def test_order_blocks_projected_country_concentration():
-    positions = [{
-        "ticker": "MSFT", "status": "open", "entry_price": 100.0,
-        "stop_price": 99.0, "shares": 55,
-    }]
+def test_projected_country_concentration_warns_without_blocking():
+    positions = [
+        {
+            "ticker": "MSFT",
+            "status": "open",
+            "entry_price": 100.0,
+            "stop_price": 99.0,
+            "shares": 55,
+            "quote_currency": "EUR",
+            "account_currency": "EUR",
+            "entry_fx_rate": 1,
+        }
+    ]
 
-    with pytest.raises(UnprocessableError, match="concentration"):
-        _service(positions=positions).create_order(_request())
+    order = _service(positions=positions).create_order(_request())
+
+    assert order["portfolio_approval"]["approved"] is True
+    assert order["portfolio_approval"]["concentration"]["status"] == "WARN"

--- a/tests/api/test_order_signed_approval.py
+++ b/tests/api/test_order_signed_approval.py
@@ -6,6 +6,7 @@ from api.models.portfolio import CreateOrderRequest
 from api.services.order_approval_token import (
     ApprovalTokenClaims,
     OrderApprovalTokenSigner,
+    strategy_revision,
 )
 from api.services.orders_service import OrdersService
 from swing_screener.errors import UnprocessableError
@@ -36,6 +37,7 @@ class _Strategies:
     def get_active_strategy(self):
         return {
             "id": self.strategy_id,
+            "updated_at": "2026-07-15T10:00:00",
             "risk": {
                 "account_size": 10_000,
                 "risk_pct": 0.01,
@@ -54,6 +56,7 @@ SIGNER = OrderApprovalTokenSigner(b"k" * 32, ttl_seconds=100)
 
 
 def _token(**updates) -> str:
+    active_strategy = _Strategies().get_active_strategy()
     values = {
         "ticker": "AAPL",
         "order_type": "BUY_LIMIT",
@@ -63,6 +66,7 @@ def _token(**updates) -> str:
         "data_status": "current",
         "data_asof": "2026-07-15",
         "strategy_id": "momentum-v1",
+        "strategy_revision": strategy_revision(active_strategy),
         "account_currency": "EUR",
         "quote_currency": "EUR",
         "account_to_quote_rate": 1,
@@ -130,3 +134,26 @@ def test_ticker_mismatch_and_active_strategy_change_block_entry():
 def test_submitted_quantity_and_prices_are_recomputed_not_overwritten():
     with pytest.raises(UnprocessableError, match="trade_risk"):
         _service().create_order(_request(quantity=30))
+
+
+def test_entry_order_fails_closed_when_signer_is_not_configured():
+    service = OrdersService(_Orders(), _Positions(), strategy_repo=_Strategies())
+
+    with pytest.raises(UnprocessableError, match="signer"):
+        service.create_order(_request())
+
+
+def test_strategy_update_with_same_id_invalidates_token():
+    strategies = _Strategies()
+    original_get = strategies.get_active_strategy
+
+    def changed_strategy():
+        value = original_get()
+        value["updated_at"] = "2026-07-15T11:00:00"
+        value["risk"]["risk_pct"] = 0.005
+        return value
+
+    strategies.get_active_strategy = changed_strategy
+
+    with pytest.raises(UnprocessableError, match="strategy"):
+        _service(strategies).create_order(_request())

--- a/tests/api/test_order_signed_approval.py
+++ b/tests/api/test_order_signed_approval.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import pytest
+
+from api.models.portfolio import CreateOrderRequest
+from api.services.order_approval_token import (
+    ApprovalTokenClaims,
+    OrderApprovalTokenSigner,
+)
+from api.services.orders_service import OrdersService
+from swing_screener.errors import UnprocessableError
+
+
+class _Orders:
+    def __init__(self):
+        self.orders = []
+
+    def list_orders(self, status=None):
+        return self.orders, "2026-07-15"
+
+    def append_order(self, order):
+        self.orders.append(order)
+
+
+class _Positions:
+    def list_positions(self, status=None):
+        return [], "2026-07-15"
+
+
+class _Strategies:
+    strategy_id = "momentum-v1"
+
+    def get_active_strategy_id(self):
+        return self.strategy_id
+
+    def get_active_strategy(self):
+        return {
+            "id": self.strategy_id,
+            "risk": {
+                "account_size": 10_000,
+                "risk_pct": 0.01,
+                "max_position_pct": 0.6,
+                "max_portfolio_heat_pct": 0.06,
+                "min_rr": 2,
+                "commission_pct": 0,
+                "max_fee_risk_pct": 0.2,
+                "max_concentration_pct": 60,
+                "account_currency": "EUR",
+            },
+        }
+
+
+SIGNER = OrderApprovalTokenSigner(b"k" * 32, ttl_seconds=100)
+
+
+def _token(**updates) -> str:
+    values = {
+        "ticker": "AAPL",
+        "order_type": "BUY_LIMIT",
+        "setup_status": "PASS",
+        "trigger_status": "PASS",
+        "plan_status": "PASS",
+        "data_status": "current",
+        "data_asof": "2026-07-15",
+        "strategy_id": "momentum-v1",
+        "account_currency": "EUR",
+        "quote_currency": "EUR",
+        "account_to_quote_rate": 1,
+        "target_source": "structural",
+        "days_to_earnings": 20,
+        "generated_entry": 100,
+        "generated_stop": 95,
+        "generated_target": 112,
+    }
+    values.update(updates)
+    return SIGNER.issue(ApprovalTokenClaims(**values), now=1_000)
+
+
+def _request(**updates) -> CreateOrderRequest:
+    values = {
+        "ticker": "AAPL",
+        "order_type": "BUY_LIMIT",
+        "quantity": 10,
+        "limit_price": 100,
+        "stop_price": 95,
+        "target_price": 112,
+        "approval_token": _token(),
+    }
+    values.update(updates)
+    return CreateOrderRequest(**values)
+
+
+def _service(strategies=None) -> OrdersService:
+    return OrdersService(
+        _Orders(),
+        _Positions(),
+        strategy_repo=strategies or _Strategies(),
+        approval_signer=SIGNER,
+        approval_now=lambda: 1_050,
+    )
+
+
+def test_signed_context_drives_and_audits_entry_approval():
+    order = _service().create_order(
+        _request(trigger_status="BLOCK", data_status="stale")
+    )
+
+    assert order["portfolio_approval"]["approved"] is True
+    assert order["decision_context"]["trigger_status"] == "PASS"
+    assert order["portfolio_approval"]["token_id"]
+    assert order["quote_currency"] == "EUR"
+
+
+@pytest.mark.parametrize("token", [None, "tampered.token"])
+def test_missing_or_tampered_token_blocks_entry(token):
+    with pytest.raises(UnprocessableError, match="approval token"):
+        _service().create_order(_request(approval_token=token))
+
+
+def test_ticker_mismatch_and_active_strategy_change_block_entry():
+    with pytest.raises(UnprocessableError, match="ticker"):
+        _service().create_order(_request(approval_token=_token(ticker="MSFT")))
+
+    strategies = _Strategies()
+    strategies.strategy_id = "momentum-v2"
+    with pytest.raises(UnprocessableError, match="strategy"):
+        _service(strategies).create_order(_request())
+
+
+def test_submitted_quantity_and_prices_are_recomputed_not_overwritten():
+    with pytest.raises(UnprocessableError, match="trade_risk"):
+        _service().create_order(_request(quantity=30))

--- a/tests/api/test_order_stop_limit_validation.py
+++ b/tests/api/test_order_stop_limit_validation.py
@@ -42,3 +42,35 @@ def test_long_entry_stop_below_limit_is_valid():
         order_kind="entry",
     )
     assert order.stop_price == 95.0
+
+
+@pytest.mark.parametrize(
+    ("order_kind", "order_type"),
+    [
+        ("stop", "BUY_LIMIT"),
+        ("take_profit", "BUY_LIMIT"),
+        ("entry", "SELL_STOP"),
+    ],
+)
+def test_order_kind_cannot_bypass_side_validation(order_kind, order_type):
+    with pytest.raises(ValidationError, match="order_kind"):
+        CreateOrderRequest(
+            ticker="AAPL",
+            order_type=order_type,
+            quantity=10,
+            limit_price=100.0,
+            stop_price=95.0,
+            order_kind=order_kind,
+        )
+
+
+def test_entry_order_rejects_nonfinite_target():
+    with pytest.raises(ValidationError, match="finite"):
+        CreateOrderRequest(
+            ticker="AAPL",
+            order_type="BUY_LIMIT",
+            quantity=10,
+            limit_price=100.0,
+            stop_price=95.0,
+            target_price=float("inf"),
+        )

--- a/tests/api/test_position_currency_context.py
+++ b/tests/api/test_position_currency_context.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from api.models.portfolio import CreatePositionRequest
+from api.services.portfolio.write import PortfolioWriteService
+from swing_screener.errors import ValidationError
+
+
+class _Positions:
+    def __init__(self) -> None:
+        self.data = {"positions": [], "asof": "2026-07-15"}
+
+    def update(self, modify):
+        self.data = modify(self.data)
+        return self.data
+
+
+class _Config:
+    def get(self):
+        return SimpleNamespace(risk=SimpleNamespace(account_currency="EUR"))
+
+
+def _request(**updates) -> CreatePositionRequest:
+    values = {
+        "ticker": "AAPL",
+        "entry_price": 200,
+        "stop_price": 190,
+        "shares": 2,
+        "entry_date": "2026-07-15",
+        "quote_currency": "USD",
+        "entry_fx_rate": 1.1,
+    }
+    values.update(updates)
+    return CreatePositionRequest(**values)
+
+
+def test_manual_position_persists_complete_currency_context():
+    service = PortfolioWriteService(_Positions(), config_repo=_Config())
+
+    position = service.create_position(_request())
+
+    assert position.quote_currency == "USD"
+    assert position.account_currency == "EUR"
+    assert position.entry_fx_rate == 1.1
+
+
+def test_manual_cross_currency_position_requires_entry_fx():
+    service = PortfolioWriteService(_Positions(), config_repo=_Config())
+
+    with pytest.raises(ValidationError, match="FX"):
+        service.create_position(_request(entry_fx_rate=None))

--- a/tests/test_strategy_config.py
+++ b/tests/test_strategy_config.py
@@ -18,3 +18,9 @@ def test_build_risk_config_ignores_account_size_mode() -> None:
     assert cfg.account_size == 1000.0
     assert cfg.risk_pct == 0.015
     assert not hasattr(cfg, "account_size_mode")
+
+
+def test_build_risk_config_exposes_explicit_portfolio_heat_limit() -> None:
+    cfg = build_risk_config({"risk": {"max_portfolio_heat_pct": 0.045}})
+
+    assert cfg.max_portfolio_heat_pct == 0.045

--- a/web-ui/src/components/domain/orders/OrderReviewExperience.tsx
+++ b/web-ui/src/components/domain/orders/OrderReviewExperience.tsx
@@ -21,6 +21,7 @@ import { candidateOrderSchema, type CandidateOrderFormValues } from '@/component
 import { getSetupExecutionGuidance } from '@/features/orders/setupGuidance';
 import { normalizeSuggestedOrderType, resolveDefaultOrderType } from '@/features/orders/executionDefaults';
 import { usePortfolioSummary } from '@/features/portfolio/hooks';
+import { isLocalPersistenceMode } from '@/features/persistence';
 import type { CreateOrderRequest } from '@/features/portfolio/types';
 import type { SameSymbolCandidateContext } from '@/features/screener/types';
 import type { RiskConfig } from '@/types/config';
@@ -176,6 +177,8 @@ export default function OrderReviewExperience({
   const stopPrice = form.watch('stopPrice') ?? 0;
   const hasOrderTypeMismatch = hasSuggestedOrderType && orderType !== normalizedSuggestedOrderType;
   const needsOverrideConfirmation = hasOrderTypeMismatch || (hasSkipSuggestion && !isRecommended);
+  const apiApprovalMissing = !isLocalPersistenceMode() && !context.approvalToken;
+  const apiOrderTypeMismatch = !isLocalPersistenceMode() && hasOrderTypeMismatch;
   const invalidBuyStopPrice = orderType === 'BUY_STOP' && knownCurrentPrice != null && limitPrice <= knownCurrentPrice;
   const triggerPriceLabel =
     orderType === 'BUY_STOP' ? t('order.candidateModal.triggerPrice') : t('order.candidateModal.limitPrice');
@@ -259,6 +262,16 @@ export default function OrderReviewExperience({
 
     if (!decisionReady) {
       setSubmissionError('Order blocked: setup, trigger, coherent plan, and current-data gates must pass.');
+      return;
+    }
+
+    if (apiApprovalMissing) {
+      setSubmissionError(t('order.candidateModal.approvalTokenRequired'));
+      return;
+    }
+
+    if (apiOrderTypeMismatch) {
+      setSubmissionError(t('order.candidateModal.approvalOrderTypeMismatch'));
       return;
     }
 
@@ -582,6 +595,8 @@ export default function OrderReviewExperience({
                       (needsOverrideConfirmation && !overrideConfirmed) ||
                       (enforceRecommendation && !isRecommended) ||
                       !decisionReady
+                      || apiApprovalMissing
+                      || apiOrderTypeMismatch
                     }
                     className="w-full sm:w-auto"
                   >

--- a/web-ui/src/components/domain/orders/OrderReviewExperience.tsx
+++ b/web-ui/src/components/domain/orders/OrderReviewExperience.tsx
@@ -57,6 +57,7 @@ export interface OrderReviewContext {
   dataAsOf?: string;
   daysToEarnings?: number | null;
   strategyId?: string;
+  approvalToken?: string;
 }
 
 interface OrderReviewExperienceProps {
@@ -305,6 +306,7 @@ export default function OrderReviewExperience({
         currency: context.currency,
         daysToEarnings: context.daysToEarnings,
         strategyId: context.strategyId,
+        approvalToken: context.approvalToken,
       });
       setSubmitSucceeded(true);
       onSuccess?.();

--- a/web-ui/src/components/domain/workspace/ActionPanel.test.tsx
+++ b/web-ui/src/components/domain/workspace/ActionPanel.test.tsx
@@ -72,6 +72,7 @@ function setCandidate(overrides: Record<string, unknown> = {}) {
           rank: 1,
           lastBar: '2026-03-02',
           dataStatus: 'current',
+          approvalToken: 'signed-candidate-token',
           daysToEarnings: 20,
           signal: 'breakout',
           entry: 100.5,
@@ -162,7 +163,7 @@ describe('ActionPanel', () => {
     expect(screen.getByText(/Breakout already occurred/i)).toBeInTheDocument();
   });
 
-  it('requires override confirmation before submitting a mismatch order type', async () => {
+  it('does not allow a signed candidate order type to be overridden in API mode', async () => {
     const user = userEvent.setup();
     setCandidate({
       suggestedOrderType: 'BUY_STOP',
@@ -177,7 +178,7 @@ describe('ActionPanel', () => {
     expect(submit).toBeDisabled();
 
     await user.click(screen.getByRole('checkbox'));
-    expect(submit).toBeEnabled();
+    expect(submit).toBeDisabled();
   });
 
   it('does not require override confirmation when verdict is recommended but backend guidance is SKIP', () => {

--- a/web-ui/src/components/domain/workspace/ActionPanel.tsx
+++ b/web-ui/src/components/domain/workspace/ActionPanel.tsx
@@ -132,6 +132,7 @@ export default function ActionPanel({ ticker }: ActionPanelProps) {
     dataAsOf: candidate?.dataAsOf ?? candidate?.lastBar,
     daysToEarnings: candidate?.daysToEarnings ?? null,
     strategyId: activeStrategyQuery.data?.id,
+    approvalToken: candidate?.approvalToken,
   };
 
   return (

--- a/web-ui/src/features/portfolio/api.test.ts
+++ b/web-ui/src/features/portfolio/api.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { closePosition, fillOrder, partialClosePosition } from '@/features/portfolio/api';
+import { closePosition, createOrder, fillOrder, partialClosePosition } from '@/features/portfolio/api';
 
 describe('portfolio api', () => {
   beforeEach(() => {
@@ -30,6 +30,23 @@ describe('portfolio api', () => {
         stopPrice: 20.33,
       }),
     ).rejects.toThrow('REP.MC: open position already exists.');
+  });
+
+  it('rejects an API entry order without an approval token before fetching', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      createOrder({
+        ticker: 'AAPL',
+        orderType: 'BUY_LIMIT',
+        quantity: 2,
+        limitPrice: 100,
+        stopPrice: 95,
+        targetPrice: 110,
+      }),
+    ).rejects.toThrow('approval token');
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('serializes close FX rate for backend close requests', async () => {

--- a/web-ui/src/features/portfolio/api.ts
+++ b/web-ui/src/features/portfolio/api.ts
@@ -217,6 +217,9 @@ export async function createOrder(request: CreateOrderRequest): Promise<void> {
     createOrderLocal(request);
     return;
   }
+  if ((request.orderKind ?? 'entry') === 'entry' && !request.approvalToken) {
+    throw new Error('Entry order approval token is required. Refresh the screener candidate and try again.');
+  }
   await fetchJson<void>(API_ENDPOINTS.orders, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },

--- a/web-ui/src/features/screener/types.ts
+++ b/web-ui/src/features/screener/types.ts
@@ -178,6 +178,7 @@ export interface CandidateDataSourceSummary {
 
 export interface ScreenerCandidate {
   ticker: string;
+  approvalToken?: string;
   currency: string;
   exchangeMic?: string;
   instrumentType?: 'equity' | 'etf' | string;
@@ -301,6 +302,7 @@ export interface DecisionSummaryAPI {
 // API response format (snake_case)
 export interface ScreenerCandidateAPI {
   ticker: string;
+  approval_token?: string | null;
   currency?: string;
   exchange_mic?: string;
   instrument_type?: string;
@@ -572,6 +574,7 @@ export function transformScreenerResponse(apiResponse: ScreenerResponseAPI): Scr
   return {
     candidates: apiResponse.candidates.map(c => ({
       ticker: c.ticker,
+      approvalToken: c.approval_token ?? undefined,
       currency: c.currency ?? 'UNKNOWN',
       exchangeMic: c.exchange_mic,
       instrumentType: c.instrument_type,

--- a/web-ui/src/i18n/messages.en.ts
+++ b/web-ui/src/i18n/messages.en.ts
@@ -369,6 +369,8 @@ export const messagesEn = {
       liquiditySlippageWarning: 'Order size is {{pct}}% of avg daily volume — expect slippage.',
       overrideConfirm: 'I understand this differs from guidance and want to continue.',
       overrideRequired: 'Please confirm the override before submitting this order.',
+      approvalTokenRequired: 'This candidate has no current server approval. Refresh the screener before submitting an entry order.',
+      approvalOrderTypeMismatch: 'The selected order type differs from the signed candidate approval. Use the suggested order type or refresh the screener.',
       buyStopHint: 'Buy Stop entries may appear as "Stop Loss" on the buy side in some brokers.',
       buyStopTerminologyTooltip: 'A Buy Stop entry can appear as "Stop Loss" under Buy orders in some brokers.',
       buyStopAboveMarketError: 'Buy Stop trigger must be above current price ({{currentPrice}}).',

--- a/web-ui/src/types/order.test.ts
+++ b/web-ui/src/types/order.test.ts
@@ -187,16 +187,7 @@ describe('Order Type Transformations', () => {
         position_id: undefined,
         isin: null,
         thesis: null,
-        setup_status: 'UNKNOWN',
-        trigger_status: 'UNKNOWN',
-        data_status: 'unknown',
-        data_asof: null,
-        target_source: 'unknown',
-        sector: null,
-        currency: null,
-        account_to_quote_rate: null,
-        days_to_earnings: null,
-        strategy_id: null,
+        approval_token: null,
       })
     })
 

--- a/web-ui/src/types/order.ts
+++ b/web-ui/src/types/order.ts
@@ -54,6 +54,7 @@ export interface CreateOrderRequest {
   accountToQuoteRate?: number;
   daysToEarnings?: number | null;
   strategyId?: string;
+  approvalToken?: string;
 }
 
 export interface CreateOrderRequestApi {
@@ -69,16 +70,7 @@ export interface CreateOrderRequestApi {
   entry_mode: EntryMode;
   isin: string | null;
   thesis: string | null;
-  setup_status: 'PASS' | 'BLOCK' | 'UNKNOWN';
-  trigger_status: 'PASS' | 'WAIT' | 'BLOCK' | 'UNKNOWN';
-  data_status: 'current' | 'stale' | 'intraday' | 'unknown';
-  data_asof: string | null;
-  target_source: 'structural' | 'manual' | 'unknown' | 'unvalidated_r_multiple';
-  sector: string | null;
-  currency: string | null;
-  account_to_quote_rate: number | null;
-  days_to_earnings: number | null;
-  strategy_id: string | null;
+  approval_token: string | null;
 }
 
 export interface FillOrderRequest {
@@ -284,15 +276,6 @@ export function transformCreateOrderRequest(req: CreateOrderRequest): CreateOrde
     entry_mode: req.entryMode || 'NEW_ENTRY',
     isin: req.isin ?? null,
     thesis: req.thesis ?? null,
-    setup_status: req.setupStatus ?? 'UNKNOWN',
-    trigger_status: req.triggerStatus ?? 'UNKNOWN',
-    data_status: req.dataStatus ?? 'unknown',
-    data_asof: req.dataAsOf ?? null,
-    target_source: req.targetSource ?? 'unknown',
-    sector: req.sector ?? null,
-    currency: req.currency ?? null,
-    account_to_quote_rate: req.accountToQuoteRate ?? null,
-    days_to_earnings: req.daysToEarnings ?? null,
-    strategy_id: req.strategyId ?? null,
+    approval_token: req.approvalToken ?? null,
   };
 }


### PR DESCRIPTION
## Stack

PR 2 of 3.

Depends on #426. Base branch: `feat/backend-auth-boundary`.

Next: #428.

## What changed

- Issues short-lived HMAC approval tokens for actionable screener candidates.
- Binds approvals to ticker, strategy revision, decision gates, currency, FX, event context, and target provenance.
- Recomputes quantity, reward/risk, risk amount, position cap, cash, heat, fees, and exposure on the server.
- Fails closed for missing signing configuration, missing FX, mixed account currencies, invalid order-kind/type combinations, and non-finite values.
- Supports authoritative add-on blended FX basis and manual position currency context.
- Adds API-mode frontend approval preflight and order-type alignment.

## Why

Entry orders previously trusted client-supplied approval and portfolio calculations. Free-form order kinds and incomplete currency context could bypass server risk policy.

## Impact

An entry order is accepted only when a fresh signed candidate context and the current authoritative portfolio state both pass policy. Country concentration remains an explicit warning rather than an accidental hard block.

## Validation

Final stacked-head verification:

- Backend/API/database: 439 passed, 1 skipped.
- Frontend: 719 passed.
- Stack-changed Python files pass Ruff; TypeScript typecheck, ESLint, and the production Vite build passed.
- Independent review findings covering order-kind bypasses, signer configuration, strategy revisions, currencies, FX, and finite-value validation were addressed.