### PR TITLE
Release v3.0.0: transactional portfolio state

### DIFF
--- a/alembic/versions/20260721_0002_legacy_import_lock.py
+++ b/alembic/versions/20260721_0002_legacy_import_lock.py
@@ -1,0 +1,29 @@
+"""Serialize legacy JSON import across application instances.
+
+Revision ID: 20260721_0002
+Revises: 20260715_0001
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260721_0002"
+down_revision = "20260715_0001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "legacy_import_lock",
+        sa.Column("id", sa.Integer(), primary_key=True),
+    )
+    op.bulk_insert(
+        sa.table("legacy_import_lock", sa.column("id", sa.Integer())),
+        [{"id": 1}],
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("legacy_import_lock")

--- a/api/README.md
+++ b/api/README.md
@@ -56,9 +56,17 @@ Docs:
   and position mutation commit or roll back together.
 - `data/orders.json` and `data/positions.json` are import-only legacy sources.
   They are validated and imported once into an empty schema, recorded with row
-  counts and SHA-256 checksums, and are never changed or dual-written.
-- Order create and fill require `Idempotency-Key`. Replaying the same request
-  returns its stored response; reusing a key for different input returns `409`.
+  counts and SHA-256 checksums, and are never changed or dual-written. A
+  migration-created singleton lock serializes import classification and writes
+  across application instances, so concurrent startup returns the committed
+  import report instead of attempting a second import.
+- Order create/fill and every persisted position write require `Idempotency-Key`.
+  Replaying the same request returns its stored response; reusing a key for
+  different input returns `409`. Stop-price market-data validation runs before
+  the idempotent write transaction, then the persisted update is rechecked and
+  reserved atomically.
+- `DATABASE_URL` accepts `postgres://` and `postgresql://`; both are normalized
+  to SQLAlchemy's `postgresql+psycopg://` dialect URL.
 
 ## Database Operations
 
@@ -91,7 +99,9 @@ counts against the JSON documents and verify `/health/ready` reports
 `connectivity=ok`, `migration=ok`, and `legacy_import=complete`. Startup refuses
 to serve when the schema is stale or the import ledger is incomplete.
 
-If readiness reports a partial import state, stop the application. Restore the
+`/health` and `/health/ready` also check that the frozen legacy JSON files and
+their parent directory remain readable and writable. `/health/live` remains a
+dependency-free process liveness check. If readiness reports a partial import state, stop the application. Restore the
 database backup, confirm that all portfolio and import-ledger tables reflect the
 same point in time, rerun `alembic upgrade head`, and retry the importer. Do not
 manually add a ledger row to populated tables. Returning to a release that

--- a/api/db/import_legacy.py
+++ b/api/db/import_legacy.py
@@ -142,6 +142,17 @@ def validate_legacy_sources(
     )
 
 
+def _report_from_ledger(ledger: LegacyImportRow) -> LegacyImportReport:
+    return LegacyImportReport(
+        state=LegacyImportState.COMPLETE,
+        imported=False,
+        order_count=ledger.order_count,
+        position_count=ledger.position_count,
+        orders_sha256=ledger.orders_sha256,
+        positions_sha256=ledger.positions_sha256,
+    )
+
+
 def import_legacy_portfolio(
     uow_factory: UowFactory,
     orders_path: Path,
@@ -153,14 +164,7 @@ def import_legacy_portfolio(
         if state is LegacyImportState.COMPLETE:
             ledger = uow.session.scalar(select(LegacyImportRow))
             assert ledger is not None
-            return LegacyImportReport(
-                state=state,
-                imported=False,
-                order_count=ledger.order_count,
-                position_count=ledger.position_count,
-                orders_sha256=ledger.orders_sha256,
-                positions_sha256=ledger.positions_sha256,
-            )
+            return _report_from_ledger(ledger)
         if state is LegacyImportState.PARTIAL:
             raise LegacyImportStateError(
                 "Legacy import state is partial; restore a database backup or clear all portfolio tables and retry"
@@ -175,7 +179,12 @@ def import_legacy_portfolio(
 
     with uow_factory() as uow:
         uow.begin_write()
+        uow.lock_legacy_import()
         state = classify_import_state(uow.session)
+        if state is LegacyImportState.COMPLETE:
+            ledger = uow.session.scalar(select(LegacyImportRow))
+            assert ledger is not None
+            return _report_from_ledger(ledger)
         if state is not LegacyImportState.EMPTY:
             raise LegacyImportStateError(
                 f"Legacy import state changed to {state.value}; no rows were imported"

--- a/api/db/models.py
+++ b/api/db/models.py
@@ -130,3 +130,11 @@ class LegacyImportRow(Base):
     imported_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )
+
+
+class LegacyImportLockRow(Base):
+    """Singleton row used to serialize legacy import across app instances."""
+
+    __tablename__ = "legacy_import_lock"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, default=1)

--- a/api/db/settings.py
+++ b/api/db/settings.py
@@ -17,6 +17,8 @@ def _boolean(value: str | None) -> bool:
 
 
 def normalize_database_url(url: str) -> str:
+    if url.startswith("postgres://"):
+        return "postgresql+psycopg://" + url.removeprefix("postgres://")
     if url.startswith("postgresql://"):
         return "postgresql+psycopg://" + url.removeprefix("postgresql://")
     return url

--- a/api/db/unit_of_work.py
+++ b/api/db/unit_of_work.py
@@ -8,7 +8,7 @@ from typing import Self
 from sqlalchemy import select
 from sqlalchemy.orm import Session, sessionmaker
 
-from api.db.models import LegacyImportRow
+from api.db.models import LegacyImportLockRow, LegacyImportRow
 from api.db.repositories import (
     SqlIdempotencyRepository,
     SqlOrdersRepository,
@@ -51,6 +51,16 @@ class PortfolioUnitOfWork:
         )
         if ledger is None:
             raise RuntimeError("Portfolio import ledger is missing.")
+
+    def lock_legacy_import(self) -> None:
+        """Serialize legacy import before inspecting or changing portfolio state."""
+        lock = self.session.scalar(
+            select(LegacyImportLockRow)
+            .where(LegacyImportLockRow.id == 1)
+            .with_for_update()
+        )
+        if lock is None:
+            raise RuntimeError("Portfolio import lock is missing.")
 
     def __exit__(
         self,

--- a/api/main.py
+++ b/api/main.py
@@ -42,6 +42,7 @@ from api.security.openapi import install_security_openapi
 from api.security.settings import get_auth_settings
 from api.db.readiness import check_database_readiness
 from api.dependencies import get_database_runtime
+from api.monitoring import HealthChecker
 
 LOG_FORMAT = "%(asctime)s %(levelname)s [%(name)s] %(message)s"
 logging.basicConfig(level=logging.INFO, format=LOG_FORMAT, stream=sys.stdout)
@@ -175,7 +176,7 @@ def register_domain_error_handler(target_app) -> None:
 app = FastAPI(
     title="Swing Screener API",
     description="REST API for the Swing Screener trading system",
-    version="0.1.0",
+    version="3.0.0",
     lifespan=lifespan,
     docs_url="/docs" if AUTH_SETTINGS.api_docs_enabled else None,
     redoc_url="/redoc" if AUTH_SETTINGS.api_docs_enabled else None,
@@ -270,7 +271,7 @@ async def root():
     return {
         "status": "ok",
         "service": "swing-screener-api",
-        "version": "0.1.0",
+        "version": "3.0.0",
         "api": "/api",
         "health": "/health",
         "docs": "/docs",
@@ -283,7 +284,7 @@ async def api_root():
     return {
         "status": "ok",
         "service": "swing-screener-api",
-        "version": "0.1.0",
+        "version": "3.0.0",
         "health": "/health",
         "docs": "/docs",
     }
@@ -298,10 +299,11 @@ async def liveness():
 @app.get("/health")
 @app.get("/health/ready")
 async def health_check():
-    """Return readiness for the database, migration, and legacy import."""
+    """Return readiness for SQL state and the frozen legacy source files."""
     from api.monitoring import get_metrics_collector
 
     metrics = get_metrics_collector().get_metrics()
+    legacy_state = HealthChecker.check_file_access()
     try:
         readiness = check_database_readiness(get_database_runtime())
     except Exception as exc:
@@ -317,19 +319,34 @@ async def health_check():
                         "connectivity": "error",
                         "migration": "unknown",
                         "legacy_import": "unknown",
-                    }
+                    },
+                    "legacy_state": legacy_state,
                 },
-                "details": {"database": "Portfolio database is unavailable."},
+                "details": {
+                    "database": "Portfolio database is unavailable.",
+                    **(
+                        {"legacy_state": "; ".join(legacy_state["issues"])}
+                        if legacy_state["issues"]
+                        else {}
+                    ),
+                },
                 "metrics": metrics,
             },
         )
 
+    healthy = readiness.healthy and legacy_state["status"] == "healthy"
+    details = dict(readiness.details)
+    if legacy_state["issues"]:
+        details["legacy_state"] = "; ".join(legacy_state["issues"])
     return JSONResponse(
-        status_code=200 if readiness.healthy else 503,
+        status_code=200 if healthy else 503,
         content={
-            "status": "healthy" if readiness.healthy else "unhealthy",
-            "checks": {"database": readiness.checks},
-            "details": readiness.details or None,
+            "status": "healthy" if healthy else "unhealthy",
+            "checks": {
+                "database": readiness.checks,
+                "legacy_state": legacy_state,
+            },
+            "details": details or None,
             "metrics": metrics,
         },
     )

--- a/api/routers/portfolio.py
+++ b/api/routers/portfolio.py
@@ -85,10 +85,14 @@ async def get_positions(
 @router.post("/positions", response_model=Position)
 async def create_position(
     request: CreatePositionRequest,
+    http_request: Request,
+    idempotency_key: str = Depends(require_idempotency_key),
     service: PortfolioService = Depends(get_portfolio_service),
 ):
     """Register a position manually after a DeGiro fill."""
-    return service.create_position(request)
+    return service.create_position(
+        request, idempotency_key=idempotency_key, subject=_subject(http_request)
+    )
 
 
 @router.get("/positions/open/intelligence", response_model=list[OpenPositionIntelligenceSummary])
@@ -150,10 +154,17 @@ async def get_position_metrics(
 async def update_position_stop(
     position_id: str,
     request: UpdateStopRequest,
+    http_request: Request,
+    idempotency_key: str = Depends(require_idempotency_key),
     service: PortfolioService = Depends(get_portfolio_service),
 ):
     """Update stop price for a position."""
-    return service.update_position_stop(position_id, request)
+    return service.update_position_stop(
+        position_id,
+        request,
+        idempotency_key=idempotency_key,
+        subject=_subject(http_request),
+    )
 
 
 @router.get("/positions/{position_id}/stop-suggestion", response_model=PositionUpdate)
@@ -179,10 +190,17 @@ async def get_position_stop_preview(
 async def update_position_trail_method(
     position_id: str,
     request: UpdateTrailMethodRequest,
+    http_request: Request,
+    idempotency_key: str = Depends(require_idempotency_key),
     service: PortfolioService = Depends(get_portfolio_service),
 ):
     """Update trail stop method for an open position."""
-    return service.update_trail_method(position_id, request)
+    return service.update_trail_method(
+        position_id,
+        request,
+        idempotency_key=idempotency_key,
+        subject=_subject(http_request),
+    )
 
 
 @router.post("/stop-suggestion/compute", response_model=PositionUpdate)
@@ -201,20 +219,34 @@ async def compute_position_stop_suggestion(
 async def close_position(
     position_id: str,
     request: ClosePositionRequest,
+    http_request: Request,
+    idempotency_key: str = Depends(require_idempotency_key),
     service: PortfolioService = Depends(get_portfolio_service),
 ):
     """Close a position."""
-    return service.close_position(position_id, request)
+    return service.close_position(
+        position_id,
+        request,
+        idempotency_key=idempotency_key,
+        subject=_subject(http_request),
+    )
 
 
 @router.post("/positions/{position_id}/partial-close")
 async def partial_close_position(
     position_id: str,
     request: PartialCloseRequest,
+    http_request: Request,
+    idempotency_key: str = Depends(require_idempotency_key),
     service: PortfolioService = Depends(get_portfolio_service),
 ):
     """Partially close an open position by closing a subset of shares."""
-    return service.partial_close_position(position_id, request)
+    return service.partial_close_position(
+        position_id,
+        request,
+        idempotency_key=idempotency_key,
+        subject=_subject(http_request),
+    )
 
 
 @router.get("/summary", response_model=PortfolioSummary)

--- a/api/services/portfolio/write.py
+++ b/api/services/portfolio/write.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import uuid
+from dataclasses import dataclass
 from decimal import Decimal, ROUND_HALF_UP
 from typing import Callable, Optional
 
@@ -30,6 +31,14 @@ logger = logging.getLogger(__name__)
 
 def _round_price(value: float) -> float:
     return float(Decimal(str(value)).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP))
+
+
+@dataclass(frozen=True)
+class PreparedStopUpdate:
+    position_id: str
+    request: UpdateStopRequest
+    old_stop: float
+    new_stop: float
 
 
 class PortfolioWriteService:
@@ -99,9 +108,10 @@ class PortfolioWriteService:
 
         return Position(**new_position)
 
-    def update_position_stop(
+    def prepare_position_stop(
         self, position_id: str, request: UpdateStopRequest
-    ) -> dict:
+    ) -> PreparedStopUpdate:
+        """Validate a stop update before acquiring the portfolio write lock."""
         new_stop = _round_price(request.new_stop)
 
         # Validate against a snapshot first (the price fetch is network I/O and must
@@ -141,6 +151,20 @@ class PortfolioWriteService:
                 f"({current_price}) for long positions",
             )
 
+        return PreparedStopUpdate(
+            position_id=position_id,
+            request=request,
+            old_stop=old_stop,
+            new_stop=new_stop,
+        )
+
+    def apply_position_stop(self, prepared: PreparedStopUpdate) -> dict:
+        """Persist a previously validated stop update under the write lock."""
+        position_id = prepared.position_id
+        request = prepared.request
+        old_stop = prepared.old_stop
+        new_stop = prepared.new_stop
+
         result: dict[str, float] = {}
 
         def _modify(data: dict) -> dict:
@@ -177,6 +201,11 @@ class PortfolioWriteService:
             "new_stop": new_stop,
             "old_stop": result["old_stop"],
         }
+
+    def update_position_stop(
+        self, position_id: str, request: UpdateStopRequest
+    ) -> dict:
+        return self.apply_position_stop(self.prepare_position_stop(position_id, request))
 
     def close_position(self, position_id: str, request: ClosePositionRequest) -> dict:
         def _modify(data: dict) -> dict:

--- a/api/services/portfolio_service.py
+++ b/api/services/portfolio_service.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
+from collections.abc import Callable
 from typing import Optional
 
 import pandas as pd
+from sqlalchemy.exc import IntegrityError
 
+from swing_screener.errors import ConflictError, UnprocessableError
 from api.models.portfolio import (
     ClosePositionRequest,
     CreatePositionRequest,
@@ -62,6 +67,97 @@ class PortfolioService:
             self._positions_repo, self._provider, self._config_repo
         )
 
+    @staticmethod
+    def _idempotency_hash(
+        *, subject: str, operation: str, resource: str, body: dict
+    ) -> str:
+        canonical = json.dumps(
+            {
+                "subject": subject,
+                "operation": operation,
+                "resource": resource,
+                "body": body,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+        ).encode("utf-8")
+        return hashlib.sha256(canonical).hexdigest()
+
+    def _stored_idempotent_response(
+        self, *, idempotency_key: str, request_hash: str
+    ) -> dict | None:
+        assert self._uow is not None
+        existing = self._uow.idempotency.get(idempotency_key)
+        if existing is None:
+            self._uow.session.rollback()
+            self._uow.write_started = False
+            return None
+        if existing.request_hash != request_hash:
+            raise ConflictError("Idempotency-Key was already used for a different request.")
+        response = dict(existing.response)
+        self._uow.session.rollback()
+        self._uow.write_started = False
+        return response
+
+    def _recover_idempotency_race(
+        self, *, idempotency_key: str, request_hash: str
+    ) -> dict:
+        assert self._uow is not None
+        self._uow.session.rollback()
+        self._uow.write_started = False
+        existing = self._uow.idempotency.get(idempotency_key)
+        if existing is None:
+            raise ConflictError("Concurrent idempotent request could not be replayed.")
+        if existing.request_hash != request_hash:
+            raise ConflictError("Idempotency-Key was already used for a different request.")
+        return dict(existing.response)
+
+    def _run_idempotent_write(
+        self,
+        *,
+        operation: str,
+        resource: str,
+        body: dict,
+        idempotency_key: str | None,
+        subject: str,
+        action: Callable[[], dict],
+    ) -> dict:
+        if self._uow is None:
+            return action()
+        if not idempotency_key:
+            raise UnprocessableError("Idempotency-Key is required.")
+        request_hash = self._idempotency_hash(
+            subject=subject, operation=operation, resource=resource, body=body
+        )
+        self._uow.begin_write()
+        existing = self._uow.idempotency.get(idempotency_key)
+        if existing is not None:
+            if existing.request_hash != request_hash:
+                raise ConflictError(
+                    "Idempotency-Key was already used for a different request."
+                )
+            return dict(existing.response)
+        try:
+            reservation = self._uow.idempotency.add(
+                operation=operation,
+                key=idempotency_key,
+                request_hash=request_hash,
+                subject=subject,
+                resource=resource,
+                status_code=0,
+                response={},
+            )
+        except IntegrityError:
+            return self._recover_idempotency_race(
+                idempotency_key=idempotency_key, request_hash=request_hash
+            )
+        response = action()
+        self._uow.idempotency.complete(
+            reservation, status_code=200, response=response
+        )
+        return response
+
     def fetch_recent_ohlcv(
         self, ticker: str, *, lookback_days: int = 400
     ) -> pd.DataFrame:
@@ -94,26 +190,104 @@ class PortfolioService:
     def get_earnings_proximity(self, ticker: str) -> EarningsProximityResponse:
         return self._pricing.get_earnings_proximity(ticker)
 
-    def create_position(self, request: CreatePositionRequest) -> Position:
-        return self._write.create_position(request)
+    def create_position(
+        self,
+        request: CreatePositionRequest,
+        *,
+        idempotency_key: str | None = None,
+        subject: str = "local",
+    ) -> Position:
+        response = self._run_idempotent_write(
+            operation="create_position",
+            resource="positions",
+            body=request.model_dump(mode="json"),
+            idempotency_key=idempotency_key,
+            subject=subject,
+            action=lambda: self._write.create_position(request).model_dump(mode="json"),
+        )
+        return Position.model_validate(response)
 
     def update_position_stop(
-        self, position_id: str, request: UpdateStopRequest
+        self,
+        position_id: str,
+        request: UpdateStopRequest,
+        *,
+        idempotency_key: str | None = None,
+        subject: str = "local",
     ) -> dict:
-        return self._write.update_position_stop(position_id, request)
+        body = request.model_dump(mode="json")
+        if self._uow is not None and idempotency_key:
+            request_hash = self._idempotency_hash(
+                subject=subject,
+                operation="update_position_stop",
+                resource=position_id,
+                body=body,
+            )
+            stored = self._stored_idempotent_response(
+                idempotency_key=idempotency_key, request_hash=request_hash
+            )
+            if stored is not None:
+                return stored
+        prepared = self._write.prepare_position_stop(position_id, request)
+        return self._run_idempotent_write(
+            operation="update_position_stop",
+            resource=position_id,
+            body=body,
+            idempotency_key=idempotency_key,
+            subject=subject,
+            action=lambda: self._write.apply_position_stop(prepared),
+        )
 
-    def close_position(self, position_id: str, request: ClosePositionRequest) -> dict:
-        return self._write.close_position(position_id, request)
+    def close_position(
+        self,
+        position_id: str,
+        request: ClosePositionRequest,
+        *,
+        idempotency_key: str | None = None,
+        subject: str = "local",
+    ) -> dict:
+        return self._run_idempotent_write(
+            operation="close_position",
+            resource=position_id,
+            body=request.model_dump(mode="json"),
+            idempotency_key=idempotency_key,
+            subject=subject,
+            action=lambda: self._write.close_position(position_id, request),
+        )
 
     def partial_close_position(
-        self, position_id: str, request: PartialCloseRequest
+        self,
+        position_id: str,
+        request: PartialCloseRequest,
+        *,
+        idempotency_key: str | None = None,
+        subject: str = "local",
     ) -> dict:
-        return self._write.partial_close_position(position_id, request)
+        return self._run_idempotent_write(
+            operation="partial_close_position",
+            resource=position_id,
+            body=request.model_dump(mode="json"),
+            idempotency_key=idempotency_key,
+            subject=subject,
+            action=lambda: self._write.partial_close_position(position_id, request),
+        )
 
     def update_trail_method(
-        self, position_id: str, request: UpdateTrailMethodRequest
+        self,
+        position_id: str,
+        request: UpdateTrailMethodRequest,
+        *,
+        idempotency_key: str | None = None,
+        subject: str = "local",
     ) -> dict:
-        return self._write.update_trail_method(position_id, request)
+        return self._run_idempotent_write(
+            operation="update_trail_method",
+            resource=position_id,
+            body=request.model_dump(mode="json"),
+            idempotency_key=idempotency_key,
+            subject=subject,
+            action=lambda: self._write.update_trail_method(position_id, request),
+        )
 
     def compute_position_stop_suggestion(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "swing-screener"
-version = "0.1.0"
+version = "3.0.0"
 description = "Modular swing trading screener and ranking framework"
 readme = "README.md"
 requires-python = ">=3.10,<4.0"

--- a/tests/api/test_portfolio_idempotency.py
+++ b/tests/api/test_portfolio_idempotency.py
@@ -136,6 +136,54 @@ def test_concurrent_identical_fill_replays_one_atomic_mutation(client):
     assert len(positions) == 1
 
 
+def _manual_position_payload():
+    return {
+        "ticker": "MSFT",
+        "entry_price": 100,
+        "stop_price": 95,
+        "shares": 10,
+        "entry_date": "2026-07-15",
+        "quote_currency": "USD",
+        "account_currency": "EUR",
+        "entry_fx_rate": 1.1,
+    }
+
+
+def test_position_writes_require_an_idempotency_key(client):
+    response = client.post("/api/portfolio/positions", json=_manual_position_payload())
+
+    assert response.status_code == 422
+
+
+def test_identical_partial_close_retry_replays_without_second_share_reduction(client):
+    created = client.post(
+        "/api/portfolio/positions",
+        json=_manual_position_payload(),
+        headers={"Idempotency-Key": "create-msft-position"},
+    )
+    assert created.status_code == 200
+    position_id = created.json()["position_id"]
+    payload = {"shares_closed": 3, "price": 110, "fee_eur": 0.5, "fx_rate": 1.1}
+    headers = {"Idempotency-Key": "partial-close-msft"}
+
+    first = client.post(
+        f"/api/portfolio/positions/{position_id}/partial-close",
+        json=payload,
+        headers=headers,
+    )
+    second = client.post(
+        f"/api/portfolio/positions/{position_id}/partial-close",
+        json=payload,
+        headers=headers,
+    )
+
+    assert first.status_code == second.status_code == 200
+    assert first.json() == second.json()
+    position = client.get(f"/api/portfolio/positions/{position_id}").json()
+    assert position["shares"] == 7
+    assert len(position["partial_closes"]) == 1
+
+
 def test_reusing_key_for_another_operation_returns_conflict(client):
     key = {"Idempotency-Key": "cross-operation-key"}
     created = client.post(

--- a/tests/api/test_position_close_endpoint.py
+++ b/tests/api/test_position_close_endpoint.py
@@ -54,6 +54,7 @@ def test_close_position_persists_optional_fee(monkeypatch, tmp_path):
             "fee_eur": 4.90,
             "reason": "Stop loss executed on broker",
         },
+        headers={"Idempotency-Key": "close-engi-1"},
     )
 
     assert response.status_code == 200

--- a/tests/api/test_trade_tagging.py
+++ b/tests/api/test_trade_tagging.py
@@ -40,6 +40,7 @@ def test_close_with_tags_stores_tags(client_with_open_position):
             "exit_price": 110.0,
             "tags": ["breakout", "stop_hit"],
         },
+        headers={"Idempotency-Key": "close-tagged-position"},
     )
     assert response.status_code == 200
 
@@ -52,6 +53,7 @@ def test_close_without_tags_stores_empty_list(client_with_open_position):
     response = client_with_open_position.post(
         "/api/portfolio/positions/POS-TAG-001/close",
         json={"exit_price": 110.0},
+        headers={"Idempotency-Key": "close-untagged-position"},
     )
     assert response.status_code == 200
 

--- a/tests/api/test_trail_customization.py
+++ b/tests/api/test_trail_customization.py
@@ -36,6 +36,7 @@ def test_patch_trail_method_persists(client, tmp_path):
     response = client.patch(
         "/api/portfolio/positions/POS-001/trail-method",
         json={"trail_method": "atr", "trail_param": 2.5},
+        headers={"Idempotency-Key": "trail-atr"},
     )
     assert response.status_code == 200
     assert response.json()["trail_method"] == "atr"
@@ -52,6 +53,7 @@ def test_patch_trail_method_manual(client, tmp_path):
     response = client.patch(
         "/api/portfolio/positions/POS-001/trail-method",
         json={"trail_method": "manual", "trail_param": None},
+        headers={"Idempotency-Key": "trail-manual"},
     )
     assert response.status_code == 200
     stored_response = client.get("/api/portfolio/positions/POS-001")
@@ -66,6 +68,7 @@ def test_patch_trail_method_invalid_value(client):
     response = client.patch(
         "/api/portfolio/positions/POS-001/trail-method",
         json={"trail_method": "unknown_method"},
+        headers={"Idempotency-Key": "trail-invalid"},
     )
     assert response.status_code == 422
 
@@ -74,6 +77,7 @@ def test_patch_trail_method_not_found(client):
     response = client.patch(
         "/api/portfolio/positions/DOES-NOT-EXIST/trail-method",
         json={"trail_method": "sma20"},
+        headers={"Idempotency-Key": "trail-missing"},
     )
     assert response.status_code == 404
 
@@ -108,6 +112,7 @@ def test_patch_trail_method_closed_position_rejected(client_closed):
     response = client_closed.patch(
         "/api/portfolio/positions/POS-CLOSED/trail-method",
         json={"trail_method": "atr", "trail_param": 2.0},
+        headers={"Idempotency-Key": "trail-closed"},
     )
     assert response.status_code == 400
 
@@ -116,6 +121,7 @@ def test_positions_list_returns_trail_method(client):
     client.patch(
         "/api/portfolio/positions/POS-001/trail-method",
         json={"trail_method": "fixed_pct", "trail_param": 5.0},
+        headers={"Idempotency-Key": "trail-fixed-pct"},
     )
     response = client.get("/api/portfolio/positions?status=open")
     assert response.status_code == 200

--- a/tests/db/test_legacy_import.py
+++ b/tests/db/test_legacy_import.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import hashlib
 import json
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier, local
 
 import pytest
 from sqlalchemy import delete
@@ -92,6 +94,43 @@ def test_imports_empty_database_once_with_checksums_and_preserves_sources(
     )
     assert repeated.imported is False
     assert orders_path.read_bytes() == original_orders
+
+
+def test_concurrent_import_replays_completed_ledger(runtime, tmp_path):
+    """Two startup processes must not race between EMPTY and COMPLETE."""
+    orders_path, positions_path = _write_pair(
+        tmp_path, orders=[_order()], positions=[_position()]
+    )
+    barrier = Barrier(2)
+    state = local()
+
+    class SynchronizedUnitOfWork:
+        def __init__(self):
+            self._inner = PortfolioUnitOfWork(runtime.session_factory)
+
+        def __enter__(self):
+            entered = self._inner.__enter__()
+            if not getattr(state, "first_context_entered", False):
+                state.first_context_entered = True
+                barrier.wait(timeout=5)
+            return entered
+
+        def __exit__(self, *args):
+            return self._inner.__exit__(*args)
+
+    def import_once(_index: int):
+        return import_legacy_portfolio(
+            SynchronizedUnitOfWork,
+            orders_path,
+            positions_path,
+            "20260715_0001",
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        reports = list(executor.map(import_once, range(2)))
+
+    assert {report.imported for report in reports} == {True, False}
+    assert all(report.state is LegacyImportState.COMPLETE for report in reports)
 
 
 def test_invalid_row_rolls_back_everything(runtime, tmp_path):

--- a/tests/db/test_migrations.py
+++ b/tests/db/test_migrations.py
@@ -25,6 +25,11 @@ def test_database_settings_default_and_postgres_normalization():
     )
     assert settings.url == "postgresql+psycopg://u:p@db/app"
     settings.validate_runtime()
+    legacy_settings = DatabaseSettings.from_env(
+        {"APP_ENV": "production", "DATABASE_URL": "postgres://u:p@db/app"}
+    )
+    assert legacy_settings.url == "postgresql+psycopg://u:p@db/app"
+    legacy_settings.validate_runtime()
 
 
 def test_production_requires_database_url_and_rejects_sqlite_by_default():
@@ -57,6 +62,7 @@ def test_upgrade_downgrade_upgrade_creates_relational_schema(tmp_path):
         "portfolio_positions",
         "idempotency_records",
         "legacy_imports",
+        "legacy_import_lock",
         "alembic_version",
     } <= set(inspector.get_table_names())
 

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -126,6 +126,38 @@ class TestHealthCheck:
         assert response.json()["status"] == "unhealthy"
 
 
+    def test_readiness_reports_unhealthy_legacy_state_files(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setattr("api.main.get_database_runtime", lambda: object())
+        monkeypatch.setattr(
+            "api.main.check_database_readiness",
+            lambda _runtime: DatabaseReadiness(
+                healthy=True,
+                checks={
+                    "connectivity": "ok",
+                    "migration": "ok",
+                    "legacy_import": "complete",
+                },
+            ),
+        )
+        monkeypatch.setattr(
+            HealthChecker,
+            "check_file_access",
+            lambda: {
+                "status": "unhealthy",
+                "positions_file": "error",
+                "orders_file": "ok",
+                "issues": ["data/positions.json: permission denied"],
+            },
+        )
+
+        response = client.get("/health/ready")
+
+        assert response.status_code == 503
+        assert response.json()["checks"]["legacy_state"]["status"] == "unhealthy"
+
+
 class TestMetrics:
     """Test metrics endpoint."""
 

--- a/uv.lock
+++ b/uv.lock
@@ -2642,7 +2642,7 @@ wheels = [
 
 [[package]]
 name = "swing-screener"
-version = "0.1.0"
+version = "3.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/web-ui/package-lock.json
+++ b/web-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "swing-screener-web",
-  "version": "0.1.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "swing-screener-web",
-      "version": "0.1.0",
+      "version": "3.0.0",
       "dependencies": {
         "@hookform/resolvers": "^3.3.4",
         "@tailwindcss/typography": "^0.5.19",

--- a/web-ui/package.json
+++ b/web-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "swing-screener-web",
   "private": true,
-  "version": "0.1.0",
+  "version": "3.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web-ui/src/features/portfolio/api.test.ts
+++ b/web-ui/src/features/portfolio/api.test.ts
@@ -49,7 +49,7 @@ describe('portfolio api', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it('sends a fresh idempotency key for each create submission', async () => {
+  it('uses a fresh idempotency key for distinct create submissions', async () => {
     const fetchMock = vi
       .fn()
       .mockImplementation(() => Promise.resolve(new Response(null, { status: 201 })));
@@ -78,6 +78,30 @@ describe('portfolio api', () => {
     );
     expect(new Headers(fetchMock.mock.calls[1][1].headers).get('Idempotency-Key')).toBe(
       '22222222-2222-4222-8222-222222222222',
+    );
+  });
+
+  it('reuses a caller-supplied idempotency key for an order retry', async () => {
+    const fetchMock = vi.fn().mockImplementation(() => new Response(null, { status: 201 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const request = {
+      ticker: 'AAPL',
+      orderType: 'BUY_LIMIT' as const,
+      quantity: 2,
+      limitPrice: 100,
+      stopPrice: 95,
+      targetPrice: 110,
+      approvalToken: 'approval-token',
+    };
+
+    await createOrder(request, 'create-aapl-retry');
+    await createOrder(request, 'create-aapl-retry');
+
+    expect(new Headers(fetchMock.mock.calls[0][1].headers).get('Idempotency-Key')).toBe(
+      'create-aapl-retry',
+    );
+    expect(new Headers(fetchMock.mock.calls[1][1].headers).get('Idempotency-Key')).toBe(
+      'create-aapl-retry',
     );
   });
 

--- a/web-ui/src/features/portfolio/api.ts
+++ b/web-ui/src/features/portfolio/api.ts
@@ -208,6 +208,10 @@ function createIdempotencyKey(): string {
   return globalThis.crypto.randomUUID();
 }
 
+function resolveIdempotencyKey(idempotencyKey?: string): string {
+  return idempotencyKey ?? createIdempotencyKey();
+}
+
 export async function fetchOrders(status: OrderFilterStatus): Promise<Order[]> {
   if (isLocalPersistenceMode()) {
     return listOrdersLocal(status);
@@ -219,7 +223,10 @@ export async function fetchOrders(status: OrderFilterStatus): Promise<Order[]> {
   return (data.orders ?? []).map(transformOrder);
 }
 
-export async function createOrder(request: CreateOrderRequest): Promise<void> {
+export async function createOrder(
+  request: CreateOrderRequest,
+  idempotencyKey?: string,
+): Promise<void> {
   if (isLocalPersistenceMode()) {
     createOrderLocal(request);
     return;
@@ -231,14 +238,18 @@ export async function createOrder(request: CreateOrderRequest): Promise<void> {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      'Idempotency-Key': createIdempotencyKey(),
+      'Idempotency-Key': resolveIdempotencyKey(idempotencyKey),
     },
     body: JSON.stringify(transformCreateOrderRequest(request)),
     errorMessage: 'Failed to create order',
   });
 }
 
-export async function fillOrder(orderId: string, request: FillOrderRequest): Promise<void> {
+export async function fillOrder(
+  orderId: string,
+  request: FillOrderRequest,
+  idempotencyKey?: string,
+): Promise<void> {
   if (isLocalPersistenceMode()) {
     fillOrderLocal(orderId, request);
     return;
@@ -261,7 +272,7 @@ export async function fillOrder(orderId: string, request: FillOrderRequest): Pro
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      'Idempotency-Key': createIdempotencyKey(),
+      'Idempotency-Key': resolveIdempotencyKey(idempotencyKey),
     },
     body: JSON.stringify(payload),
     errorMessage: 'Failed to fill order',
@@ -392,6 +403,7 @@ export async function fetchEarningsProximity(ticker: string): Promise<EarningsPr
 export async function updatePositionStop(
   positionId: string,
   request: UpdateStopRequest,
+  idempotencyKey?: string,
 ): Promise<void> {
   if (isLocalPersistenceMode()) {
     updatePositionStopLocal(positionId, request);
@@ -399,7 +411,10 @@ export async function updatePositionStop(
   }
   await fetchJson<void>(API_ENDPOINTS.positionStop(positionId), {
     method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
+    headers: {
+      'Content-Type': 'application/json',
+      'Idempotency-Key': resolveIdempotencyKey(idempotencyKey),
+    },
     body: JSON.stringify({
       new_stop: request.newStop,
       reason: request.reason || '',
@@ -472,13 +487,17 @@ export async function fetchPositionStopPreview(
 export async function updatePositionTrailMethod(
   positionId: string,
   request: UpdateTrailMethodRequest,
+  idempotencyKey?: string,
 ): Promise<void> {
   if (isLocalPersistenceMode()) {
     throw new Error('Trail method update is not supported in local persistence mode');
   }
   await fetchJson<void>(API_ENDPOINTS.positionTrailMethod(positionId), {
     method: 'PATCH',
-    headers: { 'Content-Type': 'application/json' },
+    headers: {
+      'Content-Type': 'application/json',
+      'Idempotency-Key': resolveIdempotencyKey(idempotencyKey),
+    },
     body: JSON.stringify({
       trail_method: request.trailMethod,
       trail_param: request.trailParam ?? null,
@@ -522,6 +541,7 @@ export async function computePositionStopSuggestion(
 export async function closePosition(
   positionId: string,
   request: ClosePositionRequest,
+  idempotencyKey?: string,
 ): Promise<void> {
   if (isLocalPersistenceMode()) {
     closePositionLocal(positionId, request);
@@ -529,7 +549,10 @@ export async function closePosition(
   }
   await fetchJson<void>(API_ENDPOINTS.positionClose(positionId), {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: {
+      'Content-Type': 'application/json',
+      'Idempotency-Key': resolveIdempotencyKey(idempotencyKey),
+    },
     body: JSON.stringify({
       exit_price: request.exitPrice,
       fee_eur: request.feeEur,
@@ -545,10 +568,14 @@ export async function closePosition(
 export async function partialClosePosition(
   positionId: string,
   request: PartialCloseRequest,
+  idempotencyKey?: string,
 ): Promise<void> {
   await fetchJson<void>(API_ENDPOINTS.positionPartialClose(positionId), {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: {
+      'Content-Type': 'application/json',
+      'Idempotency-Key': resolveIdempotencyKey(idempotencyKey),
+    },
     body: JSON.stringify({
       shares_closed: request.sharesClosed,
       price: request.price,

--- a/web-ui/src/features/portfolio/hooks.test.tsx
+++ b/web-ui/src/features/portfolio/hooks.test.tsx
@@ -99,7 +99,7 @@ describe('portfolio hooks', () => {
       await result.current.mutateAsync(request)
     })
 
-    expect(mockedCreateOrder).toHaveBeenCalledWith(request)
+    expect(mockedCreateOrder).toHaveBeenCalledWith(request, expect.any(String))
     expect(mockedInvalidateOrderQueries).toHaveBeenCalledWith(queryClient)
     expect(onSuccess).toHaveBeenCalledTimes(1)
   })
@@ -124,7 +124,11 @@ describe('portfolio hooks', () => {
       await result.current.mutateAsync(payload)
     })
 
-    expect(mockedUpdatePositionStop).toHaveBeenCalledWith(payload.positionId, payload.request)
+    expect(mockedUpdatePositionStop).toHaveBeenCalledWith(
+      payload.positionId,
+      payload.request,
+      expect.any(String),
+    )
     expect(mockedInvalidatePositionQueries).toHaveBeenCalledWith(queryClient)
     expect(mockedInvalidateOrderQueries).toHaveBeenCalledWith(queryClient)
     expect(mockedInvalidateDailyReviewQueries).toHaveBeenCalledWith(queryClient)

--- a/web-ui/src/features/portfolio/hooks.ts
+++ b/web-ui/src/features/portfolio/hooks.ts
@@ -36,6 +36,21 @@ import {
 import { queryKeys } from '@/lib/queryKeys';
 import { invalidateDailyReviewQueries, invalidateOrderQueries, invalidatePositionQueries } from '@/lib/queryInvalidation';
 
+const mutationIdempotencyKeys = new WeakMap<object, string>();
+
+function idempotencyKeyForMutation(variables: object): string {
+  const existing = mutationIdempotencyKeys.get(variables);
+  if (existing) {
+    return existing;
+  }
+  if (!globalThis.crypto?.randomUUID) {
+    throw new Error('Secure idempotency key generation is unavailable in this browser.');
+  }
+  const key = globalThis.crypto.randomUUID();
+  mutationIdempotencyKeys.set(variables, key);
+  return key;
+}
+
 export function useOrders(status: OrderFilterStatus) {
   return useQuery({
     queryKey: queryKeys.orders(status),
@@ -46,7 +61,8 @@ export function useOrders(status: OrderFilterStatus) {
 export function useCreateOrderMutation(onSuccess?: () => void) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (request: CreateOrderRequest) => createOrder(request),
+    mutationFn: (request: CreateOrderRequest) =>
+      createOrder(request, idempotencyKeyForMutation(request)),
     onSuccess: async () => {
       await invalidateOrderQueries(queryClient);
       onSuccess?.();
@@ -57,8 +73,12 @@ export function useCreateOrderMutation(onSuccess?: () => void) {
 export function useFillOrderMutation(onSuccess?: () => void) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: ({ orderId, request }: { orderId: string; request: FillOrderRequest }) =>
-      fillOrder(orderId, request),
+    mutationFn: (variables: { orderId: string; request: FillOrderRequest }) =>
+      fillOrder(
+        variables.orderId,
+        variables.request,
+        idempotencyKeyForMutation(variables),
+      ),
     onSuccess: async () => {
       await Promise.all([
         invalidateOrderQueries(queryClient),
@@ -167,8 +187,12 @@ export function useEarningsProximity(ticker?: string) {
 export function useUpdateStopMutation(onSuccess?: () => void) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: ({ positionId, request }: { positionId: string; request: UpdateStopRequest }) =>
-      updatePositionStop(positionId, request),
+    mutationFn: (variables: { positionId: string; request: UpdateStopRequest }) =>
+      updatePositionStop(
+        variables.positionId,
+        variables.request,
+        idempotencyKeyForMutation(variables),
+      ),
     onSuccess: async () => {
       await invalidatePositionQueries(queryClient);
       await invalidateOrderQueries(queryClient);
@@ -181,13 +205,14 @@ export function useUpdateStopMutation(onSuccess?: () => void) {
 export function useUpdateTrailMethodMutation(onSuccess?: () => void) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: ({
-      positionId,
-      request,
-    }: {
+    mutationFn: (variables: {
       positionId: string;
       request: UpdateTrailMethodRequest;
-    }) => updatePositionTrailMethod(positionId, request),
+    }) => updatePositionTrailMethod(
+      variables.positionId,
+      variables.request,
+      idempotencyKeyForMutation(variables),
+    ),
     onSuccess: async () => {
       await invalidatePositionQueries(queryClient);
       await invalidateDailyReviewQueries(queryClient);
@@ -223,8 +248,12 @@ export function usePositionStopPreviewQuery(
 export function useClosePositionMutation(onSuccess?: () => void) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: ({ positionId, request }: { positionId: string; request: ClosePositionRequest }) =>
-      closePosition(positionId, request),
+    mutationFn: (variables: { positionId: string; request: ClosePositionRequest }) =>
+      closePosition(
+        variables.positionId,
+        variables.request,
+        idempotencyKeyForMutation(variables),
+      ),
     onSuccess: async () => {
       await invalidatePositionQueries(queryClient);
       await invalidateDailyReviewQueries(queryClient);
@@ -236,8 +265,12 @@ export function useClosePositionMutation(onSuccess?: () => void) {
 export function usePartialClosePositionMutation(onSuccess?: () => void) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: ({ positionId, request }: { positionId: string; request: PartialCloseRequest }) =>
-      partialClosePosition(positionId, request),
+    mutationFn: (variables: { positionId: string; request: PartialCloseRequest }) =>
+      partialClosePosition(
+        variables.positionId,
+        variables.request,
+        idempotencyKeyForMutation(variables),
+      ),
     onSuccess: async () => {
       await invalidatePositionQueries(queryClient);
       await invalidateDailyReviewQueries(queryClient);


### PR DESCRIPTION
## v3.0.0 release follow-up

Follow-up to #428, which merged before the release-safety work could land.

## What changed

- Serialize legacy JSON import across concurrent application startups with a migrated singleton lock.
- Make every persisted position mutation idempotent; replayed requests return their original response instead of repeating a close or share reduction.
- Preserve idempotency keys across React Query mutation retries.
- Normalize both `postgres://` and `postgresql://` database URLs for SQLAlchemy/psycopg.
- Restore readiness checks for frozen legacy JSON paths while keeping `/health/live` dependency-free.
- Report `3.0.0` consistently in Python, web, API, and OpenAPI metadata.

## Migration and operations

Includes Alembic revision `20260721_0002_legacy_import_lock`. Back up the database and frozen legacy JSON files before deployment; the API README documents import validation, readiness, and recovery.

## Verification

- `pytest -q` — 1505 passed, 7 skipped
- `npx vitest run` — 720 passed
- `npm run typecheck`
- `npm run build`
- scoped `ruff check` and `git diff --check`

## Screenshots

No visible UI change; this only adds request headers and retry behavior.