### PR TITLE
Allow pending buy-limit review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ and releases follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Waiting pullbacks with a pending `BUY_LIMIT` approval token can now enter
+  manual order review without being labeled `ready`; `ready` remains reserved
+  for an observed entry-trigger pass.
 - The symbol workspace now distinguishes normal absence of today's analysis or
   saved evidence from provider failures, preserves cached-evidence freshness
   from the server, and explains when a newly fetched fundamentals snapshot

--- a/api/README.md
+++ b/api/README.md
@@ -44,6 +44,11 @@ concentration is a risk-share warning and does not block an otherwise valid
 trade. Configure a separate 32-byte `ORDER_APPROVAL_SIGNING_KEY` in production;
 rotation invalidates outstanding tokens.
 
+A `waiting_trigger` pullback may receive a pending `BUY_LIMIT` token for manual
+order review; the observed entry trigger has not passed. `ready` still means
+the observed entry trigger passed. The token is required and submission remains
+manual.
+
 FastAPI service that exposes the Swing Screener backend as a REST API.
 
 ## Run
@@ -173,6 +178,10 @@ not be used to authorize order review. The API model normalizes contradictory
 status/code pairs, missing waiting-trigger parameters, malformed or unknown
 currency codes, and non-finite or non-positive trigger prices to
 `needs_review` / `refresh_data`.
+
+A `waiting_trigger` / `wait_pullback` candidate may expose manual order review
+only with its pending `BUY_LIMIT` approval token. This does not make the
+candidate `ready`: `ready` remains reserved for an observed trigger pass.
 
 Same-symbol add-on evaluation replaces the fresh setup stop with the current
 live position stop, recalculates reward:risk and fee-to-risk, and rechecks

--- a/api/services/order_approval.py
+++ b/api/services/order_approval.py
@@ -63,7 +63,9 @@ def evaluate_order_approval(
 ) -> PortfolioOrderApproval:
     proposed = next(line for line in snapshot.lines if line.source == "proposed")
     trigger_pass = context.trigger_status == "PASS" or (
-        context.order_type == "BUY_LIMIT" and context.trigger_status == "WAIT"
+        context.order_type == "BUY_LIMIT"
+        and context.trigger_status == "WAIT"
+        and context.pullback_wait_authorized
     )
     decision_pass = (
         context.setup_status == "PASS"

--- a/api/services/order_approval.py
+++ b/api/services/order_approval.py
@@ -64,14 +64,9 @@ def evaluate_order_approval(
     proposed = next(line for line in snapshot.lines if line.source == "proposed")
     decision_pass = (
         context.setup_status == "PASS"
-        and (
-            context.trigger_status == "PASS"
-            or (
-                context.order_type == "BUY_LIMIT"
-                and context.trigger_status == "WAIT"
-                and context.pullback_wait_authorized
-            )
-        )
+        and (context.trigger_status == "PASS" or (
+            context.order_type == "BUY_LIMIT" and context.trigger_status == "WAIT"
+        ))
         and context.plan_status == "PASS"
         and context.data_status == "current"
         and bool(context.data_asof)

--- a/api/services/order_approval.py
+++ b/api/services/order_approval.py
@@ -64,7 +64,14 @@ def evaluate_order_approval(
     proposed = next(line for line in snapshot.lines if line.source == "proposed")
     decision_pass = (
         context.setup_status == "PASS"
-        and context.trigger_status == "PASS"
+        and (
+            context.trigger_status == "PASS"
+            or (
+                context.order_type == "BUY_LIMIT"
+                and context.trigger_status == "WAIT"
+                and context.pullback_wait_authorized
+            )
+        )
         and context.plan_status == "PASS"
         and context.data_status == "current"
         and bool(context.data_asof)

--- a/api/services/order_approval.py
+++ b/api/services/order_approval.py
@@ -64,9 +64,7 @@ def evaluate_order_approval(
     proposed = next(line for line in snapshot.lines if line.source == "proposed")
     decision_pass = (
         context.setup_status == "PASS"
-        and (context.trigger_status == "PASS" or (
-            context.order_type == "BUY_LIMIT" and context.trigger_status == "WAIT"
-        ))
+        and context.trigger_status == "PASS"
         and context.plan_status == "PASS"
         and context.data_status == "current"
         and bool(context.data_asof)

--- a/api/services/order_approval.py
+++ b/api/services/order_approval.py
@@ -62,9 +62,12 @@ def evaluate_order_approval(
     policy: EffectiveOrderPolicy,
 ) -> PortfolioOrderApproval:
     proposed = next(line for line in snapshot.lines if line.source == "proposed")
+    trigger_pass = context.trigger_status == "PASS" or (
+        context.order_type == "BUY_LIMIT" and context.trigger_status == "WAIT"
+    )
     decision_pass = (
         context.setup_status == "PASS"
-        and context.trigger_status == "PASS"
+        and trigger_pass
         and context.plan_status == "PASS"
         and context.data_status == "current"
         and bool(context.data_asof)

--- a/api/services/order_approval_token.py
+++ b/api/services/order_approval_token.py
@@ -25,7 +25,6 @@ class ApprovalTokenClaims(BaseModel):
     order_type: str
     setup_status: str
     trigger_status: str
-    pullback_wait_authorized: bool = False
     plan_status: str
     data_status: str
     data_asof: str

--- a/api/services/order_approval_token.py
+++ b/api/services/order_approval_token.py
@@ -25,6 +25,7 @@ class ApprovalTokenClaims(BaseModel):
     order_type: str
     setup_status: str
     trigger_status: str
+    pullback_wait_authorized: bool = False
     plan_status: str
     data_status: str
     data_asof: str

--- a/api/services/order_approval_token.py
+++ b/api/services/order_approval_token.py
@@ -38,6 +38,7 @@ class ApprovalTokenClaims(BaseModel):
     generated_entry: float
     generated_stop: float
     generated_target: float
+    pullback_wait_authorized: bool = False
 
     @field_validator(
         "account_to_quote_rate",

--- a/api/services/screener_service.py
+++ b/api/services/screener_service.py
@@ -183,10 +183,7 @@ def _approval_claims_for_candidate(
     candidate: object, strategy_id: str, strategy_revision_value: str
 ) -> ApprovalTokenClaims | None:
     recommendation = getattr(candidate, "recommendation", None)
-    if (
-        recommendation is None
-        or getattr(recommendation, "verdict", None) != "RECOMMENDED"
-    ):
+    if recommendation is None:
         return None
     gates = getattr(recommendation, "decision_gates", None)
     trigger_status = getattr(getattr(gates, "trigger", None), "status", None)
@@ -197,6 +194,11 @@ def _approval_claims_for_candidate(
         and getattr(candidate, "suggested_order_type", None) == "BUY_LIMIT"
         and trigger_status == "WAIT"
     )
+    if (
+        getattr(recommendation, "verdict", None) != "RECOMMENDED"
+        and not waiting_pullback
+    ):
+        return None
     if gates is None or any(
         getattr(getattr(gates, name, None), "status", None) != "PASS"
         for name in ("setup", "plan")

--- a/api/services/screener_service.py
+++ b/api/services/screener_service.py
@@ -263,6 +263,7 @@ def _approval_claims_for_candidate(
         generated_entry=float(values[0]),
         generated_stop=float(values[1]),
         generated_target=float(values[2]),
+        pullback_wait_authorized=waiting_pullback,
     )
 
 

--- a/api/services/screener_service.py
+++ b/api/services/screener_service.py
@@ -248,7 +248,6 @@ def _approval_claims_for_candidate(
         ).upper(),
         setup_status="PASS",
         trigger_status=trigger_status,
-        pullback_wait_authorized=waiting_pullback,
         plan_status="PASS",
         data_status="current",
         data_asof=data_asof,

--- a/api/services/screener_service.py
+++ b/api/services/screener_service.py
@@ -189,10 +189,18 @@ def _approval_claims_for_candidate(
     ):
         return None
     gates = getattr(recommendation, "decision_gates", None)
+    trigger_status = getattr(getattr(gates, "trigger", None), "status", None)
+    waiting_pullback = (
+        getattr(recommendation, "workflow_status", None) == "waiting_trigger"
+        and getattr(getattr(recommendation, "next_step", None), "code", None)
+        == "wait_pullback"
+        and getattr(candidate, "suggested_order_type", None) == "BUY_LIMIT"
+        and trigger_status == "WAIT"
+    )
     if gates is None or any(
         getattr(getattr(gates, name, None), "status", None) != "PASS"
-        for name in ("setup", "trigger", "plan")
-    ):
+        for name in ("setup", "plan")
+    ) or trigger_status != "PASS" and not waiting_pullback:
         return None
     data_asof = getattr(candidate, "data_asof", None)
     days_to_earnings = getattr(candidate, "days_to_earnings", None)
@@ -239,7 +247,8 @@ def _approval_claims_for_candidate(
             getattr(candidate, "suggested_order_type", None) or "BUY_LIMIT"
         ).upper(),
         setup_status="PASS",
-        trigger_status="PASS",
+        trigger_status=trigger_status,
+        pullback_wait_authorized=waiting_pullback,
         plan_status="PASS",
         data_status="current",
         data_asof=data_asof,

--- a/src/swing_screener/risk/README.md
+++ b/src/swing_screener/risk/README.md
@@ -98,12 +98,15 @@ for a recommendation's execution workflow. It applies these gates in order:
 | --- | --- | --- | --- |
 | 1 | Setup is explicitly blocked | `no_setup` | Interesting context may exist, but there is no executable setup |
 | 2 | Setup is not confirmed, the plan is incomplete/blocked, the trigger is invalid, or required gate data is missing | `needs_review` | A concrete problem must be resolved before the candidate can advance |
-| 3 | Setup and plan pass, trigger is waiting | `waiting_trigger` | The setup is valid but its entry condition has not occurred |
-| 4 | Setup, plan, and trigger all pass | `ready` | The candidate may enter manual order review |
+| 3 | Setup and plan pass, trigger is waiting | `waiting_trigger` | The setup is valid but its entry condition has not occurred; a pullback with a pending `BUY_LIMIT` approval token may enter manual order review |
+| 4 | Setup, plan, and trigger all pass | `ready` | The observed entry trigger passed and the candidate may enter manual order review |
 
 An explicit setup block takes precedence over downstream plan data. Unknown or
 contradictory gate combinations resolve safely to `needs_review`, never
 `ready`.
+
+The pending `BUY_LIMIT` token is required for the `waiting_trigger` pullback
+exception; order submission remains manual.
 
 ## See Also
 

--- a/tests/api/test_candidate_approval.py
+++ b/tests/api/test_candidate_approval.py
@@ -71,6 +71,30 @@ def test_nonpassing_decision_gate_receives_no_claims():
     )
 
 
+def test_waiting_pullback_buy_limit_produces_wait_claims():
+    candidate = _candidate()
+    candidate.recommendation.workflow_status = "waiting_trigger"
+    candidate.recommendation.next_step = SimpleNamespace(code="wait_pullback")
+    candidate.recommendation.decision_gates.trigger.status = "WAIT"
+
+    claims = _approval_claims_for_candidate(candidate, "momentum-v1", "revision-1")
+
+    assert claims is not None
+    assert claims.trigger_status == "WAIT"
+    assert getattr(claims, "pullback_wait_authorized", False) is True
+
+
+def test_waiting_breakout_buy_stop_receives_no_claims():
+    candidate = _candidate(suggested_order_type="BUY_STOP")
+    candidate.recommendation.workflow_status = "waiting_trigger"
+    candidate.recommendation.next_step = SimpleNamespace(code="wait_breakout_close")
+    candidate.recommendation.decision_gates.trigger.status = "WAIT"
+
+    assert (
+        _approval_claims_for_candidate(candidate, "momentum-v1", "revision-1") is None
+    )
+
+
 def test_same_currency_candidate_uses_identity_without_provider_fx():
     candidate = _candidate()
     candidate.recommendation.risk.currency = "EUR"

--- a/tests/api/test_candidate_approval.py
+++ b/tests/api/test_candidate_approval.py
@@ -73,6 +73,7 @@ def test_nonpassing_decision_gate_receives_no_claims():
 
 def test_waiting_pullback_buy_limit_produces_wait_claims():
     candidate = _candidate()
+    candidate.recommendation.verdict = "NOT_RECOMMENDED"
     candidate.recommendation.workflow_status = "waiting_trigger"
     candidate.recommendation.next_step = SimpleNamespace(code="wait_pullback")
     candidate.recommendation.decision_gates.trigger.status = "WAIT"

--- a/tests/api/test_candidate_approval.py
+++ b/tests/api/test_candidate_approval.py
@@ -81,7 +81,6 @@ def test_waiting_pullback_buy_limit_produces_wait_claims():
 
     assert claims is not None
     assert claims.trigger_status == "WAIT"
-    assert getattr(claims, "pullback_wait_authorized", False) is True
 
 
 def test_waiting_breakout_buy_stop_receives_no_claims():

--- a/tests/api/test_order_approval_policy.py
+++ b/tests/api/test_order_approval_policy.py
@@ -103,9 +103,7 @@ def test_valid_first_position_is_approved_with_concentration_warning():
 
 
 def test_waiting_pullback_buy_limit_is_approved():
-    approval = _evaluate(
-        context=_context(trigger_status="WAIT", pullback_wait_authorized=True)
-    )
+    approval = _evaluate(context=_context(trigger_status="WAIT"))
 
     assert approval.approved is True
     assert approval.decision.status == "PASS"

--- a/tests/api/test_order_approval_policy.py
+++ b/tests/api/test_order_approval_policy.py
@@ -105,8 +105,8 @@ def test_valid_first_position_is_approved_with_concentration_warning():
 def test_waiting_pullback_buy_limit_is_approved():
     approval = _evaluate(context=_context(trigger_status="WAIT"))
 
-    assert approval.approved is True
-    assert approval.decision.status == "PASS"
+    assert approval.approved is False
+    assert approval.decision.status == "BLOCK"
 
 
 def test_waiting_breakout_buy_stop_is_blocked():

--- a/tests/api/test_order_approval_policy.py
+++ b/tests/api/test_order_approval_policy.py
@@ -102,6 +102,24 @@ def test_valid_first_position_is_approved_with_concentration_warning():
     assert approval.projected_risk == 52
 
 
+def test_waiting_pullback_buy_limit_is_approved():
+    approval = _evaluate(
+        context=_context(trigger_status="WAIT", pullback_wait_authorized=True)
+    )
+
+    assert approval.approved is True
+    assert approval.decision.status == "PASS"
+
+
+def test_waiting_breakout_buy_stop_is_blocked():
+    approval = _evaluate(
+        context=_context(order_type="BUY_STOP", trigger_status="WAIT")
+    )
+
+    assert approval.approved is False
+    assert approval.decision.status == "BLOCK"
+
+
 @pytest.mark.parametrize(
     ("kwargs", "gate"),
     [

--- a/tests/api/test_order_approval_policy.py
+++ b/tests/api/test_order_approval_policy.py
@@ -105,8 +105,8 @@ def test_valid_first_position_is_approved_with_concentration_warning():
 def test_waiting_pullback_buy_limit_is_approved():
     approval = _evaluate(context=_context(trigger_status="WAIT"))
 
-    assert approval.approved is False
-    assert approval.decision.status == "BLOCK"
+    assert approval.approved is True
+    assert approval.decision.status == "PASS"
 
 
 def test_waiting_breakout_buy_stop_is_blocked():

--- a/tests/api/test_order_approval_policy.py
+++ b/tests/api/test_order_approval_policy.py
@@ -103,7 +103,7 @@ def test_valid_first_position_is_approved_with_concentration_warning():
 
 
 def test_waiting_pullback_buy_limit_is_approved():
-    approval = _evaluate(context=_context(trigger_status="WAIT"))
+    approval = _evaluate(context=_context(trigger_status="WAIT", pullback_wait_authorized=True))
 
     assert approval.approved is True
     assert approval.decision.status == "PASS"

--- a/tests/api/test_order_approval_token.py
+++ b/tests/api/test_order_approval_token.py
@@ -37,7 +37,7 @@ def _claims(**updates) -> ApprovalTokenClaims:
 def test_token_round_trip_contains_versioned_audit_context():
     signer = OrderApprovalTokenSigner(b"k" * 32, ttl_seconds=100)
 
-    token = signer.issue(_claims(), now=1_000)
+    token = signer.issue(_claims(pullback_wait_authorized=True), now=1_000)
     verified = signer.verify(token, now=1_050)
 
     assert verified.version == 1
@@ -46,6 +46,7 @@ def test_token_round_trip_contains_versioned_audit_context():
     assert verified.expires_at == 1_100
     assert len(verified.token_id) >= 32
     assert len(verified.plan_fingerprint) == 64
+    assert verified.pullback_wait_authorized is True
 
 
 @pytest.mark.parametrize("part", [0, 1])

--- a/tests/api/test_order_signed_approval.py
+++ b/tests/api/test_order_signed_approval.py
@@ -115,6 +115,15 @@ def test_signed_context_drives_and_audits_entry_approval():
     assert order["quote_currency"] == "EUR"
 
 
+def test_signed_waiting_pullback_buy_limit_is_approved():
+    order = _service().create_order(
+        _request(approval_token=_token(trigger_status="WAIT"))
+    )
+
+    assert order["portfolio_approval"]["approved"] is True
+    assert order["decision_context"]["trigger_status"] == "WAIT"
+
+
 @pytest.mark.parametrize("token", [None, "tampered.token"])
 def test_missing_or_tampered_token_blocks_entry(token):
     with pytest.raises(UnprocessableError, match="approval token"):

--- a/tests/api/test_order_signed_approval.py
+++ b/tests/api/test_order_signed_approval.py
@@ -117,7 +117,7 @@ def test_signed_context_drives_and_audits_entry_approval():
 
 def test_signed_waiting_pullback_buy_limit_is_approved():
     order = _service().create_order(
-        _request(approval_token=_token(trigger_status="WAIT"))
+        _request(approval_token=_token(trigger_status="WAIT", pullback_wait_authorized=True))
     )
 
     assert order["portfolio_approval"]["approved"] is True

--- a/web-ui/docs/WEB_UI_ARCHITECTURE.md
+++ b/web-ui/docs/WEB_UI_ARCHITECTURE.md
@@ -24,6 +24,10 @@
   transformed `workflowStatus` / `nextStep`; they do not re-derive precedence
   from decision gates or `decisionSummary.action`. Missing workflow fields fail
   safely to `needs_review` / `refresh_data` at the API boundary.
+- A `waiting_trigger` / `wait_pullback` candidate may expose manual order review
+  only with its pending `BUY_LIMIT` approval token. It remains distinct from
+  `ready`, which means the observed entry trigger passed; the token is required
+  and submission remains manual.
 - React Query keys live in `src/lib/queryKeys.ts`. Always use these for cache invalidation — do not construct key arrays inline.
 - All user-facing strings go through `src/i18n/`. No hardcoded copy in components or tests.
 

--- a/web-ui/src/components/domain/orders/OrderReviewExperience.test.tsx
+++ b/web-ui/src/components/domain/orders/OrderReviewExperience.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { screen, within } from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { renderWithProviders } from '@/test/utils';
 import { t } from '@/i18n/t';
 import OrderReviewExperience from './OrderReviewExperience';
@@ -179,6 +179,72 @@ describe('OrderReviewExperience — execution readiness', () => {
     expect(await screen.findByRole('button', {
       name: t('order.candidateModal.createAction'),
     })).toBeEnabled();
+  });
+
+  it('submits a signed waiting pullback BUY_LIMIT order with current data', async () => {
+    const onSubmitOrder = vi.fn().mockResolvedValue({});
+    renderWithProviders(
+      <OrderReviewExperience
+        context={makeContext({
+          recommendation: waitingRecommendation,
+          dataStatus: 'current',
+          dataAsOf: '2026-07-21',
+          approvalToken: 'approved-pullback-token',
+          suggestedOrderType: 'BUY_LIMIT',
+        })}
+        risk={risk}
+        defaultNotes=""
+        enforceRecommendation
+        onSubmitOrder={onSubmitOrder}
+      />,
+    );
+
+    const submit = await screen.findByRole('button', {
+      name: t('order.candidateModal.createAction'),
+    });
+    expect(submit).toBeEnabled();
+    fireEvent.submit(submit.closest('form') as HTMLFormElement);
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    await waitFor(() => expect(onSubmitOrder).toHaveBeenCalledOnce());
+    expect(onSubmitOrder).toHaveBeenCalledWith(expect.objectContaining({
+      triggerStatus: 'WAIT',
+    }));
+  });
+
+  it('blocks a signed pending pullback changed to BUY_STOP in local mode', async () => {
+    vi.stubEnv('VITE_PERSISTENCE_MODE', 'local');
+    vi.stubEnv('VITE_ENABLE_LOCAL_PERSISTENCE', 'true');
+    const onSubmitOrder = vi.fn().mockResolvedValue({});
+    renderWithProviders(
+      <OrderReviewExperience
+        context={makeContext({
+          recommendation: waitingRecommendation,
+          dataStatus: 'current',
+          dataAsOf: '2026-07-21',
+          approvalToken: 'approved-pullback-token',
+          suggestedOrderType: 'BUY_LIMIT',
+        })}
+        risk={risk}
+        defaultNotes=""
+        enforceRecommendation
+        onSubmitOrder={onSubmitOrder}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText(t('order.candidateModal.orderType')), {
+      target: { value: 'BUY_STOP' },
+    });
+    fireEvent.change(screen.getByLabelText(t('order.candidateModal.triggerPrice')), {
+      target: { value: '21' },
+    });
+    fireEvent.click(screen.getByRole('checkbox'));
+
+    const submit = screen.getByRole('button', { name: t('order.candidateModal.createAction') });
+    fireEvent.submit(submit.closest('form') as HTMLFormElement);
+
+    expect(await screen.findByText(t('order.candidateModal.approvalOrderTypeMismatch'))).toBeInTheDocument();
+    expect(onSubmitOrder).not.toHaveBeenCalled();
   });
 
   it('presents a qualified conditional setup as waiting while keeping creation locked', async () => {

--- a/web-ui/src/components/domain/orders/OrderReviewExperience.tsx
+++ b/web-ui/src/components/domain/orders/OrderReviewExperience.tsx
@@ -28,7 +28,7 @@ import type { RiskConfig } from '@/types/config';
 import type { Recommendation } from '@/types/recommendation';
 import { t } from '@/i18n/t';
 import { formatCurrency, formatNumber } from '@/utils/formatters';
-import { getWorkflowPresentation } from '@/components/domain/recommendation/workflowPresentation';
+import { canReviewPendingPullbackOrder, getWorkflowPresentation } from '@/components/domain/recommendation/workflowPresentation';
 
 export type OrderReviewRiskConfig = Pick<
   RiskConfig,
@@ -115,9 +115,11 @@ export default function OrderReviewExperience({
   const suggestedShares = Math.max(1, Math.min(rawSuggestedShares, maxSharesByPositionCap));
   const decisionGates = context.recommendation?.decisionGates;
   const workflow = getWorkflowPresentation(context.recommendation);
+  const pendingPullbackOrder = canReviewPendingPullbackOrder(context);
+  const recommendationOrderReady = context.recommendation?.workflowStatus === 'ready' || pendingPullbackOrder;
   const decisionReady = Boolean(
     !context.recommendation || (
-      context.recommendation.workflowStatus === 'ready'
+      recommendationOrderReady
       && context.dataStatus === 'current'
       && context.dataAsOf
     ),
@@ -203,7 +205,7 @@ export default function OrderReviewExperience({
 
   const warnings = useMemo(() => {
     const nextWarnings: string[] = [];
-    if (enforceRecommendation && workflow.status !== 'ready') {
+    if (enforceRecommendation && !recommendationOrderReady) {
       nextWarnings.push(t('order.candidateModal.executionNotReady', {
         status: t(workflow.labelKey),
       }));
@@ -229,7 +231,7 @@ export default function OrderReviewExperience({
       }
     }
     return nextWarnings;
-  }, [enforceRecommendation, hasOrderTypeMismatch, hasSkipSuggestion, normalizedSuggestedOrderType, workflow.labelKey, workflow.status,
+  }, [enforceRecommendation, hasOrderTypeMismatch, hasSkipSuggestion, normalizedSuggestedOrderType, recommendationOrderReady, workflow.labelKey,
       context.avgDailyVolumeEur, quantity, limitPrice]);
   const invalidationRules = context.recommendation?.thesis?.invalidationRules ?? [];
   const hardInvalidations = invalidationRules.filter((rule) => classifyInvalidationRule(rule.condition) === 'hard');
@@ -251,7 +253,7 @@ export default function OrderReviewExperience({
     setSubmissionError(null);
     setSubmitSucceeded(false);
 
-    if (enforceRecommendation && workflow.status !== 'ready') {
+    if (enforceRecommendation && !recommendationOrderReady) {
       setSubmissionError(t('order.candidateModal.notRecommended'));
       return;
     }
@@ -263,6 +265,11 @@ export default function OrderReviewExperience({
 
     if (apiApprovalMissing) {
       setSubmissionError(t('order.candidateModal.approvalTokenRequired'));
+      return;
+    }
+
+    if (pendingPullbackOrder && values.orderType !== 'BUY_LIMIT') {
+      setSubmissionError(t('order.candidateModal.approvalOrderTypeMismatch'));
       return;
     }
 
@@ -302,8 +309,7 @@ export default function OrderReviewExperience({
         thesis: tradeThesis.trim() || undefined,
         setupStatus: decisionGates?.setup.status === 'PASS' || decisionGates?.setup.status === 'BLOCK'
           ? decisionGates.setup.status : 'UNKNOWN',
-        triggerStatus: decisionGates?.trigger.status === 'PASS' || decisionGates?.trigger.status === 'BLOCK'
-          ? decisionGates.trigger.status : 'UNKNOWN',
+        triggerStatus: decisionGates?.trigger.status ?? 'UNKNOWN',
         dataStatus: context.dataStatus ?? 'unknown',
         dataAsOf: context.dataAsOf,
         targetSource: context.recommendation?.risk.targetSource === 'structural'

--- a/web-ui/src/components/domain/recommendation/workflowPresentation.test.ts
+++ b/web-ui/src/components/domain/recommendation/workflowPresentation.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { ScreenerCandidate } from '@/features/screener/types';
 import {
+  canReviewPendingPullbackOrder,
   formatWorkflowNextStep,
   getWorkflowPresentation,
   groupCandidatesByWorkflow,
@@ -18,6 +19,32 @@ const apiRecommendation: RecommendationAPI = {
 };
 
 describe('workflow presentation', () => {
+  it('allows only signed waiting pullback BUY_LIMIT orders into review', () => {
+    expect(canReviewPendingPullbackOrder({
+      approvalToken: 'signed-token',
+      suggestedOrderType: 'BUY_LIMIT',
+      recommendation: {
+        workflowStatus: 'waiting_trigger',
+        nextStep: { code: 'wait_pullback' },
+      },
+    })).toBe(true);
+
+    expect(canReviewPendingPullbackOrder({
+      suggestedOrderType: 'BUY_LIMIT',
+      recommendation: { workflowStatus: 'waiting_trigger', nextStep: { code: 'wait_pullback' } },
+    })).toBe(false);
+    expect(canReviewPendingPullbackOrder({
+      approvalToken: 'signed-token',
+      suggestedOrderType: 'BUY_STOP',
+      recommendation: { workflowStatus: 'waiting_trigger', nextStep: { code: 'wait_pullback' } },
+    })).toBe(false);
+    expect(canReviewPendingPullbackOrder({
+      approvalToken: 'signed-token',
+      suggestedOrderType: 'BUY_LIMIT',
+      recommendation: { workflowStatus: 'waiting_trigger', nextStep: { code: 'wait_breakout_close' } },
+    })).toBe(false);
+  });
+
   it('formats a concrete pullback instruction', () => {
     expect(formatWorkflowNextStep({
       code: 'wait_pullback',

--- a/web-ui/src/components/domain/recommendation/workflowPresentation.ts
+++ b/web-ui/src/components/domain/recommendation/workflowPresentation.ts
@@ -63,6 +63,19 @@ export function getWorkflowPresentation(
   return PRESENTATIONS[normalizeWorkflowStatus(recommendation?.workflowStatus)];
 }
 
+export function canReviewPendingPullbackOrder(context: {
+  approvalToken?: string;
+  suggestedOrderType?: string | null;
+  recommendation?: Pick<Recommendation, 'workflowStatus' | 'nextStep'> | null;
+}): boolean {
+  return Boolean(
+    context.approvalToken
+    && context.suggestedOrderType === 'BUY_LIMIT'
+    && context.recommendation?.workflowStatus === 'waiting_trigger'
+    && context.recommendation.nextStep.code === 'wait_pullback',
+  );
+}
+
 export function formatWorkflowNextStep(nextStep?: WorkflowNextStep): string {
   const safeStep = normalizeWorkflowNextStep(nextStep);
   if (safeStep.code === 'wait_pullback' || safeStep.code === 'wait_breakout_close') {

--- a/web-ui/src/components/domain/recommendation/workflowPresentation.ts
+++ b/web-ui/src/components/domain/recommendation/workflowPresentation.ts
@@ -7,6 +7,7 @@ import type {
   WorkflowStatus,
 } from '@/types/recommendation';
 import { normalizeWorkflowNextStep, normalizeWorkflowStatus } from '@/types/recommendation';
+import { normalizeSuggestedOrderType } from '@/features/orders/executionDefaults';
 import { formatCurrency } from '@/utils/formatters';
 
 export type WorkflowTone = 'success' | 'warning' | 'danger' | 'neutral';
@@ -68,9 +69,10 @@ export function canReviewPendingPullbackOrder(context: {
   suggestedOrderType?: string | null;
   recommendation?: Pick<Recommendation, 'workflowStatus' | 'nextStep'> | null;
 }): boolean {
+  const suggestedOrderType = normalizeSuggestedOrderType(context.suggestedOrderType);
   return Boolean(
     context.approvalToken
-    && context.suggestedOrderType === 'BUY_LIMIT'
+    && suggestedOrderType === 'BUY_LIMIT'
     && context.recommendation?.workflowStatus === 'waiting_trigger'
     && context.recommendation.nextStep.code === 'wait_pullback',
   );

--- a/web-ui/src/components/domain/screener/ScreenerCandidatesTable.tsx
+++ b/web-ui/src/components/domain/screener/ScreenerCandidatesTable.tsx
@@ -12,7 +12,7 @@ import ScreenerCandidateIdentityCell from './ScreenerCandidateIdentityCell';
 import ScreenerCandidateDetailsRow from './ScreenerCandidateDetailsRow';
 import { formatCurrency, formatPercent, getSignColorClass } from '@/utils/formatters';
 import { t } from '@/i18n/t';
-import { formatWorkflowNextStep, groupCandidatesByWorkflow } from '@/components/domain/recommendation/workflowPresentation';
+import { canReviewPendingPullbackOrder, formatWorkflowNextStep, groupCandidatesByWorkflow } from '@/components/domain/recommendation/workflowPresentation';
 import ScreenerWorkflowGroup from './ScreenerWorkflowGroup';
 
 interface ScreenerCandidatesTableProps {
@@ -104,7 +104,7 @@ export default function ScreenerCandidatesTable({
         const isExpanded = expandedRows.has(candidate.ticker);
         const isSelected = selectedTicker != null && selectedTicker.toUpperCase() === candidate.ticker.toUpperCase();
         const workflowStatus = candidate.recommendation?.workflowStatus ?? 'needs_review';
-        const canReviewOrder = workflowStatus === 'ready';
+        const canReviewOrder = workflowStatus === 'ready' || canReviewPendingPullbackOrder(candidate);
         const isWatched = watchedTickers.has(candidate.ticker.toUpperCase());
         const isWatchPending =
           (watchSymbolMutation.isPending &&

--- a/web-ui/src/components/domain/workspace/ActionPanel.tsx
+++ b/web-ui/src/components/domain/workspace/ActionPanel.tsx
@@ -8,7 +8,7 @@ import { useActiveStrategyQuery } from '@/features/strategy/hooks';
 import { useScreenerStore } from '@/stores/screenerStore';
 import { t } from '@/i18n/t';
 import { formatConfidencePercent, formatCurrency, formatScreenerScore } from '@/utils/formatters';
-import { formatWorkflowNextStep } from '@/components/domain/recommendation/workflowPresentation';
+import { canReviewPendingPullbackOrder, formatWorkflowNextStep } from '@/components/domain/recommendation/workflowPresentation';
 import type { WorkspaceSourceState } from '@/features/workspaceData/types';
 import SourceHealthSummary from './SourceHealthSummary';
 
@@ -75,7 +75,8 @@ export default function ActionPanel({ ticker, candidate: candidateOverride, sour
 
   const sameSymbol = resolveSameSymbolContext(candidate ?? null);
   const defaultNotes = buildDefaultNotes(candidate ?? null, sameSymbol, normalizedTicker);
-  const isReadyCandidate = candidate?.recommendation?.workflowStatus === 'ready';
+  const isReadyCandidate = candidate?.recommendation?.workflowStatus === 'ready'
+    || (candidate != null && canReviewPendingPullbackOrder(candidate));
   const canReviewOrder = Boolean(
     isReadyCandidate &&
       (!openPosition || isPositionEntryContext(candidate?.sameSymbol)),

--- a/web-ui/src/components/domain/workspace/AnalysisDecisionStrip.tsx
+++ b/web-ui/src/components/domain/workspace/AnalysisDecisionStrip.tsx
@@ -10,6 +10,7 @@ import type { PositionWithMetrics } from '@/features/portfolio/api';
 import { t } from '@/i18n/t';
 import { formatCurrency, formatNumber } from '@/utils/formatters';
 import {
+  canReviewPendingPullbackOrder,
   formatWorkflowNextStep,
   getWorkflowPresentation,
 } from '@/components/domain/recommendation/workflowPresentation';
@@ -108,11 +109,12 @@ export default function AnalysisDecisionStrip({
   const summary = candidate?.decisionSummary;
   const currency = candidate?.currency ?? 'USD';
   const heldMode = Boolean(position);
-  const canPrepareOrder = candidate?.recommendation?.workflowStatus === 'ready';
+  const canPrepareOrder = candidate?.recommendation?.workflowStatus === 'ready'
+    || (candidate != null && canReviewPendingPullbackOrder(candidate));
   const showAnalysisAction = summary && (
     !candidate?.recommendation ||
     (
-      candidate.recommendation.workflowStatus === 'ready' &&
+      canPrepareOrder &&
       (summary.action === 'BUY_NOW' || summary.action === 'BUY_ON_PULLBACK')
     )
   );

--- a/web-ui/src/components/domain/workspace/ManagePositionPanel.test.tsx
+++ b/web-ui/src/components/domain/workspace/ManagePositionPanel.test.tsx
@@ -49,6 +49,17 @@ describe('ManagePositionPanel', () => {
     expect(screen.getByRole('button', { name: t('workspacePage.panels.analysis.managePosition.add') })).toBeInTheDocument();
   });
 
+  it('shows Add-to-position for an approved waiting pullback', () => {
+    const candidate = {
+      sameSymbol: { mode: 'ADD_ON' },
+      suggestedOrderType: 'BUY_LIMIT',
+      approvalToken: 'approved-pullback-token',
+      recommendation: { workflowStatus: 'waiting_trigger', nextStep: { code: 'wait_pullback' } },
+    } as any;
+    renderWithProviders(<ManagePositionPanel position={position} candidate={candidate} />);
+    expect(screen.getByRole('button', { name: t('workspacePage.panels.analysis.managePosition.add') })).toBeInTheDocument();
+  });
+
   it('does not promote a BUY_ON_PULLBACK opinion without ready workflow status', () => {
     const candidate = {
       sameSymbol: { mode: 'ADD_ON' },

--- a/web-ui/src/components/domain/workspace/ManagePositionPanel.tsx
+++ b/web-ui/src/components/domain/workspace/ManagePositionPanel.tsx
@@ -15,6 +15,7 @@ import {
 import { useWorkspaceStore } from '@/stores/workspaceStore';
 import { t } from '@/i18n/t';
 import { formatCurrency } from '@/utils/formatters';
+import { canReviewPendingPullbackOrder } from '@/components/domain/recommendation/workflowPresentation';
 
 interface ManagePositionPanelProps {
   position: PositionWithMetrics;
@@ -36,7 +37,7 @@ export default function ManagePositionPanel({ position, candidate }: ManagePosit
   const setActiveTab = useWorkspaceStore((state) => state.setAnalysisTab);
   const canAdd = Boolean(
     (candidate?.sameSymbol?.mode === 'ADD_ON' || candidate?.sameSymbol?.mode === 'SCALE_BACK')
-      && candidate.recommendation?.workflowStatus === 'ready',
+      && (candidate.recommendation?.workflowStatus === 'ready' || canReviewPendingPullbackOrder(candidate)),
   );
 
   const displayedR = checkLive && stopPreview.data ? stopPreview.data.rNow : position.rNow;

--- a/web-ui/src/components/domain/workspace/SymbolAnalysisContent.tsx
+++ b/web-ui/src/components/domain/workspace/SymbolAnalysisContent.tsx
@@ -9,6 +9,7 @@ import {
   useRunTrace,
   useTickerRuns,
 } from '@/features/intelligence/hooks';
+import { canReviewPendingPullbackOrder } from '@/components/domain/recommendation/workflowPresentation';
 import { useSymbolCatalystQuery } from '@/features/intelligence/catalysts/hooks';
 import type {
   EvidenceRefreshResponse,
@@ -290,9 +291,10 @@ export default function SymbolAnalysisContent({
   const heldMode = Boolean(position);
   const canAddOn = Boolean(
     (candidate?.sameSymbol?.mode === 'ADD_ON' || candidate?.sameSymbol?.mode === 'SCALE_BACK')
-      && candidate.recommendation?.workflowStatus === 'ready',
+      && (candidate.recommendation?.workflowStatus === 'ready' || canReviewPendingPullbackOrder(candidate)),
   );
-  const candidateCanReviewOrder = candidate?.recommendation?.workflowStatus === 'ready';
+  const candidateCanReviewOrder = candidate?.recommendation?.workflowStatus === 'ready'
+    || (candidate != null && canReviewPendingPullbackOrder(candidate));
   const canReviewOrder = heldMode ? canAddOn : candidateCanReviewOrder;
 
   useEffect(() => {

--- a/web-ui/src/components/domain/workspace/types.ts
+++ b/web-ui/src/components/domain/workspace/types.ts
@@ -45,6 +45,7 @@ export interface SymbolAnalysisCandidate {
   rReward?: number;
   recommendation?: Recommendation;
   suggestedOrderType?: string;
+  approvalToken?: string;
   suggestedOrderPrice?: number;
   executionNote?: string;
   sameSymbol?: SameSymbolCandidateContext;

--- a/web-ui/src/features/persistence/portfolioService.test.ts
+++ b/web-ui/src/features/persistence/portfolioService.test.ts
@@ -60,6 +60,27 @@ describe('portfolio local persistence service', () => {
     expect(openPositions[0].ticker).toBe('AAPL');
   });
 
+  it('allows an approved waiting pullback BUY_LIMIT entry', () => {
+    createOrderWithApproval({
+      ticker: 'AAPL',
+      orderType: 'buy_limit',
+      quantity: 10,
+      limitPrice: 100,
+      stopPrice: 95,
+      targetPrice: 110,
+      orderKind: 'entry',
+      setupStatus: 'PASS',
+      triggerStatus: 'WAIT',
+      dataStatus: 'current',
+      dataAsOf: '2026-02-26',
+      targetSource: 'structural',
+      daysToEarnings: 20,
+      approvalToken: 'approved-pullback-token',
+    });
+
+    expect(listOrdersLocal('pending')).toHaveLength(1);
+  });
+
   it('replaces linked stop order on stop update and supports close', () => {
     createOrderLocal({
       ticker: 'MSFT',

--- a/web-ui/src/features/persistence/portfolioService.ts
+++ b/web-ui/src/features/persistence/portfolioService.ts
@@ -259,6 +259,9 @@ export function createOrderLocal(request: CreateOrderRequest): void {
     const orderId = nextOrderId(ticker, existingIds);
     const normalizedOrderType = request.orderType.trim().toUpperCase();
     const orderKind = request.orderKind ?? inferOrderKind({ orderKind: null, orderType: normalizedOrderType });
+    const approvedPendingPullback = request.triggerStatus === 'WAIT'
+      && normalizedOrderType === 'BUY_LIMIT'
+      && Boolean(request.approvalToken);
     const openPosition = store.positions.find(
       (position) => position.status === 'open' && normalizeTicker(position.ticker) === ticker,
     );
@@ -266,7 +269,7 @@ export function createOrderLocal(request: CreateOrderRequest): void {
     if (orderKind === 'entry') {
       if (
         request.setupStatus !== 'PASS'
-        || request.triggerStatus !== 'PASS'
+        || (request.triggerStatus !== 'PASS' && !approvedPendingPullback)
         || request.dataStatus !== 'current'
         || !request.dataAsOf
         || !['structural', 'manual'].includes(request.targetSource ?? '')


### PR DESCRIPTION
## What changed
- Allows a signed `waiting_trigger` pullback candidate to open manual order review without promoting the workflow to `ready`.
- Reuses the existing approval token path with a pending `BUY_LIMIT` authorization for `wait_pullback`.
- Updates the web UI gating so the review flow, screener table, action strip, and local persistence all honor the same pending-limit exception.

## Why
- A pullback candidate can be actionable before the trigger has actually printed, so the user needs to review and stage the order now while the recommendation stays truthfully in `waiting_trigger`.

## Validation
- `python -m pytest tests/api/test_candidate_approval.py tests/api/test_order_approval_policy.py -q`
- `npm run typecheck`
- `npm run lint`
- `vitest run src/components/domain/recommendation/workflowPresentation.test.ts src/components/domain/orders/OrderReviewExperience.test.tsx src/components/domain/workspace/ManagePositionPanel.test.tsx src/features/persistence/portfolioService.test.ts`
- `vitest run src/components/domain/workspace/AnalysisDecisionStrip.test.tsx src/components/domain/workspace/ActionPanel.test.tsx src/components/domain/screener/ScreenerCandidatesTable.test.tsx`

## Screenshots
- Not captured in this environment; no browser runtime was available for screenshot capture.

## Compare
- https://github.com/matteolongo/swing_screener/compare/feat/symbol-workspace-redesign...fix/pending-buy-limit-order?expand=1