### PR TITLE
Consolidate backend API test setup

### DIFF
--- a/tests/api/_test_helpers.py
+++ b/tests/api/_test_helpers.py
@@ -1,7 +1,10 @@
 """Shared test helper factories for API tests."""
+
 from __future__ import annotations
 
 from types import SimpleNamespace
+
+from tests.support.factories.portfolio import order_payload, position_payload
 
 
 def make_position(
@@ -14,14 +17,17 @@ def make_position(
     shares: int = 10,
     status: str = "open",
 ) -> SimpleNamespace:
-    return SimpleNamespace(
+    payload = position_payload(
         ticker=ticker,
         position_id=position_id,
         entry_price=entry_price,
-        current_price=current_price if current_price is not None else entry_price,
         stop_price=stop_price,
         shares=shares,
         status=status,
+    )
+    return SimpleNamespace(
+        **payload,
+        current_price=current_price if current_price is not None else entry_price,
     )
 
 
@@ -33,10 +39,13 @@ def make_order(
     order_kind: str = "entry",
     position_id: str | None = None,
 ) -> SimpleNamespace:
-    return SimpleNamespace(
+    payload = order_payload(
         ticker=ticker,
         order_id=order_id,
         status=status,
         order_kind=order_kind,
         position_id=position_id,
+    )
+    return SimpleNamespace(
+        **payload,
     )

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -6,6 +6,10 @@ import sys
 
 import pytest
 
+from tests.support.api import dependency_overrides as dependency_overrides_context
+from tests.support.fakes.services import PortfolioServiceStub
+from tests.support.state import JsonPortfolioState
+
 
 @pytest.fixture(autouse=True)
 def _isolate_review_queue(tmp_path_factory):
@@ -32,3 +36,33 @@ def _isolate_review_queue(tmp_path_factory):
     )
     yield
     app.dependency_overrides.pop(get_review_queue_repo, None)
+
+
+@pytest.fixture
+def api_client():
+    from api.main import app
+    from tests.support.api import api_client as make_api_client
+
+    return make_api_client(app)
+
+
+@pytest.fixture
+def portfolio_state(tmp_path, monkeypatch):
+    state = JsonPortfolioState(tmp_path / "positions.json", tmp_path / "orders.json")
+    state.write()
+    return state.install(monkeypatch)
+
+
+@pytest.fixture
+def portfolio_service_stub():
+    return PortfolioServiceStub()
+
+
+@pytest.fixture
+def override_dependencies():
+    from api.main import app
+
+    def override(mapping):
+        return dependency_overrides_context(app, mapping)
+
+    return override

--- a/tests/api/test_account_equity.py
+++ b/tests/api/test_account_equity.py
@@ -1,54 +1,39 @@
 """Tests for account equity auto-update feature."""
-import json
 
 import pytest
-from fastapi.testclient import TestClient
-
-import api.dependencies as deps
-from api.main import app
-
+from tests.support.factories.portfolio import position_payload
 
 POSITIONS = [
-    {
-        "position_id": "POS-001",
-        "ticker": "ASML.AS",
-        "status": "closed",
-        "entry_date": "2026-01-01",
-        "entry_price": 100.0,
-        "stop_price": 95.0,
-        "shares": 10,
-        "initial_risk": 50.0,
-        "exit_price": 120.0,
-        "exit_date": "2026-01-15",
-        "notes": "",
-        "tags": [],
-    },
-    {
-        "position_id": "POS-002",
-        "ticker": "AIR.PA",
-        "status": "closed",
-        "entry_date": "2026-01-05",
-        "entry_price": 200.0,
-        "stop_price": 190.0,
-        "shares": 5,
-        "initial_risk": 50.0,
-        "exit_price": 185.0,
-        "exit_date": "2026-01-20",
-        "notes": "",
-        "tags": [],
-    },
+    position_payload(
+        position_id="POS-001",
+        ticker="ASML.AS",
+        status="closed",
+        entry_price=100.0,
+        stop_price=95.0,
+        shares=10,
+        initial_risk=50.0,
+        exit_price=120.0,
+        exit_date="2026-01-15",
+    ),
+    position_payload(
+        position_id="POS-002",
+        ticker="AIR.PA",
+        status="closed",
+        entry_date="2026-01-05",
+        entry_price=200.0,
+        stop_price=190.0,
+        shares=5,
+        initial_risk=50.0,
+        exit_price=185.0,
+        exit_date="2026-01-20",
+    ),
 ]
 
 
 @pytest.fixture
-def client_with_closed_positions(tmp_path, monkeypatch):
-    positions_file = tmp_path / "positions.json"
-    orders_file = tmp_path / "orders.json"
-    positions_file.write_text(json.dumps({"asof": "2026-01-20", "positions": POSITIONS}))
-    orders_file.write_text(json.dumps({"asof": "2026-01-20", "orders": []}))
-    monkeypatch.setattr(deps, "_positions_path", positions_file)
-    monkeypatch.setattr(deps, "_orders_path", orders_file)
-    return TestClient(app)
+def client_with_closed_positions(portfolio_state, api_client):
+    portfolio_state.write(positions=POSITIONS, asof="2026-01-20")
+    return api_client
 
 
 def test_portfolio_summary_includes_realized_pnl(client_with_closed_positions):
@@ -60,7 +45,9 @@ def test_portfolio_summary_includes_realized_pnl(client_with_closed_positions):
     assert abs(data["realized_pnl"] - 125.0) < 0.01
 
 
-def test_portfolio_summary_includes_effective_account_size(client_with_closed_positions):
+def test_portfolio_summary_includes_effective_account_size(
+    client_with_closed_positions,
+):
     response = client_with_closed_positions.get("/api/portfolio/summary")
 
     data = response.json()
@@ -70,33 +57,33 @@ def test_portfolio_summary_includes_effective_account_size(client_with_closed_po
 
 
 @pytest.fixture
-def client_with_partial_close(tmp_path, monkeypatch):
-    positions_file = tmp_path / "positions.json"
-    orders_file = tmp_path / "orders.json"
-    positions_file.write_text(json.dumps({
-        "asof": "2026-01-20",
-        "positions": [{
-            "position_id": "POS-PART",
-            "ticker": "ASML.AS",
-            "status": "closed",
-            "entry_date": "2026-01-01",
-            "entry_price": 10.0,
-            "stop_price": 8.0,
-            "shares": 40,  # remaining after the partial
-            "initial_risk": 2.0,
-            "exit_price": 25.0,
-            "exit_date": "2026-01-20",
-            "partial_closes": [
-                {"date": "2026-01-10", "shares_closed": 60, "price": 20.0, "r_at_close": 5.0, "fee_eur": 0.0},
-            ],
-            "notes": "",
-            "tags": [],
-        }],
-    }))
-    orders_file.write_text(json.dumps({"asof": "2026-01-20", "orders": []}))
-    monkeypatch.setattr(deps, "_positions_path", positions_file)
-    monkeypatch.setattr(deps, "_orders_path", orders_file)
-    return TestClient(app)
+def client_with_partial_close(portfolio_state, api_client):
+    portfolio_state.write(
+        positions=[
+            position_payload(
+                position_id="POS-PART",
+                ticker="ASML.AS",
+                status="closed",
+                entry_price=10.0,
+                stop_price=8.0,
+                shares=40,
+                initial_risk=2.0,
+                exit_price=25.0,
+                exit_date="2026-01-20",
+                partial_closes=[
+                    {
+                        "date": "2026-01-10",
+                        "shares_closed": 60,
+                        "price": 20.0,
+                        "r_at_close": 5.0,
+                        "fee_eur": 0.0,
+                    }
+                ],
+            )
+        ],
+        asof="2026-01-20",
+    )
+    return api_client
 
 
 def test_realized_pnl_includes_partial_close_proceeds(client_with_partial_close):

--- a/tests/api/test_trade_tagging.py
+++ b/tests/api/test_trade_tagging.py
@@ -1,36 +1,20 @@
 """Tests for trade tagging on position close."""
-import json
 
 import pytest
-from fastapi.testclient import TestClient
-
-import api.dependencies as deps
-from api.main import app
+from tests.support.factories.portfolio import position_payload
 
 
 @pytest.fixture
-def client_with_open_position(tmp_path, monkeypatch):
-    positions_file = tmp_path / "positions.json"
-    orders_file = tmp_path / "orders.json"
-    positions_file.write_text(json.dumps({
-        "asof": "2026-01-01",
-        "positions": [{
-            "position_id": "POS-TAG-001",
-            "ticker": "AAPL",
-            "status": "open",
-            "entry_date": "2026-01-01",
-            "entry_price": 100.0,
-            "stop_price": 95.0,
-            "shares": 10,
-            "initial_risk": 50.0,
-            "notes": "",
-            "tags": [],
-        }],
-    }))
-    orders_file.write_text(json.dumps({"asof": "2026-01-01", "orders": []}))
-    monkeypatch.setattr(deps, "_positions_path", positions_file)
-    monkeypatch.setattr(deps, "_orders_path", orders_file)
-    return TestClient(app)
+def client_with_open_position(portfolio_state, api_client):
+    portfolio_state.write(
+        positions=[
+            position_payload(
+                position_id="POS-TAG-001",
+                initial_risk=50.0,
+            )
+        ]
+    )
+    return api_client
 
 
 def test_close_with_tags_stores_tags(client_with_open_position):

--- a/tests/api/test_trail_customization.py
+++ b/tests/api/test_trail_customization.py
@@ -1,38 +1,27 @@
 """Tests for F13: per-position trail method PATCH endpoint."""
+
 import json
+
 import pytest
-from fastapi.testclient import TestClient
-from api.main import app
-import api.dependencies as deps
+from tests.support.factories.portfolio import position_payload
 
 
 @pytest.fixture
-def client(tmp_path, monkeypatch):
-    pos_file = tmp_path / "positions.json"
-    ord_file = tmp_path / "orders.json"
-    pos_file.write_text(json.dumps({
-        "asof": "2026-01-01",
-        "positions": [
-            {
-                "position_id": "POS-001",
-                "ticker": "AAPL",
-                "status": "open",
-                "entry_date": "2025-12-01",
-                "entry_price": 150.0,
-                "stop_price": 140.0,
-                "shares": 10,
-                "initial_risk": 10.0,
-            }
-        ],
-    }))
-    ord_file.write_text(json.dumps({"orders": []}))
-    monkeypatch.setattr(deps, "_positions_path", pos_file)
-    monkeypatch.setattr(deps, "_orders_path", ord_file)
-    return TestClient(app)
+def client(portfolio_state, api_client):
+    portfolio_state.write(
+        positions=[
+            position_payload(
+                entry_date="2025-12-01",
+                entry_price=150.0,
+                stop_price=140.0,
+                initial_risk=10.0,
+            )
+        ]
+    )
+    return api_client
 
 
-def test_patch_trail_method_persists(client, tmp_path):
-    pos_file = tmp_path / "positions.json"
+def test_patch_trail_method_persists(client, portfolio_state):
     response = client.patch(
         "/api/portfolio/positions/POS-001/trail-method",
         json={"trail_method": "atr", "trail_param": 2.5},
@@ -45,11 +34,13 @@ def test_patch_trail_method_persists(client, tmp_path):
     pos = stored_response.json()
     assert pos["trail_method"] == "atr"
     assert pos["trail_param"] == 2.5
-    assert "trail_method" not in json.loads(pos_file.read_text())["positions"][0]
+    assert (
+        "trail_method"
+        not in json.loads(portfolio_state.positions_path.read_text())["positions"][0]
+    )
 
 
-def test_patch_trail_method_manual(client, tmp_path):
-    pos_file = tmp_path / "positions.json"
+def test_patch_trail_method_manual(client, portfolio_state):
     response = client.patch(
         "/api/portfolio/positions/POS-001/trail-method",
         json={"trail_method": "manual", "trail_param": None},
@@ -61,7 +52,10 @@ def test_patch_trail_method_manual(client, tmp_path):
     stored = stored_response.json()
     assert stored["trail_method"] == "manual"
     assert stored["trail_param"] is None
-    assert "trail_method" not in json.loads(pos_file.read_text())["positions"][0]
+    assert (
+        "trail_method"
+        not in json.loads(portfolio_state.positions_path.read_text())["positions"][0]
+    )
 
 
 def test_patch_trail_method_invalid_value(client):
@@ -83,29 +77,21 @@ def test_patch_trail_method_not_found(client):
 
 
 @pytest.fixture
-def client_closed(tmp_path, monkeypatch):
-    pos_file = tmp_path / "positions_closed.json"
-    ord_file = tmp_path / "orders_closed.json"
-    pos_file.write_text(json.dumps({
-        "asof": "2026-01-01",
-        "positions": [
-            {
-                "position_id": "POS-CLOSED",
-                "ticker": "AAPL",
-                "status": "closed",
-                "entry_date": "2025-10-01",
-                "entry_price": 150.0,
-                "stop_price": 140.0,
-                "shares": 10,
-                "exit_date": "2025-11-01",
-                "exit_price": 160.0,
-            }
-        ],
-    }))
-    ord_file.write_text(json.dumps({"orders": []}))
-    monkeypatch.setattr(deps, "_positions_path", pos_file)
-    monkeypatch.setattr(deps, "_orders_path", ord_file)
-    return TestClient(app)
+def client_closed(portfolio_state, api_client):
+    portfolio_state.write(
+        positions=[
+            position_payload(
+                position_id="POS-CLOSED",
+                status="closed",
+                entry_date="2025-10-01",
+                entry_price=150.0,
+                stop_price=140.0,
+                exit_date="2025-11-01",
+                exit_price=160.0,
+            )
+        ]
+    )
+    return api_client
 
 
 def test_patch_trail_method_closed_position_rejected(client_closed):

--- a/tests/support/__init__.py
+++ b/tests/support/__init__.py
@@ -1,0 +1,1 @@
+"""Composable, deterministic support helpers for backend tests."""

--- a/tests/support/api.py
+++ b/tests/support/api.py
@@ -1,0 +1,32 @@
+"""Helpers for safely installing FastAPI dependency overrides in tests."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator, Mapping
+from contextlib import contextmanager
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+@contextmanager
+def dependency_overrides(
+    app: FastAPI,
+    overrides: Mapping[Callable[..., object], Callable[[], object]],
+) -> Iterator[None]:
+    """Temporarily apply overrides and restore the exact prior mapping."""
+    previous = dict(app.dependency_overrides)
+    app.dependency_overrides.update(overrides)
+    try:
+        yield
+    finally:
+        app.dependency_overrides.clear()
+        app.dependency_overrides.update(previous)
+
+
+def api_client(app: FastAPI) -> TestClient:
+    """Create the standard synchronous client used by API tests."""
+    return TestClient(app)
+
+
+__all__ = ["api_client", "dependency_overrides"]

--- a/tests/support/factories/__init__.py
+++ b/tests/support/factories/__init__.py
@@ -1,0 +1,1 @@
+"""Factories for domain-shaped test inputs."""

--- a/tests/support/factories/portfolio.py
+++ b/tests/support/factories/portfolio.py
@@ -1,0 +1,79 @@
+"""Canonical JSON payloads used by JSON-backed portfolio API tests."""
+
+from __future__ import annotations
+
+_POSITION_DEFAULTS: dict[str, object] = {
+    "position_id": "POS-001",
+    "ticker": "AAPL",
+    "status": "open",
+    "entry_date": "2026-01-01",
+    "entry_price": 100.0,
+    "stop_price": 95.0,
+    "shares": 10,
+    "initial_risk": 5.0,
+    "notes": "",
+    "tags": [],
+}
+
+_ORDER_DEFAULTS: dict[str, object] = {
+    "order_id": "ORD-001",
+    "ticker": "AAPL",
+    "status": "pending",
+    "order_kind": "entry",
+    "order_type": "LIMIT",
+    "quantity": 10,
+    "limit_price": 100.0,
+    "stop_price": 95.0,
+    "order_date": "2026-01-01",
+    "filled_date": None,
+    "entry_price": None,
+    "notes": "",
+    "parent_order_id": None,
+    "position_id": None,
+    "tif": "GTC",
+    "fee_eur": None,
+    "fill_fx_rate": None,
+    "isin": None,
+    "thesis": None,
+}
+
+
+def position_payload(**overrides: object) -> dict[str, object]:
+    """Return a valid position-shaped mapping with explicit override support."""
+    payload = dict(_POSITION_DEFAULTS)
+    payload["tags"] = list(_POSITION_DEFAULTS["tags"])  # avoid shared mutable state
+    payload.update(overrides)
+    return payload
+
+
+def order_payload(**overrides: object) -> dict[str, object]:
+    """Return a valid order-shaped mapping with explicit override support."""
+    payload = dict(_ORDER_DEFAULTS)
+    payload.update(overrides)
+    return payload
+
+
+def positions_document(
+    positions: list[dict[str, object]] | None = None,
+    *,
+    asof: str = "2026-01-01",
+) -> dict[str, object]:
+    """Build the complete persisted positions document."""
+    return {"asof": asof, "positions": list(positions or [])}
+
+
+def orders_document(
+    orders: list[dict[str, object]] | None = None,
+    *,
+    asof: str = "2026-01-01",
+) -> dict[str, object]:
+    """Build the complete persisted orders document."""
+    return {"asof": asof, "orders": list(orders or [])}
+
+
+__all__ = [
+    "order_payload",
+    "orders_document",
+    "position_payload",
+    "positions_document",
+]

--- a/tests/support/factories/screener.py
+++ b/tests/support/factories/screener.py
@@ -1,0 +1,70 @@
+"""Deterministic input builders for screener API tests."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import pandas as pd
+
+
+def ohlcv_frame(
+    prices: dict[str, list[float]],
+    *,
+    start: str = "2026-01-01",
+    volume: float | dict[str, list[float]] = 1_000_000.0,
+    high_offset: float = 1.0,
+    low_offset: float = 1.0,
+) -> pd.DataFrame:
+    """Create a date-indexed ``(field, ticker)`` OHLCV frame."""
+    if not prices:
+        index = pd.date_range(start, periods=0, freq="D")
+        frame = pd.DataFrame(index=index)
+        frame.columns = pd.MultiIndex.from_tuples([], names=("field", "ticker"))
+        return frame
+    lengths = {len(values) for values in prices.values()}
+    if len(lengths) != 1:
+        raise ValueError("all price series must have the same length")
+    periods = lengths.pop()
+    index = pd.date_range(start, periods=periods, freq="D")
+    data: dict[tuple[str, str], list[float]] = {}
+    for ticker, values in prices.items():
+        close = [float(value) for value in values]
+        if isinstance(volume, Mapping):
+            volumes = volume[ticker]
+            if len(volumes) != periods:
+                raise ValueError(f"volume series for {ticker} has the wrong length")
+        else:
+            volumes = [float(volume)] * periods
+        data.update(
+            {
+                ("Open", ticker): close,
+                ("High", ticker): [value + high_offset for value in close],
+                ("Low", ticker): [value - low_offset for value in close],
+                ("Close", ticker): close,
+                ("Volume", ticker): [float(value) for value in volumes],
+            }
+        )
+    frame = pd.DataFrame(data, index=index)
+    frame.columns = pd.MultiIndex.from_tuples(frame.columns, names=("field", "ticker"))
+    return frame
+
+
+def report_row(**overrides: object) -> dict[str, object]:
+    """Return common daily-report fields while allowing scenario overrides."""
+    row: dict[str, object] = {
+        "ticker": "AAPL",
+        "signal": "breakout",
+        "entry": 100.0,
+        "stop": 95.0,
+        "shares": 10,
+        "score": 0.5,
+        "confidence": 60.0,
+        "last": 100.0,
+        "atr14": 2.0,
+        "currency": "USD",
+    }
+    row.update(overrides)
+    return row
+
+
+__all__ = ["ohlcv_frame", "report_row"]

--- a/tests/support/fakes/__init__.py
+++ b/tests/support/fakes/__init__.py
@@ -1,0 +1,1 @@
+"""Small deterministic fakes used by backend tests."""

--- a/tests/support/fakes/market_data.py
+++ b/tests/support/fakes/market_data.py
@@ -1,0 +1,73 @@
+"""Offline market-data provider fake with call recording."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+import pandas as pd
+
+from swing_screener.data.source_health import DataSourceHealth
+
+
+class FakeMarketDataProvider:
+    """Small provider fake that preserves the production OHLCV contract."""
+
+    def __init__(
+        self,
+        *,
+        ohlcv: pd.DataFrame | None = None,
+        latest_prices: dict[str, float] | None = None,
+        provider_name: str = "test",
+    ) -> None:
+        self.ohlcv = ohlcv
+        self.latest_prices = dict(latest_prices or {})
+        self.provider_name = provider_name
+        self.fetch_ohlcv_calls: list[dict[str, object]] = []
+        self.fetch_latest_price_calls: list[str] = []
+
+    def fetch_ohlcv(
+        self,
+        tickers: Iterable[str],
+        start_date: str | None = None,
+        end_date: str | None = None,
+        **kwargs: object,
+    ) -> pd.DataFrame:
+        requested = list(tickers)
+        self.fetch_ohlcv_calls.append(
+            {
+                "tickers": requested,
+                "start_date": start_date,
+                "end_date": end_date,
+                **kwargs,
+            }
+        )
+        if self.ohlcv is None:
+            raise KeyError("fake provider has no OHLCV data")
+        available = set(self.ohlcv.columns.get_level_values(1))
+        missing = [ticker for ticker in requested if ticker not in available]
+        if missing:
+            raise KeyError(f"fake provider has no OHLCV data for {missing}")
+        columns = [column for column in self.ohlcv.columns if column[1] in requested]
+        return self.ohlcv.loc[:, columns].copy()
+
+    def fetch_latest_price(self, ticker: str) -> float:
+        self.fetch_latest_price_calls.append(ticker)
+        if ticker in self.latest_prices:
+            return float(self.latest_prices[ticker])
+        if self.ohlcv is not None and ("Close", ticker) in self.ohlcv:
+            return float(self.ohlcv[("Close", ticker)].iloc[-1])
+        raise KeyError(f"fake provider has no latest price for {ticker}")
+
+    def get_provider_name(self) -> str:
+        return self.provider_name
+
+    def get_source_health(self) -> DataSourceHealth:
+        return DataSourceHealth(
+            provider=self.provider_name,
+            domain="market_data",
+            status="ok",
+            quality_score=1.0,
+            delay_policy="test_fixture",
+        )
+
+
+__all__ = ["FakeMarketDataProvider"]

--- a/tests/support/fakes/services.py
+++ b/tests/support/fakes/services.py
@@ -1,0 +1,62 @@
+"""Configurable service stubs for API tests."""
+
+from __future__ import annotations
+
+
+class PortfolioServiceStub:
+    def __init__(
+        self,
+        *,
+        positions: list[object] | None = None,
+        orders: list[object] | None = None,
+        stop_suggestions: dict[str, object] | None = None,
+    ) -> None:
+        self.positions = list(positions or [])
+        self.orders = list(orders or [])
+        self.stop_suggestions = dict(stop_suggestions or {})
+
+    def list_positions(
+        self, status: str | None = None, **kwargs: object
+    ) -> list[object]:
+        if status is None:
+            return list(self.positions)
+        return [
+            position
+            for position in self.positions
+            if getattr(position, "status", None) == status
+        ]
+
+    def list_orders(
+        self,
+        status: str | None = None,
+        ticker: str | None = None,
+        **kwargs: object,
+    ) -> list[object]:
+        result = self.orders
+        if status is not None:
+            result = [
+                order for order in result if getattr(order, "status", None) == status
+            ]
+        if ticker is not None:
+            result = [
+                order for order in result if getattr(order, "ticker", None) == ticker
+            ]
+        return list(result)
+
+    def suggest_position_stop(self, position_id: str) -> object:
+        if position_id not in self.stop_suggestions:
+            raise KeyError(f"no stop suggestion configured for {position_id}")
+        return self.stop_suggestions[position_id]
+
+
+class RecordingServiceStub:
+    calls: list[tuple[str, dict[str, object]]]
+
+    def __init__(self) -> None:
+        self.calls = []
+
+    def record(self, method: str, **kwargs: object) -> None:
+        self.calls.append((method, dict(kwargs)))
+
+
+__all__ = ["PortfolioServiceStub", "RecordingServiceStub"]

--- a/tests/support/state.py
+++ b/tests/support/state.py
@@ -1,0 +1,52 @@
+"""Temporary JSON portfolio state setup for API tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tests.support.factories.portfolio import orders_document, positions_document
+
+
+class JsonPortfolioState:
+    """Own and install isolated positions/orders JSON files for one test."""
+
+    positions_path: Path
+    orders_path: Path
+
+    def __init__(self, positions_path: Path, orders_path: Path) -> None:
+        self.positions_path = positions_path
+        self.orders_path = orders_path
+
+    def write(
+        self,
+        *,
+        positions: list[dict[str, object]] | None = None,
+        orders: list[dict[str, object]] | None = None,
+        asof: str = "2026-01-01",
+    ) -> None:
+        self.positions_path.parent.mkdir(parents=True, exist_ok=True)
+        self.orders_path.parent.mkdir(parents=True, exist_ok=True)
+        self.positions_path.write_text(
+            json.dumps(positions_document(positions, asof=asof)), encoding="utf-8"
+        )
+        self.orders_path.write_text(
+            json.dumps(orders_document(orders, asof=asof)), encoding="utf-8"
+        )
+
+    def install(self, monkeypatch: pytest.MonkeyPatch) -> "JsonPortfolioState":
+        """Redirect all exposed dependency path aliases to this state."""
+        import api.dependencies as dependencies
+
+        monkeypatch.setattr(dependencies, "_positions_path", self.positions_path)
+        monkeypatch.setattr(dependencies, "_orders_path", self.orders_path)
+        if hasattr(dependencies, "POSITIONS_FILE"):
+            monkeypatch.setattr(dependencies, "POSITIONS_FILE", self.positions_path)
+        if hasattr(dependencies, "ORDERS_FILE"):
+            monkeypatch.setattr(dependencies, "ORDERS_FILE", self.orders_path)
+        return self
+
+
+__all__ = ["JsonPortfolioState"]

--- a/tests/support/test_api_support.py
+++ b/tests/support/test_api_support.py
@@ -1,0 +1,34 @@
+"""Contract tests for API support helpers."""
+
+import pytest
+from fastapi import FastAPI
+
+from tests.support.api import dependency_overrides
+
+
+def test_dependency_overrides_restore_previous_mapping_on_success():
+    app = FastAPI()
+
+    def existing():
+        return "existing"
+
+    def added():
+        return "added"
+
+    def previous():
+        return "old"
+
+    app.dependency_overrides[existing] = previous
+    with dependency_overrides(app, {added: lambda: "new"}):
+        assert app.dependency_overrides[existing]() == "old"
+        assert app.dependency_overrides[added]() == "new"
+    assert app.dependency_overrides == {existing: previous}
+    assert added not in app.dependency_overrides
+
+
+def test_dependency_overrides_restore_after_exception():
+    app = FastAPI()
+    with pytest.raises(RuntimeError):
+        with dependency_overrides(app, {}):
+            raise RuntimeError("boom")
+    assert app.dependency_overrides == {}

--- a/tests/support/test_market_data_fake.py
+++ b/tests/support/test_market_data_fake.py
@@ -1,0 +1,38 @@
+"""Contract tests for deterministic market-data support."""
+
+import pytest
+
+from tests.support.factories.screener import ohlcv_frame
+from tests.support.fakes.market_data import FakeMarketDataProvider
+
+
+def test_ohlcv_builder_preserves_multiindex_contract():
+    frame = ohlcv_frame(
+        {"AAPL": [100.0, 101.0], "MSFT": [200.0, 201.0]},
+        volume={"AAPL": [1.0, 2.0], "MSFT": [3.0, 4.0]},
+    )
+    assert frame.index[0].strftime("%Y-%m-%d") == "2026-01-01"
+    assert frame.columns.names == ["field", "ticker"]
+    assert frame[("High", "AAPL")].tolist() == [101.0, 102.0]
+    assert frame[("Volume", "MSFT")].tolist() == [3.0, 4.0]
+
+
+def test_fake_records_calls_and_resolves_latest_prices():
+    provider = FakeMarketDataProvider(
+        ohlcv=ohlcv_frame({"AAPL": [100.0, 101.0]}),
+        latest_prices={"MSFT": 202.0},
+    )
+    assert list(provider.fetch_ohlcv(["AAPL"], start_date="2026-01-01").columns)
+    assert provider.fetch_latest_price("MSFT") == 202.0
+    assert provider.fetch_latest_price("AAPL") == 101.0
+    assert provider.fetch_ohlcv_calls[0]["tickers"] == ["AAPL"]
+    assert provider.fetch_latest_price_calls == ["MSFT", "AAPL"]
+    assert provider.get_source_health().status == "ok"
+
+
+def test_fake_raises_for_missing_data():
+    provider = FakeMarketDataProvider(ohlcv=ohlcv_frame({"AAPL": [100.0]}))
+    with pytest.raises(KeyError, match="MSFT"):
+        provider.fetch_ohlcv(["MSFT"])
+    with pytest.raises(KeyError, match="MSFT"):
+        provider.fetch_latest_price("MSFT")

--- a/tests/support/test_portfolio_factories.py
+++ b/tests/support/test_portfolio_factories.py
@@ -1,0 +1,30 @@
+"""Contract tests for canonical portfolio payload factories."""
+
+from tests.support.factories.portfolio import (
+    order_payload,
+    orders_document,
+    position_payload,
+    positions_document,
+)
+
+
+def test_position_factory_has_schema_defaults_and_overrides():
+    payload = position_payload(ticker="MSFT", initial_risk=None)
+    assert payload["ticker"] == "MSFT"
+    assert payload["position_id"] == "POS-001"
+    assert payload["initial_risk"] is None
+
+
+def test_order_factory_has_schema_defaults_and_overrides():
+    payload = order_payload(order_id="ORD-XYZ", position_id=None)
+    assert payload["order_id"] == "ORD-XYZ"
+    assert payload["position_id"] is None
+    assert payload["status"] == "pending"
+
+
+def test_documents_allow_empty_or_explicit_items():
+    position = position_payload()
+    order = order_payload()
+    assert positions_document() == {"asof": "2026-01-01", "positions": []}
+    assert orders_document([order], asof="2026-02-01")["orders"] == [order]
+    assert positions_document([position])["positions"] == [position]

--- a/tests/support/test_state.py
+++ b/tests/support/test_state.py
@@ -1,0 +1,23 @@
+"""Contract tests for isolated JSON portfolio state."""
+
+import json
+
+from tests.support.factories.portfolio import order_payload, position_payload
+from tests.support.state import JsonPortfolioState
+
+
+def test_json_state_writes_documents_and_installs_paths(tmp_path, monkeypatch):
+    state = JsonPortfolioState(tmp_path / "positions.json", tmp_path / "orders.json")
+    state.write(
+        positions=[position_payload()], orders=[order_payload()], asof="2026-02-01"
+    )
+    state.install(monkeypatch)
+
+    import api.dependencies as dependencies
+
+    assert dependencies.get_positions_path() == state.positions_path
+    assert dependencies.get_orders_path() == state.orders_path
+    assert json.loads(state.positions_path.read_text())["asof"] == "2026-02-01"
+    assert (
+        json.loads(state.orders_path.read_text())["orders"][0]["order_id"] == "ORD-001"
+    )

--- a/tests/support/test_support_imports.py
+++ b/tests/support/test_support_imports.py
@@ -1,0 +1,9 @@
+"""Smoke tests for the backend test-support package."""
+
+
+def test_support_packages_import():
+    import tests.support
+    import tests.support.factories
+    import tests.support.fakes
+
+    assert tests.support is not None


### PR DESCRIPTION
## What changed

Adds a composable `tests/support/` layer for deterministic backend tests:

- canonical portfolio/order payload and JSON document factories
- isolated JSON portfolio state installation
- OHLCV frame and report-row builders
- deterministic market-data and service fakes
- safe FastAPI dependency override restoration
- shared API fixtures

Migrates account-equity, trade-tagging, and trail-customization API tests to the shared factories and state fixture while preserving their assertions and JSON-backed persistence semantics.

## Validation

- `pytest -m 'not integration' -q` — 1,535 passed, 1 skipped, 10 deselected
- focused support and portfolio API tests — passed
- Ruff and Black checks — passed

The full suite’s Alpaca integration test remains environment-dependent: it attempted to write `.cache/alpaca_data/...` and hit a pre-existing permission error; integration tests are excluded from the green unit/API validation above.