### PR TITLE
Remove legacy action from summary header

### DIFF
--- a/web-ui/src/components/domain/workspace/DecisionSummaryCard.test.tsx
+++ b/web-ui/src/components/domain/workspace/DecisionSummaryCard.test.tsx
@@ -52,7 +52,6 @@ describe('DecisionSummaryCard', () => {
     render(<DecisionSummaryCard summary={buildSummary()} currency="USD" onRefreshFundamentals={() => undefined} />);
 
     expect(screen.getByText(/AAPL Decision Summary/)).toBeInTheDocument();
-    expect(screen.getByText(/Buy Now/)).toBeInTheDocument();
     expect(screen.getByText('High')).toBeInTheDocument();
     expect(screen.getByText('Coverage Warnings')).toBeInTheDocument();
     expect(screen.getByText('Fundamentals stale: latest quarter 2024-12-31.')).toBeInTheDocument();
@@ -82,7 +81,8 @@ describe('DecisionSummaryCard', () => {
 
     expect(screen.getByText('Ready for order review')).toBeInTheDocument();
     expect(screen.getByText('Review the proposed order')).toBeInTheDocument();
-    expect(screen.getByText(/Decision Summary.*Wait for Breakout/)).toBeInTheDocument();
+    expect(screen.getByText(/AAPL Decision Summary/)).toBeInTheDocument();
+    expect(screen.queryByText(/Wait for Breakout/)).not.toBeInTheDocument();
   });
 
   it('renders unknown catalyst as a neutral data state', () => {

--- a/web-ui/src/components/domain/workspace/DecisionSummaryCard.tsx
+++ b/web-ui/src/components/domain/workspace/DecisionSummaryCard.tsx
@@ -1,6 +1,5 @@
 import Badge from '@/components/common/Badge';
 import type {
-  DecisionAction,
   DecisionCatalystLabel,
   DecisionConviction,
   FairValueMethod,
@@ -22,25 +21,6 @@ interface DecisionSummaryCardProps {
   currency?: string;
   onRefreshFundamentals?: () => void;
   isRefreshingFundamentals?: boolean;
-}
-
-function actionLabel(action: DecisionAction): string {
-  switch (action) {
-    case 'BUY_NOW':
-      return t('workspacePage.panels.analysis.decisionSummary.actions.buyNow');
-    case 'BUY_ON_PULLBACK':
-      return t('workspacePage.panels.analysis.decisionSummary.actions.buyOnPullback');
-    case 'WAIT_FOR_BREAKOUT':
-      return t('workspacePage.panels.analysis.decisionSummary.actions.waitForBreakout');
-    case 'WATCH':
-      return t('workspacePage.panels.analysis.decisionSummary.actions.watch');
-    case 'TACTICAL_ONLY':
-      return t('workspacePage.panels.analysis.decisionSummary.actions.tacticalOnly');
-    case 'AVOID':
-      return t('workspacePage.panels.analysis.decisionSummary.actions.avoid');
-    case 'MANAGE_ONLY':
-      return t('workspacePage.panels.analysis.decisionSummary.actions.manageOnly');
-  }
 }
 
 function convictionLabel(conviction: DecisionConviction): string {
@@ -210,7 +190,7 @@ export default function DecisionSummaryCard({
     <div className="rounded-lg border border-border overflow-hidden">
       <div className={`px-3 py-2 flex items-center justify-between gap-3 ${bannerClass}`}>
         <span className="font-semibold text-sm">
-          {t('workspacePage.panels.analysis.decisionSummary.title', { ticker: summary.symbol })} — {actionLabel(summary.action)}
+          {t('workspacePage.panels.analysis.decisionSummary.title', { ticker: summary.symbol })}
         </span>
         <Badge variant={badgeVariantForConviction(summary.conviction)}>
           {convictionLabel(summary.conviction)}


### PR DESCRIPTION
Drop the old analytical action from the summary header so the canonical workflow badge and next step remain the
  only execution guidance in that panel. This keeps the UI aligned with the workflow-authoritative contract and preserves the existing workflow tests.